### PR TITLE
Add ultrasonic-specific object data placeholder

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -68,6 +68,11 @@ message DetectedObject
     // \note Field need not be set if simulated sensor is not a camera sensor.
     optional CameraSpecificObjectData camera_specifics = 12;
 
+    // Additional data that is specific to ultrasonic sensors.
+    //
+    // \note Field need not be set if simulated sensor is not an ultrasonic sensor.
+    optional UltrasonicSpecificObjectData ultrasonic_specifics = 13;
+
     // Definition of available reference points.
     //
     enum ReferencePoint

--- a/osi_sensorspecific.proto
+++ b/osi_sensorspecific.proto
@@ -28,3 +28,11 @@ message CameraSpecificObjectData
 {
     // currently no fields.
 }
+
+//
+// \brief Message encapsulates all data for detected objects that is specific to ultrasonic sensors.
+//
+message UltrasonicSpecificObjectData
+{
+    // currently no fields.
+}


### PR DESCRIPTION
This relates to issue #97, replacing PR #112, to avoid gratuitous duplicate name changes. It splits out the non-renaming changes, letting naming issues be dealt with in a new, more global, PR.