### PR TITLE
Fix version number field defaults (fixes #92)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ endforeach()
 configure_file(osi_version.proto.in ${CMAKE_CURRENT_SOURCE_DIR}/osi_version.proto)
 
 find_package(Protobuf 2.6.1 REQUIRED)
+set(PROTOBUF_IMPORT_DIRS ${PROTOBUF_INCLUDE_DIRS})
 
 set(OSI_PROTO_FILES
     osi_version.proto

--- a/osi_version.proto.in
+++ b/osi_version.proto.in
@@ -7,20 +7,31 @@ package osi;
 //
 // \brief The interface version number.
 //
-// The field containing the version number. Should be left on default, not to be modified by sender.
+// The field containing the version number.  This needs to be set by the
+// sender to the actual OSI version that is to be sent:
+//
+// version_major = @VERSION_MAJOR@;
+// version_minor = @VERSION_MINOR@;
+// version_patch = @VERSION_PATCH@;
+//
+// If a message with all components set to 0, the default value, is
+// received, the receiver can assume that the message was sent by
+// a version 2.2.0 or earlier release, or that the sender did not
+// properly set the version components prior to sending.
+//
 // Increments will happen as part of changes to the whole interface.
 //
 message InterfaceVersion
 {
     // Major version number.
     //
-    optional uint32 version_major = 1 [default = @VERSION_MAJOR@];
+    optional uint32 version_major = 1 [default = 0];
     
     // Minor version number.
     //
-    optional uint32 version_minor = 2 [default = @VERSION_MINOR@];
+    optional uint32 version_minor = 2 [default = 0];
     
     // Patch version number.
     //
-    optional uint32 version_patch = 3 [default = @VERSION_PATCH@];
+    optional uint32 version_patch = 3 [default = 0];
 }

--- a/osi_version.proto.in
+++ b/osi_version.proto.in
@@ -2,17 +2,22 @@ syntax = "proto2";
 
 option optimize_for = SPEED;
 
+import "google/protobuf/descriptor.proto";
+
 package osi;
 
 //
 // \brief The interface version number.
 //
 // The field containing the version number.  This needs to be set by the
-// sender to the actual OSI version that is to be sent:
+// sender to the actual OSI version that is to be sent.  Code wanting to
+// access the version number of the OSI code base can access a FileOption
+// which has the proper values, like this:
 //
-// version_major = @VERSION_MAJOR@;
-// version_minor = @VERSION_MINOR@;
-// version_patch = @VERSION_PATCH@;
+// @code
+// auto currentInterfaceVersion =
+//   InterfaceVersion::descriptor()->file()->options().GetExtension(current_interface_version);
+// @endcode
 //
 // If a message with all components set to 0, the default value, is
 // received, the receiver can assume that the message was sent by
@@ -35,3 +40,13 @@ message InterfaceVersion
     //
     optional uint32 version_patch = 3 [default = 0];
 }
+
+
+extend google.protobuf.FileOptions {
+    optional InterfaceVersion current_interface_version = 81000;
+}
+
+option (current_interface_version).version_major = @VERSION_MAJOR@;
+option (current_interface_version).version_minor = @VERSION_MINOR@;
+option (current_interface_version).version_patch = @VERSION_PATCH@;
+


### PR DESCRIPTION
This change allows the version number field in ground truth to work as expected, i.e. a version mismatch between sender and receiver can now be found. This change requires the sender to actively set the version number, for which the sender can use the current_interface_version file option of the osi_version.proto file to always use the version the sender was compiled against.