### PR TITLE
OSI Bibtex Key added and renaming of "motor bike" to "motorbike"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,19 @@ In order to generate the doxygen documentation for OSI, please follow the follow
 cmake -DFILTER_PROTO2CPP_PY_PATH=<path-to-proto2cpp.py> <path-to-CMakeLists.txt>
 ```
 5. The build process will then generate the doxygen documentation under the directory doc.
+
+
+Citing
+-------------
+
+For refering to OSI in your publication, please cite as:
+
+```
+@misc{osi.2017,
+	author = {Hanke, Timo and Hirsenkorn, Nils and {van~Driesten}, Carlo and {Garcia~Ramos}, Pilar and Schiementz, Mark and Schneider, Sebastian},
+	year = {2017},
+	title = {{Open Simulation Interface: A generic interface for the environment perception of automated driving functions in virtual scenarios.}},
+	url = {http://www.hot.ei.tum.de/forschung/automotive-veroeffentlichungen/},
+	note = {{Accessed: 2017-08-28}}
+}
+```


### PR DESCRIPTION
OSI Bibtex Key for standardized citation.
Renaming of "motor bike" to "motorbike" following recommondation in various dictionaries (e.g. [https://dictionary.cambridge.org/dictionary/english-german/motorbike](cambridge) ) 