### PR TITLE
Use vehicle axis system definition of DIN ISO 8855

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -97,18 +97,24 @@ message Dimension3d
 // 
 // The preferred angular range is (-pi, pi]. The coordinate system is defined as right-handed. 
 //  
-// The rotations are to be performed \b roll \b first, \b pitch \b second and \b yaw \b third to follow the definition according to [1]. 
+// The rotations are to be performed \b yaw \b first, \b pitch \b second and \b roll \b third to follow the definition according to [1]. 
 // 
 // Rotations are defined in the reference coordinate frame around z-axis (=yaw), y-axis (=pitch) and x-axis (=roll), 
 // not in the body frame of the object. 
-// A positive angle corresponds to a counter-clockwise rotation around the respective axis.
+// A positive angle corresponds to a clockwise rotation around the respective axis.
 //
 // Roll/Pitch are 0 if the objects xy-plane is parallel to its parent's xy-plane.
 // Yaw is 0 if the object's local x-axis is parallel to its parent's x-axis.
 //
+// Rotation_yaw_pitch_roll = Rotation_roll*Rotation_pitch*Rotation_yaw
+//
+// vector_global_coord_system := Inverse_Rotation_yaw_pitch_roll(orientation)*(vector_local_coord_system) + local_origin.position
+
+//
+// \note This definition changed in OSI version 3.0.0. Previous OSI versions (V2.xx) had an other definition.
+//
 // \par References: 
-// [1] LAVALLE, Steven M. Planning algorithms. Cambridge university press, 2006. Chapter 3.2.3.
-// See http://planning.cs.uiuc.edu/node102.html for online version of this chapter.
+// [1] DIN ISO 8855:2013-11
 //
 message Orientation3d
 {
@@ -155,7 +161,7 @@ message MountingPosition
     optional Vector3d position = 1;
 
     // Orientation offset relative to the specified reference coordinate system.
-    //
+    // Origin_sensor := Rotation_yaw_pitch_roll(MountingPosition.orientation)*(Origin_reference_coordinate_system - MountingPosition.position)
     optional Orientation3d orientation = 2;
 }
 
@@ -167,7 +173,10 @@ message MountingPosition
 // Units are [m] for radial distance and [rad] for azimuth and elevation angles. 
 // If azimuth and elevation are zero, the referenced point lies directly ahead
 // in the central viewing direction of the sensor, and the respective vector points directly in the latter.
+// A positive angle corresponds to a clockwise rotation around the respective axis, i.e. 
+// z-axis (azimuth = yaw), y-axis (elevation = pitch).
 //
+// vector_cartesian := Rotation(elevation)*Rotation(azimuth)*Unit_vector_x*distance
 message Spherical3d
 {
     // The radial distance.
@@ -188,6 +197,9 @@ message Spherical3d
 // 
 // This includes the StationaryObject, TrafficSign, TrafficLight, RoadMarking messages.
 //
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
 message BaseStationary
 {
     // The 3D dimensions of the stationary object (bounding box), e.g. a landmark:
@@ -199,7 +211,9 @@ message BaseStationary
     optional Vector3d position = 2;
 
     // The relative orientation of the stationary object w.r.t. its parent frame.
-    // There may be some constraints how to use orientation w.r.t. to some stationary object's or entity's definition.
+    //
+    // Origin_base_stationary_entity := Rotation_yaw_pitch_roll(BaseStationary.orientation)*(Origin_parent_coordinate_system - BaseStationary.position)
+    // \note There may be some constraints how to align the orientation w.r.t. to some stationary object's or entity's definition.
     optional Orientation3d orientation = 3;
     
     // Usage as ground truth:
@@ -225,6 +239,9 @@ message BaseStationary
 // 
 // This includes the MovingObject messages.
 //
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
 message BaseMoving
 {
     // The 3D dimension of the moving object (its bounding box).
@@ -237,18 +254,27 @@ message BaseMoving
 
     // The relative orientation of the moving object w.r.t. its parent frame.
     //
+    // Origin_base_moving_entity := Rotation_yaw_pitch_roll(BaseMoving.orientation)*(Origin_parent_coordinate_system - BaseMoving.position)
+    // \note There may be some constraints how to align the orientation w.r.t. to some stationary object's or entity's definition.
     optional Orientation3d orientation = 3;
 
     // The relative velocity of the moving object w.r.t. its parent frame and parent velocity.
     // The velocity becomes global/absolute if the parent frame does not move.
+    //
+    // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt 
     optional Vector3d velocity = 4;
 
     // The relative acceleration of the moving object w.r.t. its parent frame and parent acceleration.
     // The acceleration becomes global/absolute if the parent frame is not accelerating.
+    //
+    // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt+acceleration/2*dt^2
+    // BaseMoving.velocity(t) := BaseMoving.velocity(t-dt)+acceleration*dt 
     optional Vector3d acceleration = 5;
 
-    // The relative orientation rate of the moving object w.r.t. its parent frame and parent orientation rate in the center point of the bounding box.
-    // The orientation rate becomes global/absolute if the parent frame is not rotating.
+    // The relative orientation rate of the moving object w.r.t. its parent frame and parent orientation rate in the center point of the bounding box (origin of the bounding box frame).
+    //
+    // Rotation_yaw_pitch_roll(BaseMoving.orientation(t)) := Rotation_yaw_pitch_roll(BaseMoving.orientation_rate*dt)*Rotation_yaw_pitch_roll(BaseMoving.orientation(t-dt))
+    // \note BaseMoving.orientation(t) is \b not equal BaseMoving.orientation(t-dt)+BaseMoving.orientation_rate*dt
     optional Orientation3d orientation_rate = 6;
     
     // Usage as ground truth:

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -87,21 +87,22 @@ message Dimension3d
 }
 
 //
-// \brief A 3D orientation, orientation rate or orientation acceleration (i.e. derivatives)
-// or its uncertainties denoted in euler angles.
+// \brief A 3D orientation, orientation rate or orientation acceleration (i.e. 
+// derivatives) or its uncertainties denoted in euler angles.
 // 
 // Units are 
 // \arg [rad] for orientation
 // \arg [rad/s] for rates
 // \arg [rad/s^2] for accelerations
 // 
-// The preferred angular range is (-pi, pi]. The coordinate system is defined as right-handed. 
+// The preferred angular range is (-pi, pi]. The coordinate system is defined as 
+// right-handed. 
+// For the sense of each rotation, the right-hand rule applies.
 //  
-// The rotations are to be performed \b yaw \b first, \b pitch \b second and \b roll \b third to follow the definition according to [1]. 
-// 
-// Rotations are defined in the reference coordinate frame around z-axis (=yaw), y-axis (=pitch) and x-axis (=roll), 
-// not in the body frame of the object. 
-// A positive angle corresponds to a clockwise rotation around the respective axis.
+// The rotations are to be performed \b yaw \b first (around the z-axis), 
+// \b pitch \b second (around the new y-axis) and \b roll \b third (around the 
+// new x-axis) to follow the definition according to [1] (Tait-Bryan / Euler 
+// convention z-y'-x'').
 //
 // Roll/Pitch are 0 if the objects xy-plane is parallel to its parent's xy-plane.
 // Yaw is 0 if the object's local x-axis is parallel to its parent's x-axis.
@@ -111,7 +112,8 @@ message Dimension3d
 // vector_global_coord_system := Inverse_Rotation_yaw_pitch_roll(orientation)*(vector_local_coord_system) + local_origin.position
 
 //
-// \note This definition changed in OSI version 3.0.0. Previous OSI versions (V2.xx) had an other definition.
+// \note This definition changed in OSI version 3.0.0. Previous OSI versions 
+// (V2.xx) had an other definition.
 //
 // \par References: 
 // [1] DIN ISO 8855:2013-11
@@ -134,13 +136,16 @@ message Orientation3d
 //
 // \brief A common identifier (ID), represented as an integer.
 // 
-// Has to be unique among all simulated items at any given time. For ground truth, the identifier of an item (object,
-// lane, sign, etc.) must remain stable over its lifetime. Identifier values may be only be reused if the available
-// address space is exhausted and the specific values have not been in use for several timesteps. Sensor specific
-// tracking IDs have no restrictions and should behave according to the sensor specifications.
+// Has to be unique among all simulated items at any given time. For ground
+// truth, the identifier of an item (object, lane, sign, etc.) must remain
+// stable over its lifetime. Identifier values may be only be reused if the
+// available address space is exhausted and the specific values have not been in
+// use for several timesteps. Sensor specific tracking IDs have no restrictions
+// and should behave according to the sensor specifications.
 //
-// The value MAX(uint64) = 2^(64) -1 = 0b1111111111111111111111111111111111111111111111111111111111111111 is reserved and 
-// indicates an invalid ID or error.
+// The value MAX(uint64) = 2^(64) -1 = 
+// 0b1111111111111111111111111111111111111111111111111111111111111111 is 
+// reserved and indicates an invalid ID or error.
 //
 message Identifier
 {
@@ -170,11 +175,19 @@ message MountingPosition
 //
 // Used e.g., for low level representations of radar detections.
 // 
-// Units are [m] for radial distance and [rad] for azimuth and elevation angles. 
+// Units are [m] for radial distance and [rad] for azimuth and elevation angles.
+// With the x-axis of the sensor frame pointing in the central viewing direction 
+// of the sensor, the z-axis pointing upwards and the senor frame being 
+// right-handed, azimuth and elevation are defined as the rotations that would 
+// have to be applied to the sensor frame to make its x-axis point towards the 
+// referenced point or to align it with the referenced vector. The rotations are 
+// to be performed \b azimuth \b first (around the z-axis) and \b elevation 
+// \b second (around the new y-axis) to follow the definition of 
+// OSI:Orientation3D. For the sense of each rotation, the right-hand rule 
+// applies. 
 // If azimuth and elevation are zero, the referenced point lies directly ahead
-// in the central viewing direction of the sensor, and the respective vector points directly in the latter.
-// A positive angle corresponds to a clockwise rotation around the respective axis, i.e. 
-// z-axis (azimuth = yaw), y-axis (elevation = pitch).
+// in the central viewing direction of the sensor, and the respective vector 
+// points directly in the latter.
 //
 // vector_cartesian := Rotation(elevation)*Rotation(azimuth)*Unit_vector_x*distance
 message Spherical3d
@@ -195,40 +208,47 @@ message Spherical3d
 //
 // \brief The base attributes of a stationary object or entity.
 // 
-// This includes the StationaryObject, TrafficSign, TrafficLight, RoadMarking messages.
+// This includes the \c OSI::StationaryObject, \c OSI::TrafficSign,
+// \c OSI::TrafficLight, \c OSI::RoadMarking messages.
 //
 // All coordinates and orientations are relative to the global ground truth
 // coordinate system.
 //
 message BaseStationary
 {
-    // The 3D dimensions of the stationary object (bounding box), e.g. a landmark:
-    //
+    // The 3D dimensions of the stationary object (bounding box), e.g. a
+    // landmark.
     optional Dimension3d dimension = 1;
 
-    // The reference point for position and orientation, i.e. the center (x, y, z) of the bounding box.
-    //
+    // The reference point for position and orientation, i.e. the center (x,y,z)
+    // of the bounding box.
     optional Vector3d position = 2;
 
-    // The relative orientation of the stationary object w.r.t. its parent frame.
+    // The relative orientation of the stationary object w.r.t. its parent
+    // frame.
     //
     // Origin_base_stationary_entity := Rotation_yaw_pitch_roll(BaseStationary.orientation)*(Origin_parent_coordinate_system - BaseStationary.position)
-    // \note There may be some constraints how to align the orientation w.r.t. to some stationary object's or entity's definition.
+    //
+    // \note There may be some constraints how to align the orientation w.r.t. 
+    // to some stationary object's or entity's definition.
     optional Orientation3d orientation = 3;
     
     // Usage as ground truth:
-    // The two dimensional (flat) contour of the object. This is an extension of the concept of a 
-    // bounding box as defined by Dimension3d. The contour is the projection of the object's outline 
-    // onto the z-plane in the object frame (independent of its current position and orientation). 
+    // The two dimensional (flat) contour of the object. This is an extension of
+    // the concept of a bounding box as defined by Dimension3d. The contour is
+    // the projection of the object's outline onto the z-plane in the object
+    // frame (independent of its current position and orientation). 
     //
     // Usage as sensor data:
     // The polygon describes the visible part of the object's contour.
     //
     // General definitions:
-    // The polygon is defined in the local object frame: x pointing forward and y to the left.
+    // The polygon is defined in the local object frame: x pointing forward and
+    // y to the left.
     // The origin is the center of the bounding box.
-    // As ground truth, the polygon is closed by connecting the last with the first point. Therefore  
-    // these two points must be different. The polygon must consist of at least three points.
+    // As ground truth, the polygon is closed by connecting the last with the 
+    // first point. Therefore these two points must be different. The polygon  
+    // must consist of at least three points.
     // As sensor data, however, the polygon is open.
     // The polygon is defined counter-clockwise.
     repeated Vector2d base_polygon = 4;
@@ -248,49 +268,59 @@ message BaseMoving
     //
     optional Dimension3d dimension = 1;
 
-    // The reference point for position and orientation: the center (x, y, z) of the bounding box.
-    //
+    // The reference point for position and orientation: the center (x,y,z) of
+    // the bounding box.
     optional Vector3d position = 2;
 
     // The relative orientation of the moving object w.r.t. its parent frame.
     //
     // Origin_base_moving_entity := Rotation_yaw_pitch_roll(BaseMoving.orientation)*(Origin_parent_coordinate_system - BaseMoving.position)
-    // \note There may be some constraints how to align the orientation w.r.t. to some stationary object's or entity's definition.
+    //
+    // \note There may be some constraints how to align the orientation w.r.t.
+    // to some stationary object's or entity's definition.
     optional Orientation3d orientation = 3;
 
-    // The relative velocity of the moving object w.r.t. its parent frame and parent velocity.
+    // The relative velocity of the moving object w.r.t. its parent frame and
+    // parent velocity.
     // The velocity becomes global/absolute if the parent frame does not move.
     //
     // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt 
     optional Vector3d velocity = 4;
 
-    // The relative acceleration of the moving object w.r.t. its parent frame and parent acceleration.
-    // The acceleration becomes global/absolute if the parent frame is not accelerating.
+    // The relative acceleration of the moving object w.r.t. its parent frame
+    // and parent acceleration.
+    // The acceleration becomes global/absolute if the parent frame is not
+    // accelerating.
     //
     // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt+acceleration/2*dt^2
     // BaseMoving.velocity(t) := BaseMoving.velocity(t-dt)+acceleration*dt 
     optional Vector3d acceleration = 5;
 
-    // The relative orientation rate of the moving object w.r.t. its parent frame and parent orientation rate in the center point of the bounding box (origin of the bounding box frame).
+    // The relative orientation rate of the moving object w.r.t. its parent
+    // frame and parent orientation rate in the center point of the bounding box
+    // (origin of the bounding box frame).
     //
     // Rotation_yaw_pitch_roll(BaseMoving.orientation(t)) := Rotation_yaw_pitch_roll(BaseMoving.orientation_rate*dt)*Rotation_yaw_pitch_roll(BaseMoving.orientation(t-dt))
+    //
     // \note BaseMoving.orientation(t) is \b not equal BaseMoving.orientation(t-dt)+BaseMoving.orientation_rate*dt
     optional Orientation3d orientation_rate = 6;
     
     // Usage as ground truth:
-    // The two dimensional (flat) contour of the object. This is an extension of the concept of a 
-    // bounding box as defined by Dimension3d. The contour is the projection of the object's outline 
-    // onto the z-plane in the object frame (independent of its current position and orientation). 
+    // The two dimensional (flat) contour of the object. This is an extension of
+    // the concept of a  bounding box as defined by Dimension3d. The contour is
+    // the projection of the object's outline onto the z-plane in the object
+    // frame (independent of its current position and orientation). 
     //
     // Usage as sensor data:
     // The polygon describes the visible part of the object's contour.
     //
     // General definitions:
-    // The polygon is defined in the local object frame: x pointing forward and y to the left.
-    // The origin is the center of the bounding box.
-    // As ground truth, the polygon is closed by connecting the last with the first point. Therefore  
-    // these two points must be different. The polygon must consist of at least three points.
-    // As sensor data, however, the polygon is open.
+    // The polygon is defined in the local object frame: x pointing forward and
+    // y to the left. The origin is the center of the bounding box.
+    // As ground truth, the polygon is closed by connecting the last with the
+    // first point. Therefore these two points must be different. The polygon
+    // must consist of at least three points. As sensor data, however, the 
+    // polygon is open.
     // The polygon is defined counter-clockwise.
     repeated Vector2d base_polygon = 7;    
 }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -6,8 +6,9 @@ package osi;
 
 
 //
-// \brief A cartesian 3D vector for positions, velocities or accelerations or its uncertainties.
-// 
+// \brief A cartesian 3D vector for positions, velocities or accelerations or
+// its uncertainties.
+//
 // Units are [m] for positions, [m/s] for velocities and [m/s^2] for accelerations.
 //
 // The coordinate system is defined as right-handed. 
@@ -16,55 +17,64 @@ message Vector3d
 {
     // The x coordinate.
     //
+    // Unit [m] [m/s] or [m/s^2]
     optional double x = 1;
 
     // The y coordinate.
     //
+    // Unit [m] [m/s] or [m/s^2]
     optional double y = 2;
 
     // The z coordinate.
     //
+    // Unit [m] [m/s] or [m/s^2]
     optional double z = 3;
 }
 
 //
-// \brief A cartesian 2D vector for positions, velocities or accelerations or its uncertainties.
-// 
+// \brief A cartesian 2D vector for positions, velocities or accelerations or
+// its uncertainties.
+//
 // Units are [m] for positions, [m/s] for velocities and [m/s^2] for accelerations.
 //
 message Vector2d
 {
     // The x coordinate.
     //
+    // Unit [m] [m/s] or [m/s^2]
     optional double x = 1;
 
     // The y coordinate.
     //
+    // Unit [m] [m/s] or [m/s^2]
     optional double y = 2;
 }
 
 //
 // \brief A timestamp.
 // 
-// Names and types of fields are chosen in accordance to google/protobuf/timestamp.proto to allow a possible switch in the future. 
-// There is no definition of the zero point in time neither it is the Unix epoch. 
-// A simulation may start at the zero point in time but it is not mandatory.
-//
+// Names and types of fields are chosen in accordance to 
+// google/protobuf/timestamp.proto to allow a possible switch in the future. 
+// There is no definition of the zero point in time neither it is the Unix
+// epoch. A simulation may start at the zero point in time but it is not
+// mandatory.
 message Timestamp
 {
-    // The number of seconds since the start of e.g. the simulation / system / vehicle. 
+    // The number of seconds since the start of e.g. the simulation / system / 
+    // vehicle. 
+    //
     // Unit: [s]
     optional int64 seconds = 1;
 
     // The number of nanoseconds since the start of the last second. 
+    //
     // Unit: [ns]
     optional int32 nanos = 2;
 }
 
 //
-// \brief The dimension of a 3D box, e.g. the size of a 3D bounding box or its uncertainties.
-// 
-// Units are all [m].
+// \brief The dimension of a 3D box, e.g. the size of a 3D bounding box or its
+// uncertainties.
 //
 // The dimensions are positive. Uncertainties are negative or positive.
 //
@@ -75,14 +85,17 @@ message Dimension3d
 {
     // The length of the box.
     //
+    // Unit [m]
     optional double length = 1;
     
     // The width of the box.
     //
+    // Unit [m]
     optional double width = 2;
     
     // The height of the box.
     //
+    // Unit [m]
     optional double height = 3;
 }
 
@@ -90,10 +103,8 @@ message Dimension3d
 // \brief A 3D orientation, orientation rate or orientation acceleration (i.e. 
 // derivatives) or its uncertainties denoted in euler angles.
 // 
-// Units are 
-// \arg [rad] for orientation
-// \arg [rad/s] for rates
-// \arg [rad/s^2] for accelerations
+// Units are [rad] for orientation [rad/s] for rates and [rad/s^2] for 
+// accelerations
 // 
 // The preferred angular range is (-pi, pi]. The coordinate system is defined as 
 // right-handed. 
@@ -122,14 +133,17 @@ message Orientation3d
 {
     // The roll angle/rate/acceleration.
     //
+    // Unit: [rad] [rad/s] or [rad/s^2]
     optional double roll = 1;
     
     // The pitch angle/rate/acceleration.
     //
+    // Unit: [rad] [rad/s] or [rad/s^2]
     optional double pitch = 2;
     
     // The yaw angle/rate/acceleration.
     //
+    // Unit: [rad] [rad/s] or [rad/s^2]
     optional double yaw = 3;
 }
 
@@ -175,33 +189,30 @@ message MountingPosition
 //
 // Used e.g., for low level representations of radar detections.
 // 
-// Units are [m] for radial distance and [rad] for azimuth and elevation angles.
-// With the x-axis of the sensor frame pointing in the central viewing direction 
-// of the sensor, the z-axis pointing upwards and the senor frame being 
-// right-handed, azimuth and elevation are defined as the rotations that would 
-// have to be applied to the sensor frame to make its x-axis point towards the 
-// referenced point or to align it with the referenced vector. The rotations are 
-// to be performed \b azimuth \b first (around the z-axis) and \b elevation 
-// \b second (around the new y-axis) to follow the definition of 
-// OSI:Orientation3D. For the sense of each rotation, the right-hand rule 
-// applies. 
-// If azimuth and elevation are zero, the referenced point lies directly ahead
-// in the central viewing direction of the sensor, and the respective vector 
-// points directly in the latter.
+// Azimuth and elevation are defined as the rotations that would have to be 
+// applied to the local frame (e.g sensor frame definition in 
+// \c OSI:DetectionHeader) to make its x-axis point towards the referenced point
+// or to align it with the referenced vector. The rotations are to be performed
+// \b azimuth \b first (around the z-axis) and \b elevation \b second (around 
+// the new y-axis) to follow the definition of \c OSI:Orientation3D. For the
+// sense of each rotation, the right-hand rule applies.
 //
 // vector_cartesian := Rotation(elevation)*Rotation(azimuth)*Unit_vector_x*distance
 message Spherical3d
 {
     // The radial distance.
     //
+    // Unit: [m]
     optional double distance = 1;
 
     // The azimuth (horizontal) angle.
     //
+    // Unit: [rad]
     optional double azimuth = 2;
 
     // The elevation (vertical) angle.
     //
+    // Unit: [rad]
     optional double elevation = 3;
 }
 

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -93,16 +93,20 @@ message DetectedObject
     // The estimated probabilities for the object to belong to a specific class.
     //
     optional ClassProbability class_probability = 17;
-
-    // The estimated pedestrian head pose.
+    
+    // Pedestrian head pose for behaviour prediction. Describes the head
+    // orientation w.r.t. the host vehicle orientation.
+    // x-axis of head_pose is pedestrian's straight ahead viewing direction.
     //
-    // \note Pedestrian specific value.
-    optional Orientation3d pedestrian_head_pose = 18;
+    // View_normal_base_coord_system = Inverse_Rotation(head_pose)*Unit_vector_x 
+    optional Orientation3d head_pose = 18;
 
-    // The estimated pedestrian upper body pose.
+    // Pedestrian upper body pose for behaviour prediction. Describes the
+    // upper body orientation w.r.t. the host vehicle orientation.
+    // x-axis of upper_body_pose is pedestrian's upper body intended moving direction.
     //
-    // \note Pedestrian specific value.
-    optional Orientation3d pedestrian_upper_body_pose = 19;
+    // View_normal_base_coord_system = Inverse_Rotation(upper_body_pose)*Unit_vector_x 
+    optional Orientation3d upper_body_pose = 19;
 
     // Percentage side lane left.
     //

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -18,12 +18,13 @@ message DetectedObject
     //
     optional DetectedObjectHeader header = 1;
 
-    // Specific ID of the object as assigned by the sensor internally. Need not match with ground_truth_id.
-    //
+    // Specific ID of the object as assigned by the sensor internally. Need not
+    // match with ground_truth_id.
     optional Identifier tracking_id = 2;
 
-    // The ID of the original object in the ground truth list of vehicles / objects / etc.
-    // Multiple entries if detected object is a merge of multiple ground truth objects.
+    // The ID of the original object in the ground truth list of vehicles /
+    // objects etc. Multiple entries if detected object is a merge of multiple
+    // ground truth objects.
     repeated Identifier ground_truth_id = 3;
 
     // The amount of time that this object has been currently observed/tracked.
@@ -34,40 +35,44 @@ message DetectedObject
     //
     optional MeasurementState measurement_state = 5;
 
-    // Base parameters of the object. object.position is the middle of the bounding box of the target object.
-    //
+    // Base parameters of the object. object.position is the middle of the
+    // bounding box of the target object.
     optional BaseMoving object = 6;
 
-    // The root mean squared error of the base parameters in object (cross correlations are currently neglected).
-    //
+    // The root mean squared error of the base parameters in object (cross 
+    // correlations are currently neglected).
     optional BaseMoving object_rmse = 7;
 
-    // Reference point location specification of the sensor measurement (required to decouple sensor measurement,
-    // position and bounding box estimation) as used by the sensor (model).
+    // Reference point location specification of the sensor measurement
+    // (required to decouple sensor measurement, position and bounding box
+    // estimation) as used by the sensor (model).
     //
-    // \note Note that the value of this field has no impact on the value of object.position, which always references
-    // the center of the object / bounding box.
+    // \note Note that the value of this field has no impact on the value of 
+    // object.position, which always references the center of the object /
+    // bounding box.
     optional ReferencePoint reference_point = 8;
 
     // Actual movement state w.r.t. the moving object history.
     //
     optional MovementState movement_state = 9;
 
-    // The estimated probability that this object really exists, not based on history.
+    // The estimated probability that this object really exists, not based on
+    // history.
     //
-    // \note Use as confidence measure where a low value means less confidence and a high value indicates
-    // strong confidence.
+    // \note Use as confidence measure where a low value means less confidence
+    // and a high value indicates strong confidence.
     optional double existence_probability = 10;
 
-    // Current state of lights as perceived by sensor, only relevant if the object is estimated to be an object that
-    // has lights.
+    // Current state of lights as perceived by sensor, only relevant if the
+    // object is estimated to be an object that has lights.
     optional Vehicle.LightState light_state = 11;
 
-    // Additional internal data and state flags required and used by the sensor-models, should not be used by
-    // subscribers to SensorData. Generally this field should be cleared after internal processing.
+    // Additional internal data and state flags required and used by the
+    // sensor-models, should not be used by subscribers to SensorData. Generally 
+    // this field should be cleared after internal processing.
     //
-    // \note optional. List of used detections to recognize this object. Detections have also an identifier to
-    // reference to the detected object.
+    // \note optional. List of used detections to recognize this object. 
+    // Detections have also an identifier to reference to the detected object.
     optional ModelInternalObject model_internal_object = 12;
 
     // Additional data that is specific to radar sensors.
@@ -87,7 +92,8 @@ message DetectedObject
 
     // Additional data that is specific to ultrasonic sensors.
     //
-    // \note Field need not be set if simulated sensor is not an ultrasonic sensor.
+    // \note Field need not be set if simulated sensor is not an ultrasonic 
+    // sensor.
     optional UltrasonicSpecificObjectData ultrasonic_specifics = 16;
 
     // The estimated probabilities for the object to belong to a specific class.
@@ -96,16 +102,27 @@ message DetectedObject
     
     // Pedestrian head pose for behaviour prediction. Describes the head
     // orientation w.r.t. the host vehicle orientation.
-    // x-axis of head_pose is pedestrian's straight ahead viewing direction.
+    // The x-axis of the right-handed head frame is pointing along the 
+    // pedestrian's straight ahead viewing direction and the z-axis is pointing 
+    // upwards (cranial direction [1] i.e. to pedestrian's skull cap).
     //
     // View_normal_base_coord_system = Inverse_Rotation(head_pose)*Unit_vector_x 
+    //
+    // \par References: 
+    // [1] https://en.wikipedia.org/wiki/Anatomical_terms_of_location
     optional Orientation3d head_pose = 18;
 
     // Pedestrian upper body pose for behaviour prediction. Describes the
     // upper body orientation w.r.t. the host vehicle orientation.
-    // x-axis of upper_body_pose is pedestrian's upper body intended moving direction.
+    // The x-axis of the right-handed upper body frame is pointing along the 
+    // pedestrian's upper body ventral direction [2] (i.e. usually pedestrian's 
+    // intended moving direction) and the z-axis is pointing upwards (to 
+    // pedestrian's head).
     //
     // View_normal_base_coord_system = Inverse_Rotation(upper_body_pose)*Unit_vector_x 
+    //
+    // \par References: 
+    // [2] https://en.wikipedia.org/wiki/Anatomical_terms_of_location
     optional Orientation3d upper_body_pose = 19;
 
     // Percentage side lane left.
@@ -118,16 +135,20 @@ message DetectedObject
     // Percentage value of the object width in the corresponding lane.
     optional double percentage_side_lane_right = 21;
     
-    // Definition of available reference points. Left/middle/right and front/middle/rear indicate the position in y- and
-    // x direction respectively. The z position is always considered as middle.
+    // Definition of available reference points. Left/middle/right and 
+    // front/middle/rear indicate the position in y- and x-direction 
+    // respectively. The z position is always considered as middle.
     //
     enum ReferencePoint
     {
-        // Reference point is unknown, i.e. sensor does not report a reference point for the position coordinate.
+        // Reference point is unknown, i.e. sensor does not report a reference 
+        // point for the position coordinate.
         // Value must not be used in ground truth data.
-        // Usually this means that the reference point for the given position coordinates is a largely arbitrary point
-        // within the bounding volume unknown to the sensor. If this value is set, the center of the bounding box should
-        // be used as reference point by convention, unless the specific use case requires otherwise.
+        // Usually this means that the reference point for the given position 
+        // coordinates is a largely arbitrary point within the bounding volume 
+        // unknown to the sensor. If this value is set, the center of the 
+        // bounding box should be used as reference point by convention, unless 
+        // the specific use case requires otherwise.
         REFERENCE_POINT_UNKNOWN = 0;
         
         // Other (unspecified but known) reference point.
@@ -191,13 +212,14 @@ message DetectedObject
         //
         MOVEMENT_STATE_MOVING = 3;
 
-        // Object movement was detected in tracking history, but object is currently not moving.
-        //
+        // Object movement was detected in tracking history, but object is
+        // currently not moving.
         MOVEMENT_STATE_STOPPED = 4;
     }
 
     //
-    // \brief Probabilities for the classification of the object as perceived by the sensor.
+    // \brief Probabilities for the classification of the object as perceived by 
+    // the sensor.
     //
     message ClassProbability
     {
@@ -266,7 +288,8 @@ message DetectedObject
         //
         optional double prob_stationary = 16;
 
-        // Probability that the object is an unspecified but known vehicle. Range [0,1].
+        // Probability that the object is an unspecified but known vehicle. 
+        // Range [0,1].
         //
         optional double prob_other_vehicle = 17;
     }
@@ -293,11 +316,13 @@ message DetectedObjectHeader
     //
     optional uint32 cycle_counter = 3;
 
-    // Data Qualifier expresses to what extent the content of this event can be relied on.
-    //
+    // Data Qualifier expresses to what extent the content of this event can be
+    // relied on.
     optional DataQualifier data_qualifier = 4;
 
-    // \brief Data qualifier communicates the overall availability of the interface.
+    //
+    // \brief Data qualifier communicates the overall availability of the
+    // interface.
     //
     enum DataQualifier
     {
@@ -331,7 +356,8 @@ message DetectedObjectHeader
     }
 
     //
-    // \brief Version of detected object messages (DetectionObject etc.).
+    // \brief Version of detected object messages ( \c OSI::DetectedObject
+    // etc.).
     //
     message InterfaceVersion
     {
@@ -357,15 +383,15 @@ enum MeasurementState
     //
     MEASUREMENT_STATE_UNKNOWN = 0;
 
-    // Measurement state is unspecified (but known, i.e. value is not part of this enum list).
-    //
+    // Measurement state is unspecified (but known, i.e. value is not part of
+    // this enum list).
     MEASUREMENT_STATE_OTHER = 1;
 
     // Entity has been measured by the sensor in the current timestep.
     //
     MEASUREMENT_STATE_MEASURED = 2;
 
-    // Entity has not been measured by the sensor in the current timestep. Values provided by tracking only.
-    //
+    // Entity has not been measured by the sensor in the current timestep.
+    // Values provided by tracking only.
     MEASUREMENT_STATE_PREDICTED = 3;
 }

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -54,17 +54,18 @@ message DetectionHeader
     //
     // The origin of the detection coordinate system (= spherical polar
     // coordinates) is the sensor mounting pose in the host vehicle coordinate
-    // system.
+    // system w.r.t. orientation of the sensor mounting position.
     //
     // The host vehicle coordinate system is at the center of the rear axle
     // (from the top view as well as from the side view) in the static case.
     // The origin represents the current mounting pose to the best knowledge of
-    // the sensor. It includes the estimated 6D pose estimation given by  the
+    // the sensor. It includes the estimated 6D pose estimation given by the
     // calibration. The uncertainty of this estimation is given with the
     // corresponding 6D root mean squared error. The estimation of the current
     // origin does not include effects due to short-time dynamics, such as pitch
     // angles from braking, but includes long-time calibration values, such as
     // pitch angles from luggage in the trunk.
+    // 
     optional MountingPosition mounting_position = 4;
 
     // Uncertainty of the mounting pose calibration should be included in the

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -45,35 +45,40 @@ message DetectionHeader
     // for detailed discussions on the semantics of time-related fields.
     optional Timestamp measurement_time = 2;
 
-    // Monotonous counter to identify the exact cycle.
-    //
-    optional uint32 cycle_counter = 3;
+    // Monotonous counter to identify the exact cycle. 
+    // Generally the detecion function is called periodic and 
+    // \c DetectionHeader::cycle_counter corresponds to the number of periods.
+    optional uint64 cycle_counter = 3;
 
-    // Mounting position of the sensor (origin and orientation of the cartesian
-    // sensor coordinate system); given relative from the middle of the rear
-    // axle of the host vehicle coordinate system (see: \c OSI::Vehicle vehicle
-    // reference point) to the sensor detection coordinate system's origin. The
-    // sensor detection coordinate system is a spherical polar coordinate system
-    // (same origin and orientation as cartesian sensor coordinate system).
+
+    // Mounting position of the sensor (origin and orientation of the sensor 
+    // frame). Both origin and orientation are given in and with respect to the 
+    // host vehicle coordinate system (see: \c OSI::Vehicle vehicle reference
+    // point).
     //
-    // The sensor detection coordinate system's x-axis must be the angle
-    // bisector of the sensor's horizontal and vertical field of view in a
-    // right-handed coordinate system. The xy-plane represents the horizontal
-    // field of view and the xz-plane the vertical field of view.
+    // The sensor frame's x-axis is pointing in the central viewing direction of 
+    // the sensor. It is the angle bisector of the sensor's horizontal and 
+    // vertical field of view. The terms horizontal and vertical must be 
+    // understood as names for the two principal planes of the sensor's field of 
+    // view (relative to the sensor frame's orientation), which do not have to
+    // be horizontal or vertical in the strict sense of being parallel or 
+    // perpendicular to the local gravitational vector. The horizontal field
+    // of view defines the sensor frame's xy-plane and the vertical field
+    // of view defines the xz-plane. The sensor frame is right-handed and the 
+    // z-axis is pointing in an upward direction.
     //
-    // The origin represents the current mounting pose to the best knowledge of
-    // the sensor. The estimation of the 6D pose given by the calibration. The
-    // uncertainty of this estimation is given with the corresponding 6D root
-    // mean squared error. The estimation of the current origin does not include
-    // effects due to short-time dynamics, such as pitch angles from braking,
-    // but includes long-time calibration values, such as pitch angles from
-    // luggage in the trunk. 
-    //
+    // The sensor frame uses cartesian coordinates. The sensor frame's origin is
+    // identical to sensor detection frame's origin. Detections are defined in 
+    // the sensor detection frame which uses e.g. spherical coordinates.
     optional MountingPosition mounting_position = 4;
 
-    // Uncertainty of the mounting pose calibration should be included in the
-    // interface (x, y, z, yaw, pitch, roll).
-    //
+    // The origin/orientation of the sensor frame represents the current
+    // mounting pose to the best knowledge of the sensor. The estimation of the
+    // 6D pose given by the calibration. The uncertainty of this estimation is
+    // given with the corresponding 6D root mean squared error. The estimation
+    // of the current origin does not include effects due to short-time
+    // dynamics, such as pitch angles from braking, but includes long-time
+    // calibration values, such as pitch angles from luggage in the trunk. 
     optional MountingPosition mounting_position_rmse = 5;
 
     // Data Qualifier expresses to what extent the content of this event can be 
@@ -172,7 +177,7 @@ enum DetectionClassification
 
 
 //
-// \brief A list of lidar detection.
+// \brief A list of lidar detection from one sensor.
 //
 message LidarDetectionList
 {
@@ -235,7 +240,7 @@ message LidarDetection
 }
 
 //
-// \brief A list of radar detections.
+// \brief A list of radar detections from one sensor.
 //
 message RadarDetectionList
 {    

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -7,10 +7,14 @@ import "osi_common.proto";
 package osi;
 
 //
-// \brief Interface for sensor data, in contrast to interpreted data after object hypothesis and tracking.
+// \brief Interface for sensor data, in contrast to interpreted data after 
+// object hypothesis and tracking.
 //
-// All information regarding the environment is given with respect to the sensor coordinate system specified in \c DetectionHeader::mounting_position. 
-// When simulating multiple sensors, each sensor has an individual copy of FeatureData in its own reference frame. This allows an independent treatment of the sensors.
+// All information regarding the environment is given with respect to the sensor 
+// coordinate system specified in \c DetectionHeader::mounting_position. 
+// When simulating multiple sensors, each sensor has an individual copy of 
+// \c OSI::FeatureData in its own reference frame. This allows an independent 
+// treatment of the sensors.
 //
 message FeatureData
 {
@@ -28,7 +32,8 @@ message FeatureData
 //
 message DetectionHeader
 {
-    // Version number of used detecion list messages (DetectionHeader, LidarDetection, LidarDetectionList etc.).
+    // Version number of used detecion list messages ( \c OSI::DetectionHeader, 
+    // \c OSI::LidarDetection, \c OSI::LidarDetectionList etc.).
     // 
     optional DetectionInterfaceVersion version = 1;
 
@@ -44,28 +49,26 @@ message DetectionHeader
     //
     optional uint32 cycle_counter = 3;
 
-    // Mounting position of the sensor (origin and orientation of the sensor
-    // coordinate system); given relative to the middle of the rear axle of the
-    // host vehicle.
+    // Mounting position of the sensor (origin and orientation of the cartesian
+    // sensor coordinate system); given relative from the middle of the rear
+    // axle of the host vehicle coordinate system (see: \c OSI::Vehicle vehicle
+    // reference point) to the sensor detection coordinate system's origin. The
+    // sensor detection coordinate system is a spherical polar coordinate system
+    // (same origin and orientation as cartesian sensor coordinate system).
     //
-    // The x-axis must be the angle bisector of the horizontal field of view in
-    // a right-handed coordinate system. The xy-plane represents the
-    // horizontal field of view and the xz-plane the vertical field of view.
+    // The sensor detection coordinate system's x-axis must be the angle
+    // bisector of the sensor's horizontal and vertical field of view in a
+    // right-handed coordinate system. The xy-plane represents the horizontal
+    // field of view and the xz-plane the vertical field of view.
     //
-    // The origin of the detection coordinate system (= spherical polar
-    // coordinates) is the sensor mounting pose in the host vehicle coordinate
-    // system w.r.t. orientation of the sensor mounting position.
-    //
-    // The host vehicle coordinate system is at the center of the rear axle
-    // (from the top view as well as from the side view) in the static case.
     // The origin represents the current mounting pose to the best knowledge of
-    // the sensor. It includes the estimated 6D pose estimation given by the
-    // calibration. The uncertainty of this estimation is given with the
-    // corresponding 6D root mean squared error. The estimation of the current
-    // origin does not include effects due to short-time dynamics, such as pitch
-    // angles from braking, but includes long-time calibration values, such as
-    // pitch angles from luggage in the trunk.
-    // 
+    // the sensor. The estimation of the 6D pose given by the calibration. The
+    // uncertainty of this estimation is given with the corresponding 6D root
+    // mean squared error. The estimation of the current origin does not include
+    // effects due to short-time dynamics, such as pitch angles from braking,
+    // but includes long-time calibration values, such as pitch angles from
+    // luggage in the trunk. 
+    //
     optional MountingPosition mounting_position = 4;
 
     // Uncertainty of the mounting pose calibration should be included in the
@@ -73,7 +76,8 @@ message DetectionHeader
     //
     optional MountingPosition mounting_position_rmse = 5;
 
-    // Data Qualifier expresses to what extent the content of this event can be relied on.
+    // Data Qualifier expresses to what extent the content of this event can be 
+    // relied on.
     //
     optional DataQualifier data_qualifier = 6;
 
@@ -82,7 +86,8 @@ message DetectionHeader
     // \note This value has to be set if the list contains invalid detections.    
     optional uint32 number_of_detections = 7;
 
-    // \brief Data qualifier communicates the overall availability of the interface.
+    // \brief Data qualifier communicates the overall availability of the 
+    // interface.
     //
     enum DataQualifier
     {
@@ -116,7 +121,8 @@ message DetectionHeader
     }
 
     //
-    // \brief Version of detection messages (DetectionHeader, LidarDetection, LidarDetectionList, etc.).
+    // \brief Version of detection messages ( \c OSI::DetectionHeader, 
+    // \c OSI::LidarDetection, \c OSI::LidarDetectionList, etc.).
     //
     message DetectionInterfaceVersion
     {
@@ -146,7 +152,8 @@ enum DetectionClassification
     //
     DETECTION_CLASSIFICATION_OTHER = 1;
 
-    // Invalid detection, not to be used for object tracking, of unspecified type (none of the other types applies).
+    // Invalid detection, not to be used for object tracking, of unspecified 
+    // type (none of the other types applies).
     //
     DETECTION_CLASSIFICATION_INVALID = 2;
 
@@ -183,17 +190,20 @@ message LidarDetectionList
 //
 message LidarDetection
 {
-    // Existence probability of the detection not based on history. Value does not depend on any past experience with similar detections.
+    // Existence probability of the detection not based on history. Value does 
+    // not depend on any past experience with similar detections.
     //
-    // \note Used as confidence measure where a low value means less confidence and a high value indicates 
-    // strong confidence.
+    // \note Used as confidence measure where a low value means less confidence 
+    // and a high value indicates strong confidence.
     optional double existence_probability = 1;
 
-    // ID of the object this detection is associated to; ID = MAX(uint64) indicates no reference to an object.
+    // ID of the object this detection is associated to; ID = MAX(uint64) 
+    // indicates no reference to an object.
     //
     optional Identifier object_id = 2;
 
-    // Measured position of the detection, given in spherical coordinates in the sensor coordinate system.
+    // Measured position of the detection, given in spherical coordinates in the 
+    // sensor coordinate system.
     //
     optional Spherical3d position = 3;
 
@@ -201,8 +211,8 @@ message LidarDetection
     //
     optional Spherical3d position_rmse = 4;
 
-    // Height value, which is required when multiple scan points are vertically clustered.
-    // Only vertical clustering is allowed (z-axis).
+    // Height value, which is required when multiple scan points are vertically 
+    // clustered. Only vertical clustering is allowed (z-axis).
     optional double height = 5;
 
     // Root mean squared error of the object height.
@@ -213,7 +223,8 @@ message LidarDetection
     // Unit: [%]
     optional double intensity = 7;
 
-    // The free space probability in the range [0.0, 1.0] from the origin of the sensor up to this detection, as given by the distance.
+    // The free space probability in the range [0.0, 1.0] from the origin of the 
+    // sensor up to this detection, as given by the distance.
     // 
     optional double free_space_probability = 8;
 
@@ -242,17 +253,21 @@ message RadarDetectionList
 //
 message RadarDetection
 {
-    // Existence probability of the detection not based on history. Value does not depend on any past experience with similar detections.
+    // Existence probability of the detection not based on history. Value does 
+    // not depend on any past experience with similar detections.
     //
-    // \note Use as confidence measure where a low value means less confidence and a high value indicates 
+    // \note Use as confidence measure where a low value means less confidence 
+    // and a high value indicates 
     // strong confidence.
     optional double existence_probability = 1;
 
-    // ID of the object this detection is associated to; ID = MAX(uint64) indicates no reference to an object.
+    // ID of the object this detection is associated to; ID = MAX(uint64) 
+    // indicates no reference to an object.
     // 
     optional Identifier object_id = 2;
 
-    // Measured position of the detection, given in spherical coordinates in the sensor coordinate system.
+    // Measured position of the detection, given in spherical coordinates in the
+    // sensor coordinate system.
     //
     optional Spherical3d position = 3;
 
@@ -276,12 +291,14 @@ message RadarDetection
     // Unit: [dB m^2].
     optional double snr = 8;
 
-    // Describes the possibility whether more than one object may have led to this detection.
+    // Describes the possibility whether more than one object may have led to 
+    // this detection.
     // 
     optional double point_target_probability = 9;
 
     // Ambiguity Information: 
-    // Each ambiguous measurement generates one Ambiguity ID. Ambiguity is indicated by an identical Ambiguity ID. 
+    // Each ambiguous measurement generates one Ambiguity ID. Ambiguity is 
+    // indicated by an identical Ambiguity ID. 
     // Unambiguous measurements have the Amiguity ID 0.
     optional Identifier ambiguity_id = 10;
 

--- a/osi_landmark.proto
+++ b/osi_landmark.proto
@@ -9,6 +9,9 @@ package osi;
 //
 // \brief A traffic sign.
 //
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
 message TrafficSign
 {
     // The ID of the traffic sign.
@@ -935,6 +938,9 @@ message TrafficLight
 // 
 // Lane Markings are excluded and defined as LaneBoundaries as part of the Lanes.
 //
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
 message RoadMarking
 {
     // The ID of the road marking.
@@ -987,11 +993,6 @@ message RoadMarking
     // The id(s) of the lane(s) that the road marking is assigned to.
     // Might be multiple if the road marking goes across multiple lanes.
     repeated Identifier assigned_lane = 9;
-
-    // Intersection orientation of the road marking.
-    //
-    // \note Defined for \c Lane::type = TYPE_INTERSECTION, otherwise zero vector
-    optional Vector3d roadmarking_orientation = 10;
 
     // Definition of road marking types.
     //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -15,10 +15,10 @@ package osi;
 // for the host vehicle (R rotates from vehicle to world frame, i.e. inverse
 // orientation of base.orientation).
 // 
-// For all vehicles, including host vehicles, the position given  in
+// For all vehicles, including host vehicles, the position given in
 // base.position points to the center of the vehicle's bounding box.
 //
-// The object coordinates are defined as x-axis is the direction from rear to
+// The vehicle object coordinates are defined as x-axis is the direction from rear to
 // front of the vehicle, y-axis corresponds to rear axle and z-axis points to
 // vehicle ceiling.
 //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -18,9 +18,13 @@ package osi;
 // For all vehicles, including host vehicles, the position given in
 // base.position points to the center of the vehicle's bounding box.
 //
-// The vehicle object coordinates are defined as x-axis is the direction from rear to
-// front of the vehicle, y-axis corresponds to rear axle and z-axis points to
-// vehicle ceiling.
+// The vehicle object coordinates are defined as x-axis is the direction from 
+// rear to front of the vehicle, y-axis corresponds to rear axle and z-axis 
+// points to vehicle ceiling [1]. The coordinate system is right-handed.
+// Therefore the positive y-axis points to the left of the vehicle. 
+//
+// \par References: 
+// [1] DIN ISO 8855:2013-11
 //
 message Vehicle
 {
@@ -44,12 +48,15 @@ message Vehicle
     // host vehicle(s), false for other vehicles.  See the description above!
     optional bool host_vehicle = 5;
 
-    // The vector pointing from the bounding box center point (base.position) to the middle (in x, y and z) 
-    // of the rear axle under neutral load conditions. In object coordinates.
+    // The vector pointing from the bounding box center point (base.position) to
+    // the middle (in x, y and z) of the rear axle under neutral load 
+    // conditions. In object coordinates.
     optional Vector3d bbcenter_to_rear = 6;
 
     // The IDs of the lanes that this vehicle is assigned to.
-    // \note Might be multiple if the vehicle is switching lanes or moving from one lane into another following lane.
+    //
+    // \note Might be multiple if the vehicle is switching lanes or moving from 
+    // one lane into another following lane.
     repeated Identifier assigned_lane = 7;
 
     // Flag defining whether the vehicle has an attached trailer.
@@ -57,15 +64,20 @@ message Vehicle
     optional bool has_trailer = 8;
 
     // Id of the attached trailer.
-    // \note Field need not be set if has_Trailer is set to false or use value for non valid id.
+    //
+    // \note Field need not be set if has_Trailer is set to false or use value
+    // for non valid id.
     optional Identifier trailer_id = 9;
 
     // The ID of the driver of the (host) vehicle.
-    // \note Field need not be set if host_vehicle is set to false or use value for non valid id.
+    //
+    // \note Field need not be set if host_vehicle is set to false or use value
+    // for non valid id.
     optional Identifier driver = 10;
     
-    // The vector pointing from the bounding box center point (base.position) to the middle (in x, y and z)
-    // of the front axle under neutral load conditions. In object coordinates.
+    // The vector pointing from the bounding box center point (base.position) to
+    // the middle (in x, y and z) of the front axle under neutral load 
+    // conditions. In object coordinates.
     optional Vector3d bbcenter_to_front = 11;
     
     // Static minimal distance in [m] of underbody plane to ground
@@ -215,15 +227,16 @@ message Vehicle
             //
             BRAKE_LIGHT_STATE_NORMAL = 3;
             
-            // Brake lights are on with extra bright intensity (indicating stronger braking).
-            //
+            // Brake lights are on with extra bright intensity (indicating
+            // stronger braking).
             BRAKE_LIGHT_STATE_STRONG = 4;
         }
     }
 }
 
 //
-// \brief A simulated object that is neither a moving object (vehicle) nor a stationary object (traffic sign, traffic light, StationaryObject).
+// \brief A simulated object that is neither a moving object (vehicle) nor a
+// stationary object (traffic sign, traffic light, StationaryObject).
 //
 // MovingObject excludes vehicles
 //
@@ -263,7 +276,9 @@ message MovingObject
 }
 
 //
-// \brief A simulated object that is neither a moving object (vehicle or MovingObject e.g. pedestrian or animal) nor a stationary object (traffic sign, traffic light).
+// \brief A simulated object that is neither a moving object (vehicle or 
+// \c OSI::MovingObject e.g. pedestrian or animal) nor a stationary object 
+// (traffic sign, traffic light).
 //
 // StationaryObject excludes traffic lights and traffic signs
 //

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -76,16 +76,21 @@ message SensorData
     optional Identifier host_vehicle_id = 5;
     
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
+    // given in vehicle coordinates [1].
     //
-    // given in vehicle coordinates: origin is ( \c Vehicle::base.position + INV(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) the orientation is equal to the orientation of the vehicle \c Vehicle::base.orientation.
+    // \arg \b x-direction of sensor coordinate system: sensor viewing direction
+    // \arg \b z-direction of sensor coordinate system: sensor (up)
+    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z right hand system
     //
-    // \arg \b x-direction: longitudinal direction & positive in driving direction
-    // \arg \b y-direction: lateral direction & positive to the left when looking orientated as a driver
-    // \arg \b z-direction: perpendicular to x and z right hand system (up)
-    //
-    // See https://en.wikipedia.org/wiki/Axes_conventions#/media/File:RPY_angles_of_cars.png 
+    // \par References: 
+    // [1] DIN ISO 8855:2013-11
     //
     // \note This field is usually static during the simulation.
+    // \note The origin of vehicle's coordinate system in world frame is 
+    // ( \c Vehicle::base.position + Inverse_Rotation_yaw_pitch_roll(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) .
+    // The orientation of the vehicle's coordinate system is equal to the orientation 
+    // of the vehicle's bounding box \c Vehicle::base.orientation.
+    //
     optional MountingPosition mounting_position = 6;
 
     // The root mean squared error of the mounting position.

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -64,23 +64,31 @@ package osi;
 message SensorInputConfiguration
 {
     // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
+    // given in vehicle coordinates [1].
     //
-    // given in vehicle coordinates: origin is \c Vehicle::reference_point; the orientation is equal to the orientation of the vehicle.
+    // \arg \b x-direction of sensor coordinate system: sensor viewing direction
+    // \arg \b z-direction of sensor coordinate system: sensor (up)
+    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z right hand system
     //
-    // \arg \b x-direction: longitudinal direction & positive in driving direction
-    // \arg \b y-direction: lateral direction & positive to the left when looking orientated as a driver
-    // \arg \b z-direction: perpendicular to x and z right hand system (up)
+    // \par References: 
+    // [1] DIN ISO 8855:2013-11
     //
-    // See https://en.wikipedia.org/wiki/Axes_conventions#/media/File:RPY_angles_of_cars.png
+    // \note The origin of vehicle's coordinate system in world frame is 
+    // ( \c Vehicle::base.position + Inverse_Rotation_yaw_pitch_roll(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) .
+    // The orientation of the vehicle's coordinate system is equal to the orientation 
+    // of the vehicle's bounding box \c Vehicle::base.orientation.
     // \note A default position can be provided by the sensor model (e.g. to indicate the position the model was validated for),
     // but this is optional; the environment simulation must provide a valid mounting position (based on the vehicle configuration)
     // when setting the input configuration.
+    //
     optional MountingPosition mounting_position = 1;
 
     // Field of View in horizontal orientation of the sensor
     //
     // This determines the limit of the cone of interest of ground truth
     // that the simulation environment has to provide.
+    // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal]
+    // in sensor coordinate system.
     //
     // Unit: [rad]
     optional double field_of_view_horizontal = 2;
@@ -89,6 +97,8 @@ message SensorInputConfiguration
     //
     // This determines the limit of the cone of interest of ground truth
     // that the simulation environment has to provide.
+    // Viewing range: [-field_of_view_vertical/2, field_of_view_vertical]
+    // in sensor coordinate system.
     //
     // Unit: [rad]
     optional double field_of_view_vertical = 3;
@@ -199,6 +209,7 @@ message RadarSensorInputConfiguration
     //
     // \brief The radar antenna diagram.
     //
+    // \note Rotation is defined analog OSI:Spherical3d
     message AntennaDiagramEntry {
         // Horizontal deflection (azimuth) of entry in sensor/antenna
         // coordinates

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -63,23 +63,27 @@ package osi;
 //
 message SensorInputConfiguration
 {
-    // The mounting position of the sensor (origin and orientation of the sensor coordinate system)
-    // given in vehicle coordinates [1].
+    // The mounting position of the sensor (origin and orientation of the sensor
+    // coordinate system) given in vehicle coordinates [1].
     //
     // \arg \b x-direction of sensor coordinate system: sensor viewing direction
     // \arg \b z-direction of sensor coordinate system: sensor (up)
-    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z right hand system
+    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z
+    // right hand system
     //
     // \par References: 
     // [1] DIN ISO 8855:2013-11
     //
     // \note The origin of vehicle's coordinate system in world frame is 
-    // ( \c Vehicle::base.position + Inverse_Rotation_yaw_pitch_roll(\c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear) .
-    // The orientation of the vehicle's coordinate system is equal to the orientation 
-    // of the vehicle's bounding box \c Vehicle::base.orientation.
-    // \note A default position can be provided by the sensor model (e.g. to indicate the position the model was validated for),
-    // but this is optional; the environment simulation must provide a valid mounting position (based on the vehicle configuration)
-    // when setting the input configuration.
+    // ( \c Vehicle::base.position + Inverse_Rotation_yaw_pitch_roll( 
+    // \c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear ).
+    // The orientation of the vehicle's coordinate system is equal to the
+    // orientation of the vehicle's bounding box \c Vehicle::base.orientation.
+    // \note A default position can be provided by the sensor model (e.g. to 
+    // indicate the position the model was validated for),
+    // but this is optional; the environment simulation must provide a valid
+    // mounting position (based on the vehicle configuration) when setting the
+    // input configuration.
     //
     optional MountingPosition mounting_position = 1;
 
@@ -87,9 +91,8 @@ message SensorInputConfiguration
     //
     // This determines the limit of the cone of interest of ground truth
     // that the simulation environment has to provide.
-    // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal]
-    // in sensor coordinate system.
-    //
+    // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
+    // azimuth in the sensor frame as defined in \c OSI:Spherical3d.
     // Unit: [rad]
     optional double field_of_view_horizontal = 2;
 
@@ -97,8 +100,9 @@ message SensorInputConfiguration
     //
     // This determines the limit of the cone of interest of ground truth
     // that the simulation environment has to provide.
-    // Viewing range: [-field_of_view_vertical/2, field_of_view_vertical]
-    // in sensor coordinate system.
+    // Viewing range: [-field_of_view_vertical/2, field_of_view_vertical/2]
+    // elevation in the sensor frame at zero azimuth as defined in 
+    // \c OSI:Spherical3d.
     //
     // Unit: [rad]
     optional double field_of_view_vertical = 3;
@@ -364,8 +368,8 @@ message CameraSensorInputConfiguration
 }
 
 //
-// \brief The configuration settings for the Ultrasonic Sensor Input to be provided
-// by the environment simulation.
+// \brief The configuration settings for the Ultrasonic Sensor Input to be
+// provided by the environment simulation.
 //
 message UltrasonicSensorInputConfiguration
 {

--- a/osi_sensorspecific.proto
+++ b/osi_sensorspecific.proto
@@ -29,15 +29,7 @@ message LidarSpecificObjectData
 //
 message CameraSpecificObjectData
 {
-    // Pedestrian head pose for behaviour prediction. Describes the head
-    // orientation w.r.t. the host vehicle orientation.
-    //
-    optional Orientation3d head_pose = 1;
-
-    // Pedestrian upper body pose for behaviour prediction. Describes the
-    // upper body orientation w.r.t. the host vehicle orientation.
-    //
-    optional Orientation3d upper_body_pose = 2;
+    // currently no fields.
 }
 
 //


### PR DESCRIPTION
This PR addresses issue #51 

Change OSI transformation between axis systems to ISO definition.
World frame -> vehicle frame -> sensor frame ...

Orientation is defined (world -> vehicle) rotate yaw -> rotate pitch -> rotate roll.

Note this is the international standard and differs from national american standard.
(OSI V2.xxx used national american standard)


**Additional Bugfixes:**
remove road marking orientation

remove camera sensor specific values. Redundant!