### PR TITLE
Detected... message references sensors (issue #147)

### DIFF
--- a/osi_detectedlandmark.proto
+++ b/osi_detectedlandmark.proto
@@ -53,6 +53,12 @@ message DetectedTrafficSign
     // Links to the corresponding lanes.
     //    
     repeated RelevantLane relevant_lane = 10;
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 11;
 
     // Definition of traffic sign geometries.
     //
@@ -182,6 +188,13 @@ message DetectedTrafficLight
     // The root mean squared error of the base parameters of the detected traffic light.
     //
     optional BaseStationary rmse = 9;
+    
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 10;
 
     //
     // \brief Further specifies the relevant directions of the traffic light.
@@ -267,9 +280,16 @@ message DetectedRoadMarking
     // The measurement state.
     //
     optional MeasurementState measurement_state = 7;
-    // The root mean squared error of the base parameters of the detected road marking.
+
+    // The root mean square error of the base parameters of the detected road marking.
     //
     optional BaseStationary rmse = 8;
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 9;
 }
 
 //

--- a/osi_detectedlane.proto
+++ b/osi_detectedlane.proto
@@ -35,6 +35,12 @@ message DetectedLane
     // \note Use as confidence measure where a low value means less confidence and a high value indicates
     // strong confidence.
     optional double existence_probability = 5;
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 6;
 }
 
 //
@@ -81,4 +87,10 @@ message DetectedLaneBoundary
     // Confidence of the segments of the BoundaryPoint information from a LaneBoundary.
     // For every \c lane_boundary.boundary_line point exact one \c boundary_line_confidence confidence value is specified.
     repeated double boundary_line_confidence = 10;
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 11;
 }

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -93,26 +93,32 @@ message DetectedObject
     // The estimated probabilities for the object to belong to a specific class.
     //
     optional ClassProbability class_probability = 17;
+    
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 18;
 
     // The estimated pedestrian head pose.
     //
     // \note Pedestrian specific value.
-    optional Orientation3d pedestrian_head_pose = 18;
+    optional Orientation3d pedestrian_head_pose = 19;
 
     // The estimated pedestrian upper body pose.
     //
     // \note Pedestrian specific value.
-    optional Orientation3d pedestrian_upper_body_pose = 19;
+    optional Orientation3d pedestrian_upper_body_pose = 20;
 
     // Percentage side lane left.
     //
     // Percentage value of the object width in the corresponding lane.
-    optional double percentage_side_lane_left = 20;
+    optional double percentage_side_lane_left = 21;
 
     // Percentage side lane right.
     //
     // Percentage value of the object width in the corresponding lane.
-    optional double percentage_side_lane_right = 21;
+    optional double percentage_side_lane_right = 22;
     
     // Definition of available reference points. Left/middle/right and front/middle/rear indicate the position in y- and
     // x direction respectively. The z position is always considered as middle.

--- a/osi_detectedoccupant.proto
+++ b/osi_detectedoccupant.proto
@@ -38,4 +38,11 @@ message DetectedOccupant
     // The measurement state.
     //
     optional MeasurementState measurement_state = 6;
+
+    // A list of sensors which 'detected' this 'object'.
+    // 
+    // \note This is a redundant information because you can determine this list from 
+    // the \c ...Detection::object_id and the sensors to which these detections belong.
+    repeated Identifier sensor_id = 7;
 }
+

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -72,14 +72,22 @@ message DetectionHeader
     //
     optional MountingPosition mounting_position_rmse = 5;
 
+    // The id of the sensor at host vehicle's mounting_position.
+    //
+    // This id can be equal to \c SensorData::id 
+    //
+    // \note This is a redundant information because the sensor's 
+    // mounting_position defines unique the host vehicle's sensor.
+    optional Identifier sensor_id = 6;
+    
     // Data Qualifier expresses to what extent the content of this event can be relied on.
     //
-    optional DataQualifier data_qualifier = 6;
+    optional DataQualifier data_qualifier = 7;
 
     // The current number of valid detections in the detections list.
     //
     // \note This value has to be set if the list contains invalid detections.    
-    optional uint32 number_of_detections = 7;
+    optional uint32 number_of_detections = 8;
 
     // \brief Data qualifier communicates the overall availability of the interface.
     //

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -26,6 +26,12 @@ message SensorData
 {  
     // The ID of the sensor.
     //
+    // This id can be equal to \c DetectionHeader::sensor_id. 
+    // In case of a multisensor configuration this id is different to
+    // the DetectionHeader::sensor_id.
+    //
+    // \note This is a redundant information because the sensor's 
+    // mounting_position defines unique the host vehicle's sensor.
     optional Identifier id = 1;
 
     // The timestamp of the sensor data. Zero time is arbitrary but must be


### PR DESCRIPTION
This PR adress issue #147 

Add a list of sensor ids to all Detected... messages. These sensors confirm this Detected... 'object'. It is a redundant info.