### PR TITLE
Add host vehicle data as sensor input data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(OSI_PROTO_FILES
     osi_detectedoccupant.proto
     osi_environment.proto
     osi_groundtruth.proto
+    osi_hostvehicledata.proto
     osi_landmark.proto
     osi_lane.proto
     osi_featuredata.proto

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -1,0 +1,30 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_common.proto";
+
+package osi;
+
+//
+// \brief Interface for host vehicle data, that is available to sensors and
+// other functions due to host vehicle internal communication.
+//
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
+message HostVehicleData
+{
+    // Current estimated location based on GPS- and related navigation sensors
+    //
+    // Note that dimension and base_polygon need not be filled.
+    //
+    optional BaseMoving location = 1;
+
+    // Current estimated location error based on GPS- and related navigation sensors
+    //
+    // Note that dimension and base_polygon need not be filled.
+    //
+    optional BaseMoving location_rmse = 2;
+
+}

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -10,6 +10,7 @@ import "osi_detectedoccupant.proto";
 import "osi_groundtruth.proto";
 import "osi_sensorview.proto";
 import "osi_featuredata.proto";
+import "osi_hostvehicledata.proto";
 
 package osi;
 
@@ -73,7 +74,7 @@ message SensorData
     // The id of the host vehicle in the ground_truth data.
     //    
     optional Identifier host_vehicle_id = 5;
-
+    
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
     //
     // given in vehicle coordinates: origin is ( \c Vehicle::base.position + INV(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) the orientation is equal to the orientation of the vehicle \c Vehicle::base.orientation.
@@ -141,4 +142,11 @@ message SensorData
     // object hypothesis and tracking.
     //
     optional FeatureData feature_data = 17;
+    
+    // Host Vehicle Data
+    //
+    // Host vehicle data is data that the host vehicle knows about itself,
+    // e.g. from location sensors, internal sensors and ECU bus data, etc.,
+    // that is made available to sensors as input.
+    optional HostVehicleData host_vehicle_data_id = 18;
 }

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ class GenerateProtobuf(install):
         'osi_detectedlane.proto',
         'osi_environment.proto',
         'osi_groundtruth.proto',
+        'osi_hostvehicledata.proto',
         'osi_landmark.proto',
         'osi_featuredata.proto',
         'osi_modelinternal.proto',


### PR DESCRIPTION
This changeset introduces HostVehicleData which comprises all vehicle
internal data that is available to the sensors (or in the future other
parts of OSI) as additional input. This includes e.g. GPS-sensor derived
data as well as e.g. engine ECU data, etc.  For now this only includes
GPS-sensor location data with error estimation.