### PR TITLE
Add layer id to low level point cloud data.

### DIFF
--- a/osi_lowleveldata.proto
+++ b/osi_lowleveldata.proto
@@ -66,6 +66,9 @@ message LidarPoint
 
     /// Duration of the echo pulse (above system noise cut-off threshold). Unit: [ns].
     optional double echo_pulse_duration = 6;
+    
+    // Layer id starting from zero for the bottom layer of the point cloud.
+    optional uint32 layer = 7;
 
     /// Definition of reflection types.
     enum ReflectionType


### PR DESCRIPTION
We need the layer number for laserscanner point cloud data for easier processing and matching to real sensor data.