### PR TITLE
Clarify and refactor timestamp field definitions

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -265,9 +265,13 @@ message DetectedObjectHeader
     //
     optional InterfaceVersion version = 1;
 
-    // Time stamp at which the measurement was taken (not the time at which it was processed or at which it is
-    // transmitted) in the global synchronized time.
-    optional Timestamp timestamp = 2;
+    // Time stamp at which the measurement was taken (not the time at which it
+    // was processed or at which it is transmitted) in the global synchronized
+    // time.
+    //
+    // \note See SensorData::timestamp and SensorData::last_measurement_time
+    // for detailed discussions on the semantics of time-related fields.
+    optional Timestamp measurement_time = 2;
 
     // Continuous up counter to identify the cycle.
     //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -32,9 +32,13 @@ message DetectionHeader
     // 
     optional DetectionInterfaceVersion version = 1;
 
-    // Time stamp at which the measurement was taken (not the time at which it was processed or at which it is transmitted) in the global synchronized time. 
+    // Time stamp at which the measurement was taken (not the time at which it
+    // was processed or at which it is transmitted) in the global synchronized
+    // time.
     //
-    optional Timestamp timestamp = 2;
+    // \note See SensorData::timestamp and SensorData::last_measurement_time
+    // for detailed discussions on the semantics of time-related fields.
+    optional Timestamp measurement_time = 2;
 
     // Continuous up counter to identify the cycle.
     //

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -37,9 +37,15 @@ message GroundTruth
     //
     optional InterfaceVersion version = 1;
 
-    // The data timestamp of the simulation environment. Zero time is arbitrary but must be identical for all messages.
-    // Zero time does not need to coincide with the unix epoch. Recommended is the starting time point of the
-    // simulation.
+    // The data timestamp of the simulation environment. Zero time is arbitrary
+    // but must be identical for all messages. Zero time does not need to
+    // coincide with the unix epoch. Recommended is the starting time point of
+    // the simulation.
+    //
+    // \note For ground truth data this timestamp coincides both with the
+    // notional simulation time the data applies to and the time it was sent
+    // (there is no inherent latency for ground truth data, as opposed to
+    // sensor data).
     optional Timestamp timestamp = 2;
 
     // A list of vehicles.

--- a/osi_modelinternal.proto
+++ b/osi_modelinternal.proto
@@ -23,10 +23,6 @@ message ModelInternal
     // Low Level data should be transferred to receiving components by means of a separate data stream. Therefore they
     // are not part the top level SensorData message, as they are used only internally by some models.
     optional FeatureData feature_data = 1;
-
-    // Latency, time offset that should have been elapsed before the data is transmitted to the receiving component.
-    // Unit [ms].
-    optional double latency = 2;
 }
 
 //

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -26,9 +26,30 @@ message SensorData
     //
     optional Identifier id = 1;
 
-    // The data timestamp of the sensor data. Zero time is arbitrary but must be identical for all messages.
-    // Zero time does not need to coincide with the unix epoch. Recommended is the starting time point of the
+    // The timestamp of the sensor data. Zero time is arbitrary but must be
+    // identical for all messages. Zero time does not need to coincide with
+    // the unix epoch. Recommended is the starting time point of the
     // simulation.
+    //
+    // \note This is the point in time that the sensor data message becomes
+    // available to the rest of the system (i.e. the driving functions), so
+    // it corresponds with the sending time and thus takes the latency of
+    // internal processing of the sensor into account. Latencies of bus
+    // communications, etc., that occur after the sensor output have to be
+    // applied on top of this, if needed.
+    //
+    // The time that the actual measurement was performed (which will usually
+    // correspond with the timestamp of the GroundTruth the sensor model
+    // processed to arrive at these results) can be found in the additional
+    // field SensorData::last_measurement_time.
+    //
+    // For an ideal zero latency sensor the two timestamps would be the same
+    // and would correspond with the timestamp from the current GroundTruth
+    // message.
+    //
+    // For a sensor model that does not know its own internal latencies (e.g.
+    // a dumb sensor with no internal time concept), the two timestamps might
+    // also be identical, but delayed from the GroundTruth timestamp.
     optional Timestamp timestamp = 2;
 
     // Should be used as constant; use this if you require fields that do not exist in osi_sensordata or for the purpose
@@ -93,6 +114,15 @@ message SensorData
     // The id of the ego lane in the DetectedLane data, relative to the sensor.
     // 
     optional Identifier ego_lane_id = 15;
+    
+    // The timestamp of the last real-world measurement (e.g. GT input) that
+    // this set of sensor data takes into account.  This in effect is the last
+    // time instance of reality the measurements correspond to.  See field
+    // SensorData::timestamp for a detailed discussion.  This value is also
+    // the upper bound to the DetectedObjectHeader::measurement_time and the
+    // feature data DetectionHeader::measurement_time fields.
+    // 
+    optional Timestamp last_measurement_time = 16;
 }
 
 //


### PR DESCRIPTION
This adds clarifying documentation to the timing-related fields, renames
the timestamp fields in DetectedObjectHeader and DetectionHeader to
indicate their measurment time related nature, adds a field named
last_measurement_time to the SensorData message to provide an upper
bound on embedded measurement times and removes legacy/ill-defined
fields.