### PR TITLE
Extended Documentaton (also for issue #104)

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -22,7 +22,7 @@ message DetectedObject
     // Multiple entries if detected object is a merge of multiple ground truth objects.
     repeated Identifier ground_truth_id = 2;
 
-    // Base parameters of the object. Reference point is the middle of the bounding box of the target object.
+    // Base parameters of the object. object.position is the middle of the bounding box of the target object.
     //
     optional BaseMoving object = 3;
 
@@ -42,7 +42,7 @@ message DetectedObject
     // has lights.
     optional Vehicle.LightState light_state = 7;
 
-    // Reference point of the sensor measurement (required to decouple position and bounding box estimation) as used by
+    // Reference point location specification of the sensor measurement (required to decouple sensor measurement, position and bounding box estimation) as used by
     // the sensor (model).
     //
     // \note Note that the value of this field has no impact on the value of object.position, which always references the

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -33,6 +33,7 @@ message SensorData
 
     // Should be used as constant; use this if you require fields that do not exist in osi_sensordata or for the purpose
     // of matching sensor output against ground truth data.
+    //
     optional SensorDataGroundTruth ground_truth = 3;
     
     // The id of the ego vehicle in the ground_truth data.
@@ -41,13 +42,14 @@ message SensorData
 
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
     //
-    // given in vehicle coordinates: origin is \c Vehicle::reference_point; the orientation is equal to the orientation of the vehicle.
+    // given in vehicle coordinates: origin is ( \c Vehicle::base.position + INV(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) the orientation is equal to the orientation of the vehicle \c Vehicle::base.orientation.
     //
     // \arg \b x-direction: longitudinal direction & positive in driving direction
     // \arg \b y-direction: lateral direction & positive to the left when looking orientated as a driver
     // \arg \b z-direction: perpendicular to x and z right hand system (up)
     //
     // See https://en.wikipedia.org/wiki/Axes_conventions#/media/File:RPY_angles_of_cars.png 
+    //
     // \note This field is usually static during the simulation.
     optional MountingPosition mounting_position = 5;
 
@@ -88,18 +90,18 @@ message SensorData
 //
 message SensorDataGroundTruth
 {
-    // Ground truth w.r.t. global coordinate system (copy of GroundTruth message),
+    // Ground truth w.r.t. global coordinate system (copy of GroundTruth message to \c SensorData::ground_truth.global_ground_truth),
     //
     // needed for setting fields in the SensorData that are not covered by the model.
     // \note Should be used as constant in the sensor models.
     // 
     optional GroundTruth global_ground_truth = 1;
 
-    // Ground truth w.r.t. the sensor coordinate system.
+    // Ground truth w.r.t. the sensor coordinate system (\c SensorData::ground_truth.sensor_ground_truth.ground_truth.global_ground_truth).
     //
     // Is equal to the version of the SensorData interface that is used as input by the sensor model before
     // any processing takes place aside from the coordinate transformation from global to sensor reference frame.
     //
-    // SensorData.ground_truth is not set in this instance to avoid the resulting infinite loop.
+    // \c SensorData::ground_truth.sensor_ground_truth.ground_truth.sensor_ground_truth is not set in this instance to avoid the resulting infinite loop.
     optional SensorData sensor_ground_truth = 2;
 }


### PR DESCRIPTION
Documentation how to store GT information in Sensordata is specified. Documentation of Vehicle rear axle is corrected in documentation.

Improve Documentation with suggestions from issue #104.