### PR TITLE
Only require cmake 3.5, add default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,21 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.5)
 
 project(open_simulation_interface)
+
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(default_build_type "Debug")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 # read the version number from the file "VERSION" 
 file(STRINGS "VERSION" VERSION_CONTENTS)


### PR DESCRIPTION
- Lower required version of cmake to 3.5, since that is easily
  enough and supported by more distributions (e.g. Ubuntu 16.04 LTS).
- Add default build type selection logic, so that builds without
  specified build type will default to either Release or Debug and not
  to empty build type. Deals correctly with generators that support
  multi-type builds, like VS.