### PR TITLE
Standardised Message Naming (related to issue #97)

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -54,15 +54,19 @@ message DetectedObject
 
     // Additional data that is specific to radar sensors.
     // Field need not be set if simulated sensor is not a radar sensor.
-    optional RadarSpecificObjectData radar_specifics = 10;
+    optional SpecificRadarData radar_specifics = 10;
 
     // Additional data that is specific to lidar sensors.
     // Field need not be set if simulated sensor is not a lidar sensor.
-    optional LidarSpecificObjectData lidar_specifics = 11;
+    optional SpecificLidarData lidar_specifics = 11;
 
     // Additional data that is specific to camera sensors.
     // Field need not be set if simulated sensor is not a camera sensor.
-    optional CameraSpecificObjectData camera_specifics = 12;
+    optional SpecificCameraData camera_specifics = 12;
+
+    // Additional data that is specific to ultrasonic sensors.
+    // Field need not be set if simulated sensor is not an ultrasonic sensor.
+    optional SpecificUltrasonicData ultrasonic_specifics = 13;
 
     // Definition of available reference points.
     //

--- a/osi_sensorspecific.proto
+++ b/osi_sensorspecific.proto
@@ -7,16 +7,16 @@ package osi;
 //
 // \brief Message encapsulates all data for detected objects that is specific to radar sensors.
 //
-message RadarSpecificObjectData
+message SpecificRadarData
 {
-    // The radar cross section (RCS) of the detected object. Unit: [dB sqm].
+    // The radar cross section (RCS) of the detected object. Unit: [dB m^2].
     optional double rcs = 1;
 }
 
 //
 // \brief Message encapsulates all data for detected objects that is specific to lidar sensors.
 //
-message LidarSpecificObjectData
+message SpecificLidarData
 {
     // currently no fields.
 }
@@ -24,7 +24,15 @@ message LidarSpecificObjectData
 //
 // \brief Message encapsulates all data for detected objects that is specific to camera sensors.
 //
-message CameraSpecificObjectData
+message SpecificCameraData
+{
+    // currently no fields.
+}
+
+//
+// \brief Message encapsulates all data for detected objects that is specific to ultrasonic sensors.
+// 
+message SpecificUltrasonicData
 {
     // currently no fields.
 }


### PR DESCRIPTION
SensorSpecific messages had a different naming convention. Renamed in a similar way as other messages.
This changeset is related to issue #97 (Reworking documentation). 