### PR TITLE
Add initial draft of sensor input configuration message (fix #98)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(OSI_PROTO_FILES
     osi_occupant.proto
     osi_sensordata.proto
     osi_sensorspecific.proto
+    osi_sensorinputconfiguration.proto
 )
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES})

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -20,6 +20,16 @@ package osi;
 // configuration allowed for multiple alternatives, in which case the set
 // configuration will only contain the alternative chosen.
 //
+// It should be noted that this message is not intended to provide for
+// parametrization of a generic sensor model, but rather for the automatic
+// configuration of an environment simulation in order to supply the 
+// necessary input to it, depending on its actual configuration.
+// Mechanisms to parametrize sensor models are currently packaging-specific,
+// i.e. they depend on the packaging mechanism chosen:  For FMU-packaging
+// the parametrization can be implemented using normal FMU parameters,
+// and the requested sensor input configuration can depend on those
+// parameter values by being defined as a calculatedParameter.
+//
 message SensorInputConfiguration
 {
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
@@ -117,21 +127,23 @@ message RadarSensorInputConfiguration
     // This represents the combined TX/RX antenna diagram
     repeated AntennaDiagramEntry combined_antenna_diagram = 1;
 
-    // Number of rays to cast across horizontal field of view
+    // Number of rays to cast across horizontal field of view (azimuth)
     optional uint32 number_of_rays_horizontal = 2;
 
-    // Number of rays to cast across vertical field of view
+    // Number of rays to cast across vertical field of view (elevation)
     optional uint32 number_of_rays_vertical = 3;
 
     // Maximum number of interactions to take into account
     optional uint32 max_number_of_interactions = 4;
 
     message AntennaDiagramEntry {
-        // Horizontal deflection of entry in sensor/antenna coordinates
+        // Horizontal deflection (azimuth) of entry in sensor/antenna
+        // coordinates
         // Unit: [rad]
         optional double horizontal_angle = 1;
 
-        // Vertical deflection of entry in sensor/antenna coordinates
+        // Vertical deflection (elevation) of entry in sensor/antenna
+        // coordinates
         // Unit: [rad]
         optional double vertical_angle = 2;
 

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -1,0 +1,216 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_common.proto";
+
+package osi;
+
+//
+// \brief The configuration settings for the Sensor Input to be provided
+// by the environment simulation.
+//
+// This message can be provided by the sensor model to the environment
+// simulation, in which case it describes the input configuration that
+// is desired by the sensor model.  In response the environment simulation
+// will configure the input and provide a new message of this type, which
+// describes the actual configuration that it is going to employ.  The two
+// can and will differ, when either the environment simulation does not
+// support a given requested configuration, and/or when the requested
+// configuration allowed for multiple alternatives, in which case the set
+// configuration will only contain the alternative chosen.
+//
+message SensorInputConfiguration
+{
+    // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
+    //
+    // given in vehicle coordinates: origin is \c Vehicle::reference_point; the orientation is equal to the orientation of the vehicle.
+    //
+    // \arg \b x-direction: longitudinal direction & positive in driving direction
+    // \arg \b y-direction: lateral direction & positive to the left when looking orientated as a driver
+    // \arg \b z-direction: perpendicular to x and z right hand system (up)
+    //
+    // See https://en.wikipedia.org/wiki/Axes_conventions#/media/File:RPY_angles_of_cars.png
+    // \note A default position can be provided by the sensor model (e.g. to indicate the position the model was validated for),
+    // but this is optional; the environment simulation must provide a valid mounting position (based on the vehicle configuration)
+    // when setting the input configuration.
+    optional MountingPosition mounting_position = 1;
+
+    // Field of View in horizontal orientation of the sensor
+    //
+    // This determines the limit of the cone of interest of ground truth
+    // that the simulation environment has to provide.
+    //
+    // Unit: [rad]
+    optional double field_of_view_horizontal = 2;
+
+    // Field of View in vertical orientation of the sensor
+    //
+    // This determines the limit of the cone of interest of ground truth
+    // that the simulation environment has to provide.
+    //
+    // Unit: [rad]
+    optional double field_of_view_vertical = 3;
+
+    // Maximum range of the sensor
+    //
+    // This determines the limit of the cone of interest of ground truth
+    // that the simulation environment has to provide.
+    //
+    // Unit: [m]
+    optional double range = 4;
+
+    // The update cycle time of the sensor model
+    //
+    // This specifies the rate at which the sensor model is provided with
+    // new input data.
+    //
+    // Unit: [s]
+    // \note In the case of FMU packaging this will correspond to the
+    // communication step size.
+    optional double update_cycle_time = 5;
+
+    // Radar-specific Sensor Input Configuration
+    optional RadarSensorInputConfiguration radar_sensor_input_configuration = 1000;
+
+    // Lidar-specific Sensor Input Configuration
+    optional LidarSensorInputConfiguration lidar_sensor_input_configuration = 1001;
+
+    // Camera-specific Sensor Input Configuration
+    optional CameraSensorInputConfiguration camera_sensor_input_configuration = 1002;
+
+    // Ultrasonic-specific Sensor Input Configuration
+    optional UltrasonicSensorInputConfiguration ultrasonic_sensor_input_configuration = 1003;
+}
+
+message RadarSensorInputConfiguration
+{
+    // This represents the combined TX/RX antenna diagram
+    repeated AntennaDiagramEntry combined_antenna_diagram = 1;
+
+    // Number of rays to cast across horizontal field of view
+    optional uint32 number_of_rays_horizontal = 2;
+
+    // Number of rays to cast across vertical field of view
+    optional uint32 number_of_rays_vertical = 3;
+
+    // Maximum number of interactions to take into account
+    optional uint32 max_number_of_interactions = 4;
+
+    message AntennaDiagramEntry {
+        // Horizontal deflection of entry in sensor/antenna coordinates
+        // Unit: [rad]
+        optional double horizontal_angle = 1;
+
+        // Vertical deflection of entry in sensor/antenna coordinates
+        // Unit: [rad]
+        optional double vertical_angle = 2;
+
+        // Combined response of emitter and receiver antenna at this
+        // point
+        // Unit: [dB]
+        // TBD: Merge with emitted power thus specify in dBm?
+        optional double response = 3;
+    }
+}
+
+message LidarSensorInputConfiguration
+{
+    // Number of rays to cast across horizontal field of view
+    optional uint32 number_of_rays_horizontal = 1;
+
+    // Number of rays to cast across vertical field of view
+    optional uint32 number_of_rays_vertical = 2;
+
+    // Maximum number of interactions to take into account
+    optional uint32 max_number_of_interactions = 3;
+}
+
+message CameraSensorInputConfiguration
+{
+    // Number of pixels to produce across horizontal field of view
+    optional uint32 number_of_pixels_horizontal = 1;
+
+    // Number of pixels to produce across horizontal field of view
+    optional uint32 number_of_pixels_vertical = 2;
+
+    // Format for image data (includes number, kind and format of channels)
+    //
+    // In the message provided by the sensor model, this field can
+    // be repeated and all values are acceptable to the model, with
+    // the most acceptable value being listed first, and the remaining
+    // values indicating alternatives in descending order of preference.
+    //
+    // In the message provided to the sensor model, this field must
+    // contain exactly one value, indicating the format of the image
+    // data being provided by the simulation environment - which must
+    // be one of the values the sensor model requested - or there
+    // must be no value, indicating that the simulation environment
+    // cannot provide image data in one of the requested formats.
+    repeated ChannelFormat channel_format = 3;
+
+    enum ChannelFormat {
+        // Type of channel format is unknown (must not be used).
+        //
+        FORMAT_UNKNOWN = 0;
+
+        // Single Luminance Channel UINT8 Linear
+        //
+        FORMAT_MONO_U8_LIN = 1;
+
+        // Single Luminance Channel UINT16 Linear
+        //
+        FORMAT_MONO_U16_LIN = 2;
+
+        // Single Luminance Channel UINT32 Linear
+        //
+        FORMAT_MONO_U32_LIN = 3;
+
+        // Single Luminance Channel Single Precision FP Linear
+        //
+        FORMAT_MONO_F32_LIN = 4;
+
+        // Packed RGB Channels (no padding) UINT8 Linear
+        //
+        FORMAT_RGB_U8_LIN = 5;
+
+        // Packed RGB Channels (no padding) UINT16 Linear
+        //
+        FORMAT_RGB_U16_LIN = 6;
+
+        // Packed RGB Channels (no padding) UINT32 Linear
+        //
+        FORMAT_RGB_U32_LIN = 7;
+
+        // Packed RGB Channels (no padding) Single Precision FP Linear
+        //
+        FORMAT_RGB_F32_LIN = 8;
+
+        // Bayer RGGB Channels UINT8 FP Linear
+        //
+        FORMAT_BAYER_BGGR_U8_LIN = 9;
+
+        // Bayer RGGB Channels UINT16 FP Linear
+        //
+        FORMAT_BAYER_BGGR_U16_LIN = 10;
+
+        // Bayer RGGB Channels UINT32 FP Linear
+        //
+        FORMAT_BAYER_BGGR_U32_LIN = 11;
+
+        // Bayer RGGB Channels Single Precision FP Linear
+        //
+        FORMAT_BAYER_BGGR_F32_LIN = 12;
+
+        // TBD: Further channel permutations and padding (e.g. RGBZ,
+        // BGR, BAYER_RGGB/GBRG/GRBG/...), non-BAYER filters, non-linear
+        // encodings, ...
+    }
+
+    // TBD: Optical (and other) effects to apply to image, etc.
+}
+
+message UltrasonicSensorInputConfiguration
+{
+    // TBD: Ultrasonic Sensor specific configuration
+}

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -30,6 +30,37 @@ package osi;
 // and the requested sensor input configuration can depend on those
 // parameter values by being defined as a calculatedParameter.
 //
+// The sensor-technology specific configurations are intended to allow
+// sensor models to use useful sensor modeling base capabilities of the
+// environment simulation (e.g. ray tracing engines, camera/lens image
+// generation), which need configuration by the sensor model to supply
+// suitable data. The specified details are not directly related to
+// sensor details, but rather provide the necessary base machinery
+// setup so that the data provided is suitable to model the sensor to
+// a sufficient degree of fidelity internally.  For example the number
+// of rays parameters for the Lidar configuration does not match one to
+// one with the number of laser rays a lidar sensor might cast, but
+// rather specifies the number of rays being cast by a ray 
+// casting/tracing engine, which might be many more than the physical
+// rays being cast at any point in time.
+//
+// This also implies that for sensors that have dynamically varying
+// characteristics (e.g. switching between wide and narrow focus, 
+// switching update rates, etc.), the basic approach is to specify
+// the maximum amount of data needed at all times here, and internally
+// select the data that is needed at any point in time.
+//
+// In order to optimize the workload and bandwidth needed for sensor
+// simulation, OSI packaging mechanisms can specify the ability to
+// exchange SensorInputConfiguration messages not only prior to
+// simulation startup, but also dynamically during simulation runs,
+// thereby allowing dynamic input configuration switching to only
+// request data that is needed in the current sensor mode.  However
+// this is more or less only a resource optimization strategy, and
+// since providing fine-grained information like this can reveal
+// internal characteristics of the sensor and/or sensor model, will
+// not always be the preferred approach for reasons of IP protection.
+//
 message SensorInputConfiguration
 {
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
@@ -128,12 +159,21 @@ message RadarSensorInputConfiguration
     repeated AntennaDiagramEntry combined_antenna_diagram = 1;
 
     // Number of rays to cast across horizontal field of view (azimuth)
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_rays_horizontal = 2;
 
     // Number of rays to cast across vertical field of view (elevation)
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_rays_vertical = 3;
 
     // Maximum number of interactions to take into account
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 max_number_of_interactions = 4;
 
     message AntennaDiagramEntry {
@@ -158,21 +198,36 @@ message RadarSensorInputConfiguration
 message LidarSensorInputConfiguration
 {
     // Number of rays to cast across horizontal field of view
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_rays_horizontal = 1;
 
     // Number of rays to cast across vertical field of view
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_rays_vertical = 2;
 
     // Maximum number of interactions to take into account
+    //
+    // \note This is a characteristic of the ray tracing engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 max_number_of_interactions = 3;
 }
 
 message CameraSensorInputConfiguration
 {
     // Number of pixels to produce across horizontal field of view
+    //
+    // \note This is a characteristic of the rendering engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_pixels_horizontal = 1;
 
     // Number of pixels to produce across horizontal field of view
+    //
+    // \note This is a characteristic of the rendering engine of the
+    // environment simulation, not a direct characteristic of the sensor.
     optional uint32 number_of_pixels_vertical = 2;
 
     // Format for image data (includes number, kind and format of channels)

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -69,6 +69,35 @@ message SensorInputConfiguration
     // \note In the case of FMU packaging this will correspond to the
     // communication step size.
     optional double update_cycle_time = 5;
+    
+    // Initial update cycle offset of the sensor model
+    //
+    // This specifies the initial offset (i.e. initial delay) of the
+    // sensor model update cycle that the simulation should take into
+    // account. It is defined against a simulation start time of 0:
+    // i.e. an initial offset of 0.008s would mean, that the initial
+    // update of sensor input data to the model should occur at 0+0.008s,
+    // and then update_cycle_time after that, etc. If the simulation
+    // start time of the simulation is non-zero, then the offset still
+    // has to be interpreted against a 0 start time, and not simply
+    // added on top of the start time: e.g. if the simulation starts at
+    // 0.030s, and the update cycle time is 0.020s, then the first
+    // update to the sensor input should happen at 0.048s, or 0.018s
+    // after simulation start.  This convention is needed to ensure
+    // stable phase position of the offset in the case of changing
+    // simulation start times, e.g. for partial resimulation.
+    //
+    // Unit: [s]
+    optional double update_cycle_offset = 6;
+    
+    // Simulation Start time
+    //
+    // This specifies the simulation start time that the Simulation
+    // has chosen. This field has no defined meaning if provided by
+    // the sensor model.
+    //
+    // Unit: [s]
+    optional double simulation_start_time = 7;
 
     // Radar-specific Sensor Input Configuration
     optional RadarSensorInputConfiguration radar_sensor_input_configuration = 1000;

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -155,42 +155,57 @@ message SensorInputConfiguration
 
 message RadarSensorInputConfiguration
 {
-    // This represents the combined TX/RX antenna diagram
-    repeated AntennaDiagramEntry combined_antenna_diagram = 1;
-
     // Number of rays to cast across horizontal field of view (azimuth)
     //
     // \note This is a characteristic of the ray tracing engine of the
     // environment simulation, not a direct characteristic of the sensor.
-    optional uint32 number_of_rays_horizontal = 2;
+    optional uint32 number_of_rays_horizontal = 1;
 
     // Number of rays to cast across vertical field of view (elevation)
     //
     // \note This is a characteristic of the ray tracing engine of the
     // environment simulation, not a direct characteristic of the sensor.
-    optional uint32 number_of_rays_vertical = 3;
+    optional uint32 number_of_rays_vertical = 2;
 
     // Maximum number of interactions to take into account
     //
     // \note This is a characteristic of the ray tracing engine of the
     // environment simulation, not a direct characteristic of the sensor.
-    optional uint32 max_number_of_interactions = 4;
+    optional uint32 max_number_of_interactions = 3;
+
+    // Emitter Frequency
+    //
+    // This information can be used by a ray tracing engine to calculate
+    // doppler shift information and take into account differences in
+    // refraction and reflection.  For doppler shift calculations the
+    // sensor model can of course always provide a nominal frequency and
+    // adjust the resulting doppler shift information to actual frequency
+    // through frequency adjustments.  For material and geometry interaction
+    // purposes the frequency is also relevant.
+    //
+    // Unit: [Hz]
+    optional double emitter_frequency = 4;
+    
+    // This represents the combined TX/RX antenna diagram
+    repeated AntennaDiagramEntry combined_antenna_diagram = 5;
 
     message AntennaDiagramEntry {
         // Horizontal deflection (azimuth) of entry in sensor/antenna
         // coordinates
+        //
         // Unit: [rad]
         optional double horizontal_angle = 1;
 
         // Vertical deflection (elevation) of entry in sensor/antenna
         // coordinates
+        //
         // Unit: [rad]
         optional double vertical_angle = 2;
 
         // Combined response of emitter and receiver antenna at this
-        // point
+        // point (positive dB is gain, negative dB is attenuation)
+        //
         // Unit: [dB]
-        // TBD: Merge with emitted power thus specify in dBm?
         optional double response = 3;
     }
 }
@@ -214,6 +229,19 @@ message LidarSensorInputConfiguration
     // \note This is a characteristic of the ray tracing engine of the
     // environment simulation, not a direct characteristic of the sensor.
     optional uint32 max_number_of_interactions = 3;
+
+    // Emitter Frequency
+    //
+    // This information can be used by a ray tracing engine to calculate
+    // doppler shift information and take into account differences in
+    // refraction and reflection.  For doppler shift calculations the
+    // sensor model can of course always provide a nominal frequency and
+    // adjust the resulting doppler shift information to actual frequency
+    // through frequency adjustments.  For material and geometry interaction
+    // purposes the frequency is also relevant.
+    //
+    // Unit: [Hz]
+    optional double emitter_frequency = 4;
 }
 
 message CameraSensorInputConfiguration

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ class GenerateProtobuf(install):
         'osi_occupant.proto',
         'osi_lane.proto',
         'osi_sensordata.proto',
-        'osi_sensorspecific.proto')
+        'osi_sensorspecific.proto',
+        'osi_sensorinputconfiguration.proto')
 
     """ Generate Protobuf Messages """
 


### PR DESCRIPTION
This is a first draft of the message used to configure the sensor input
between the model and the simulation environment. The mechanics of the
message interchange are determined by the model packaging.

It should be noted that the sensor input configuration mechanism is
separate from any mechanisms that are used to configure the sensor
model itself, which currently are packaging dependent.

Note that this pull request is to aid reviewing and further development,
more work to flesh out this approach if adopted is still needed. This is
just the result of discussions with @raueATconti based on the input by
@hschoen and others.