### PR TITLE
Refactor SensorDataGroundTruth, add SensorView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,9 @@ set(OSI_PROTO_FILES
     osi_object.proto
     osi_occupant.proto
     osi_sensordata.proto
-    osi_sensorspecific.proto
     osi_sensorinputconfiguration.proto
+    osi_sensorspecific.proto
+    osi_sensorview.proto
 )
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES})

--- a/osi_modelinternal.proto
+++ b/osi_modelinternal.proto
@@ -8,24 +8,6 @@ import "osi_object.proto";
 package osi;
 
 //
-// \brief Internal data and state flags for the sensor model, set and used during modification of the interface data.
-//
-// Content of all ModelInternal* messages may be cleared at the end of the sensor model processing chain and not sent
-// with the final output of the sensor model. Receiving components must not expect values in ModelInternal* messages to
-// be set. In particular, the message structures defined in this file must not be used by receiving components outside
-// of the sensor model to read required input data.
-//
-message ModelInternal
-{
-    // Low level data interface, for use by models performing statistical generation of such "low level data" before
-    // object hypothesis and tracking from object ground truth.
-    //
-    // Low Level data should be transferred to receiving components by means of a separate data stream. Therefore they
-    // are not part the top level SensorData message, as they are used only internally by some models.
-    optional FeatureData feature_data = 1;
-}
-
-//
 // \brief Additional internal data and state flags for SensorDataObjects.
 //
 message ModelInternalObject

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -8,7 +8,8 @@ import "osi_detectedlane.proto";
 import "osi_detectedobject.proto";
 import "osi_detectedoccupant.proto";
 import "osi_groundtruth.proto";
-import "osi_modelinternal.proto";
+import "osi_sensorview.proto";
+import "osi_featuredata.proto";
 
 package osi;
 
@@ -52,14 +53,26 @@ message SensorData
     // also be identical, but delayed from the GroundTruth timestamp.
     optional Timestamp timestamp = 2;
 
-    // Should be used as constant; use this if you require fields that do not exist in osi_sensordata or for the purpose
-    // of matching sensor output against ground truth data.
+    // Ground truth w.r.t. global coordinate system
     //
-    optional SensorDataGroundTruth ground_truth = 3;
+    // This is the ground truth that is provided to the sensor model by the
+    // simulation environment.
+    // \note Should be used as constant in the sensor models.
+    // 
+    optional GroundTruth global_ground_truth = 3;
+    
+    // Sensor view w.r.t. the sensor coordinate system
+    //
+    // This provides additional data to the sensor model as configured in
+    // the sensor input configuration.  All data is relative to the sensor
+    // both in terms of the coordinate system, as well as the content.
+    // \note Should be used as constant in the sensor models.
+    // 
+    optional SensorView sensor_view = 4;
     
     // The id of the host vehicle in the ground_truth data.
     //    
-    optional Identifier host_vehicle_id = 4;
+    optional Identifier host_vehicle_id = 5;
 
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
     //
@@ -72,50 +85,12 @@ message SensorData
     // See https://en.wikipedia.org/wiki/Axes_conventions#/media/File:RPY_angles_of_cars.png 
     //
     // \note This field is usually static during the simulation.
-    optional MountingPosition mounting_position = 5;
-
-    // The list of objects detected by the sensor as perceived by the sensor.
-    //
-    repeated DetectedObject object = 6;
-
-    // The list of traffic signs detected by the sensor
-    //
-    repeated DetectedTrafficSign traffic_sign = 7;
-    
-    // The list of traffic lights detected by the sensor
-    // 
-    repeated DetectedTrafficLight traffic_light = 8;
-
-    // The list of road marking detected by the sensor.
-    // This excludes lane boundary marking as these are included in DetectedLane.
-    repeated DetectedRoadMarking road_marking = 9;
-
-    // The list of lane detected by the sensor
-    // 
-    repeated DetectedLane lane = 10;
-
-    // The list of occupants of the host vehicle
-    // 
-    repeated DetectedOccupant occupant = 11;
-
-    // Additional internal data and state flags required and used by the sensor-models.
-    // \note Should not be used by subscribers to SensorData data. 
-    // Generally this field should be cleared after internal processing.
-    optional ModelInternal model_internal = 12;
+    optional MountingPosition mounting_position = 6;
 
     // The root mean square error of the mounting position.
     //
-    optional MountingPosition mounting_position_rmse = 13;
+    optional MountingPosition mounting_position_rmse = 7;
 
-    // The list of road marking detected by the sensor.
-    // This excludes lane boundary marking as these are included in DetectedLane.
-    repeated DetectedLaneBoundary lane_boundary = 14;
-
-    // The id of the lane the host vehicle travels on in the DetectedLane data,
-    // relative to the sensor.
-    // 
-    optional Identifier host_vehicle_lane_id = 15;
-    
     // The timestamp of the last real-world measurement (e.g. GT input) that
     // this set of sensor data takes into account.  This in effect is the last
     // time instance of reality the measurements correspond to.  See field
@@ -123,28 +98,47 @@ message SensorData
     // the upper bound to the DetectedObjectHeader::measurement_time and the
     // feature data DetectionHeader::measurement_time fields.
     // 
-    optional Timestamp last_measurement_time = 16;
-}
-
-//
-// \brief Ground truth data with respect to two different reference frames (global and sensor).
-// 
-// Use in the sensor model's data processing and comparison of sensor and ground truth data.
-//
-message SensorDataGroundTruth
-{
-    // Ground truth w.r.t. global coordinate system (copy of GroundTruth message to \c SensorData::ground_truth.global_ground_truth),
+    optional Timestamp last_measurement_time = 8;
+    
+    // The list of objects detected by the sensor as perceived by the sensor.
     //
-    // needed for setting fields in the SensorData that are not covered by the model.
-    // \note Should be used as constant in the sensor models.
+    repeated DetectedObject object = 9;
+
+    // The list of traffic signs detected by the sensor
+    //
+    repeated DetectedTrafficSign traffic_sign = 10;
+    
+    // The list of traffic lights detected by the sensor
     // 
-    optional GroundTruth global_ground_truth = 1;
+    repeated DetectedTrafficLight traffic_light = 11;
 
-    // Ground truth w.r.t. the sensor coordinate system (\c SensorData::ground_truth.sensor_ground_truth.ground_truth.global_ground_truth).
+    // The list of road marking detected by the sensor.
+    // This excludes lane boundary markings.
     //
-    // Is equal to the version of the SensorData interface that is used as input by the sensor model before
-    // any processing takes place aside from the coordinate transformation from global to sensor reference frame.
+    repeated DetectedRoadMarking road_marking = 12;
+
+    // The list of lane detected by the sensor
+    // 
+    repeated DetectedLane lane = 13;
+
+    // The list of lane boundary markings detected by the sensor.
     //
-    // \c SensorData::ground_truth.sensor_ground_truth.ground_truth.sensor_ground_truth is not set in this instance to avoid the resulting infinite loop.
-    optional SensorData sensor_ground_truth = 2;
+    repeated DetectedLaneBoundary lane_boundary = 14;
+
+    // The id of the lane the host vehicle travels on in the DetectedLane data,
+    // relative to the sensor.
+    //
+    optional Identifier host_vehicle_lane_id = 15;
+
+    // The list of occupants of the host vehicle
+    // 
+    repeated DetectedOccupant occupant = 16;
+    
+    // Low level feature data interface.
+    //
+    // Low Level feature data is optionally provided by sensor models that
+    // model sensors giving access to this low level data, i.e. data prior to
+    // object hypothesis and tracking.
+    //
+    optional FeatureData feature_data = 17;
 }

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -186,8 +186,11 @@ message RadarSensorInputConfiguration
     // Unit: [Hz]
     optional double emitter_frequency = 4;
     
-    // This represents the combined TX/RX antenna diagram
-    repeated AntennaDiagramEntry combined_antenna_diagram = 5;
+    // This represents the TX antenna diagram
+    repeated AntennaDiagramEntry tx_antenna_diagram = 5;
+    
+    // This represents the RX antenna diagram
+    repeated AntennaDiagramEntry rx_antenna_diagram = 6;
 
     message AntennaDiagramEntry {
         // Horizontal deflection (azimuth) of entry in sensor/antenna

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -66,6 +66,7 @@ message RadarSensorView {
     
     message Reflection {
         // Relative signal level of the reflection
+        //
         // This takes the combined_antenna_diagram (losses in TX and RX)
         // as well as the signal losses due to scattering and absorption
         // into account, and will, when multiplied by TX power yield the
@@ -74,6 +75,7 @@ message RadarSensorView {
         optional double signal_strength = 1;
         
         // Time of flight
+        //
         // This is the time of flight of the reflection, which is directly
         // proportional to the distance travelled. 
         // Unit: [s]
@@ -84,6 +86,20 @@ message RadarSensorView {
         // Shift in frequency based on the specified TX frequency
         // Unit: [Hz]
         optional double doppler_shift = 3;
+        
+        // TX horizontal angle (azimuth)
+        //
+        // Horizontal angle of incidence of the source of the reflection
+        // at the TX antenna.
+        // Unit: [rad]
+        optional double source_horizontal_angle = 4;
+        
+        // TX vertical angle (elevation)
+        //
+        // Vertical angle of incidence of the source of the reflection
+        // at the TX antenna.
+        // Unit: [rad]
+        optional double source_vertical_angle = 5;
     }
 }
 
@@ -106,6 +122,7 @@ message LidarSensorView {
 
     message Reflection {
         // Relative signal level of the reflection
+        //
         // This takes the combined_antenna_diagram (losses in TX and RX)
         // as well as the signal losses due to scattering and absorption
         // into account, and will, when multiplied by TX power yield the
@@ -114,6 +131,7 @@ message LidarSensorView {
         optional double signal_strength = 1;
             
         // Time of flight
+        //
         // This is the time of flight of the reflection, which is directly
         // proportional to the distance travelled. 
         // Unit: [s]

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -1,0 +1,158 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_version.proto";
+import "osi_common.proto";
+import "osi_sensorinputconfiguration.proto";
+
+package osi;
+
+//
+// \brief sensor view
+//
+// 
+//
+message SensorView
+{
+    // The interface version used by the sender (simulation environment).
+    //
+    optional InterfaceVersion version = 1;
+
+    // The data timestamp of the simulation environment. Zero time is arbitrary
+    // but must be identical for all messages. Zero time does not need to
+    // coincide with the unix epoch. Recommended is the starting time point of
+    // the simulation.
+    //
+    // \note For sensor view data this timestamp coincides both with the
+    // notional simulation time the data applies to and the time it was sent
+    // (there is no inherent latency for sensor view data, as opposed to
+    // sensor data).
+    optional Timestamp timestamp = 2;
+    
+    // Radar-Specific SensorView
+    //
+    optional RadarSensorView radar_sensor_view = 1000;
+
+    // Lidar-Specific SensorView
+    //
+    optional LidarSensorView lidar_sensor_view = 1001;
+
+    // Camera-Specific SensorView
+    //
+    optional CameraSensorView camera_sensor_view = 1002;
+
+    // Ultrasonic-Specific SensorView
+    //
+    optional UltrasonicSensorView ultrasonic_sensor_view = 1003;
+}
+
+//
+// \brief Radar Sensor View
+//
+// Radar-Specific Sensor View Data
+message RadarSensorView {
+    
+    // Radar Input Configuration valid at the time the data was created
+    //
+    optional RadarSensorInputConfiguration radar_sensor_input_configuration = 1;
+
+    // Ray Tracing Data
+    //
+    // This field includes one entry for each ray, in left-to-right,
+    // top-to-bottom order (think scan lines in a TV).
+    //
+    repeated Reflection reflection = 2;
+    
+    message Reflection {
+        // Relative signal level of the reflection
+        // This takes the combined_antenna_diagram (losses in TX and RX)
+        // as well as the signal losses due to scattering and absorption
+        // into account, and will, when multiplied by TX power yield the
+        // actual RX power.
+        // Unit: [dB]
+        optional double signal_strength = 1;
+        
+        // Time of flight
+        // This is the time of flight of the reflection, which is directly
+        // proportional to the distance travelled. 
+        // Unit: [s]
+        optional double time_of_flight = 2;
+        
+        // Doppler shift
+        //
+        // Shift in frequency based on the specified TX frequency
+        // Unit: [Hz]
+        optional double doppler_shift = 3;
+    }
+}
+
+//
+// \brief Lidar Sensor View
+//
+// Lidar-Specific Sensor View Data
+message LidarSensorView {
+
+    // Lidar Input Configuration valid at the time the data was created
+    //
+    optional LidarSensorInputConfiguration lidar_sensor_input_configuration = 1;
+    
+    // Ray Tracing Data
+    //
+    // This field includes one entry for each ray, in left-to-right,
+    // top-to-bottom order (think scan lines in a TV).
+    //
+    repeated Reflection reflections = 2;
+
+    message Reflection {
+        // Relative signal level of the reflection
+        // This takes the combined_antenna_diagram (losses in TX and RX)
+        // as well as the signal losses due to scattering and absorption
+        // into account, and will, when multiplied by TX power yield the
+        // actual RX power.
+        // Unit: [dB]
+        optional double signal_strength = 1;
+            
+        // Time of flight
+        // This is the time of flight of the reflection, which is directly
+        // proportional to the distance travelled. 
+        // Unit: [s]
+        optional double time_of_flight = 2;
+            
+        // Doppler shift
+        //
+        // Shift in frequency based on the specified TX frequency
+        // Unit: [Hz]
+        optional double doppler_shift = 3;
+    }
+}
+
+//
+// \brief Camera Sensor View
+//
+// Camera-Specific Sensor View Data
+message CameraSensorView {
+    
+    // Camera Input Configuration valid at the time the data was created
+    //
+    optional CameraSensorInputConfiguration camera_sensor_input_configuration = 1;
+    
+    // Raw Image Data
+    //
+    // The raw image data in the memory layout and order specified by the
+    // camera sensor input configuration.
+    //
+    optional bytes image_data = 2;
+}
+
+//
+// \brief Ultrasonic Sensor View
+//
+// Ultrasonic-Specific Sensor View Data
+message UltrasonicSensorView {
+
+    // Ultrasonic Input Configuration valid at the time the data was created
+    //
+    optional UltrasonicSensorInputConfiguration ultrasonic_sensor_input_configuration = 1;
+    
+}

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ class GenerateProtobuf(install):
         'osi_occupant.proto',
         'osi_lane.proto',
         'osi_sensordata.proto',
+        'osi_sensorinputconfiguration.proto',
         'osi_sensorspecific.proto',
-        'osi_sensorinputconfiguration.proto')
+        'osi_sensorview.proto')
 
     """ Generate Protobuf Messages """
 


### PR DESCRIPTION
This cleans up SensorData, removes ModelInternal, SensorDataGroundTruth,
and introduces the new SensorView message which contains sensor-relative
and sensor-specific views on the GroundTruth. Note that this is a first
draft for discussion.