### PR TITLE
Replacing semantic Traffic Lights with Traffic Light Bulbs (issue #70)

### DIFF
--- a/osi_detectedlandmark.proto
+++ b/osi_detectedlandmark.proto
@@ -192,17 +192,21 @@ message DetectedTrafficLight
     //
     optional Identifier ground_truth_id = 3;
 
-    // Description of the detected traffic light.
+    // A list of candidates for this traffic light as estimated by the sensor.
     //
-    optional TrafficLight traffic_light = 4;
+    repeated CandidateTrafficLight candidate_traffic_light = 4;
+    
+    // The root mean squared error of the base parameters of the detected
+    // traffic light.
+    optional BaseStationary rmse = 5;
 
     // Determines for which directions the traffic light applies.
     //
-    repeated RelevantDirection relevant_direction = 5;
+    repeated RelevantDirection relevant_direction = 6;
 
     // Links to the corresponding lanes.
     //
-    repeated RelevantLane relevant_lane = 6;
+    repeated RelevantLane relevant_lane = 7;
 
     // The estimated probability that this traffic light really exists, not
     // based on history.
@@ -210,17 +214,12 @@ message DetectedTrafficLight
     // \note Use as confidence measure where a low value means less confidence
     // and a high value indicates strong confidence.
     //
-    optional double existence_probability = 7;
+    optional double existence_probability = 8;
 
     // The measurement state.
     //
-    optional MeasurementState measurement_state = 8;
+    optional MeasurementState measurement_state = 9;
     
-    // The root mean squared error of the base parameters of the detected
-    // traffic light.
-    //
-    optional BaseStationary rmse = 9;
-   
     // A list of sensors which detected this detected entity.
     //
     // If SensorData has detected entities and all detections are missing, then 
@@ -270,6 +269,21 @@ message DetectedTrafficLight
             DIRECTION_RIGHT = 4;
         }
     }
+}
+
+//
+// \brief A candidate for (a) detected traffic light(s) as estimated by the
+// sensor.
+message CandidateTrafficLight
+{
+    // The definition of one traffic light that define this candidate.
+    //
+    optional TrafficLight traffic_light = 1;
+
+    // The estimated probability that this candidate is the true value. 
+    // Range [0,1].
+    // The sum of all candidate_probabilities must be one.
+    optional double candidate_probability = 2;
 }
 
 //

--- a/osi_detectedlandmark.proto
+++ b/osi_detectedlandmark.proto
@@ -197,7 +197,8 @@ message DetectedTrafficLight
     repeated CandidateTrafficLight candidate_traffic_light = 4;
     
     // The root mean squared error of the base parameters of the detected
-    // traffic light.
+    // traffic light's geometry. TrafficLight::base have to be identical for all
+    // \c DetectedTrafficLight::candidate_traffic_light traffic lights.
     optional BaseStationary rmse = 5;
 
     // Determines for which directions the traffic light applies.

--- a/osi_detectedlandmark.proto
+++ b/osi_detectedlandmark.proto
@@ -48,7 +48,7 @@ message DetectedTrafficSign
     // The measurement state.
     //
     optional MeasurementState measurement_state = 8;
-    
+
     // The root mean squared error of the base parameters of the detected
     // traffic sign.
     //
@@ -137,8 +137,8 @@ message DetectedTrafficSign
 message CandidateSign
 {
     // The definition of the candidate's properties.
-    // The sign.id values of all \c CandidateSign within one
-    // \c DetectedTrafficSign correspond to the tracking ID and must be identical.
+    // The sign.id values of all CandidateSigns within one DetectedTrafficSign
+    // correspond to the tracking ID and must be identical.
     //
     optional TrafficSign sign = 1;
 
@@ -199,6 +199,7 @@ message DetectedTrafficLight
     // The root mean squared error of the base parameters of the detected
     // traffic light's geometry. TrafficLight::base have to be identical for all
     // \c DetectedTrafficLight::candidate_traffic_light traffic lights.
+    //
     optional BaseStationary rmse = 5;
 
     // Determines for which directions the traffic light applies.
@@ -284,6 +285,7 @@ message CandidateTrafficLight
     // The estimated probability that this candidate is the true value. 
     // Range [0,1].
     // The sum of all candidate_probabilities must be one.
+    //
     optional double candidate_probability = 2;
 }
 

--- a/osi_landmark.proto
+++ b/osi_landmark.proto
@@ -480,6 +480,10 @@ message TrafficSign
         // Lane for buses (StVO 245). 
         // See e.g.: https://www.dvr.de/bilder/stvo/gt/245.png
         TYPE_BUS_LANE = 91;
+
+        // Green arrow sign at a traffic light (StVO 720).
+        //
+        TYPE_TRAFFIC_LIGHT_GREEN_ARROW = 92;
     }
 
     // Definition of the variability of the traffic sign.
@@ -812,133 +816,81 @@ message TrafficLight
     //
     optional BaseStationary base = 2;
 
-    // The type of the traffic light.
+    // Specifies the alignment of the individual light bulbs / sub-displays
+    // of this traffic light and determines the order in which they are given
+    // in the \c bulbs field. See \c TrafficLight::Arrangement for details.
     //
-    optional Type type = 3;
-
-    // The shape of the traffic light.
+    optional Arrangement arrangement = 3;
+    
+    // The individual light bulbs / sub-displays of the traffic light.
+    // See \c TrafficLight::Arrangement for details on the order of the entries
+    // of this field. For example, this field starts at the left of the traffic
+    // light if a horizontal arrangement (\c arrangement =
+    // \c ARRANGEMENT_LEFT_TO_RIGHT) is given.
     //
-    optional Shape shape = 4;
-
-    // The state of the traffic light.
-    //
-    optional LightState light_state = 5;
-
-    // Presence of a green arrow sign indicating permitted right turns at the
-    // red traffic light.
-    //
-    optional GreenArrowPresence green_arrow = 6;
-
+    repeated TrafficLightBulb bulbs = 4;
+    
     // The IDs of the lanes that the traffic light is assigned to.
     // Might be multiple if the traffic light is valid for multiple driving
     // lanes.
-    repeated Identifier assigned_lanes = 7;
-
-    // Definition of traffic light types.
     //
-    enum Type
+    repeated Identifier assigned_lanes = 5;
+    
+    //
+    // \brief Geometrical arrangement of the individual light bulbs of a traffic
+    // light.
+    //
+    enum Arrangement
     {
-        // Unknown type of traffic light (must not be used in ground truth).
+        // Arrangement is unknown (must not be used in ground truth).
         //
-        TYPE_UNKNOWN = 0;
+        ARRANGEMENT_UNKNOWN = 0;
         
-        // Other (unspecified but known) type of traffic light.
+        // Other (unspecified but known) arrangement.
         //
-        TYPE_OTHER = 1;
+        ARRANGEMENT_OTHER = 1;
         
-        // Normal traffic light for motor vehicle traffic.
+        // The light bulbs / sub-displays are arranged top to bottom, i.e. the
+        // entries in the \c TrafficLight::bulbs field start at the top of the
+        // physical traffic light.
         //
-        TYPE_NORMAL = 2;
+        ARRANGEMENT_TOP_TO_BOTTOM = 2;
         
-        // Light for pedestrian traffic.
+        // The light bulbs / sub-displays are arranged left to right, i.e. the
+        // entries in the \c TrafficLight::bulbs field start at the left of the
+        // physical traffic light.
         //
-        TYPE_PEDESTRIAN = 3;
+        ARRANGEMENT_LEFT_TO_RIGHT = 3;
         
-        // Light for bicycle traffic.
+        // The light bulbs / sub-displays do not have a specific alignment, e.g.
+        // the traffic light consists of a single LED display unit that can
+        // show arbitrary content.
         //
-        TYPE_BICYCLE = 4;
+        ARRANGEMENT_GENERIC = 4;
     }
-
-    // Definition of traffic light shapes.
+    
     //
-    enum Shape
-    {
-        // Unknown shape of traffic light (must not be used in ground truth).
-        //
-        SHAPE_UNKNOWN = 0;
-        
-        // Other (unspecified but known) shape of traffic light.
-        //
-        SHAPE_OTHER = 1;
-        
-        // This is a normal traffic light without specification of direction.
-        //
-        SHAPE_CIRCULAR = 2;
-        
-        // This traffic light applies to the lane straight ahead.
-        //
-        SHAPE_ARROW_STRAIGHT_AHEAD = 3;
-        
-        // This traffic light applies to left turns.
-        //
-        SHAPE_ARROW_LEFT = 4;
-        
-        // This traffic light applies to diagonal left turns.
-        //
-        SHAPE_ARROW_DIAG_LEFT = 5;
-        
-        // This traffic light applies to a lane allowing to drive straight ahead
-        // or to turn left.
-        SHAPE_ARROW_STRAIGHT_AHEAD_LEFT = 6;
-        
-        // This traffic light applies to right turns.
-        //
-        SHAPE_ARROW_RIGHT = 7;
-        
-        // This traffic light applies to diagonal right turns.
-        //
-        SHAPE_ARROW_DIAG_RIGHT = 8;
-        
-        // This traffic light applies to a lane allowing to drive straight ahead
-        // or to turn right.
-        SHAPE_ARROW_STRAIGHT_AHEAD_RIGHT = 9;
-        
-        // This traffic light applies to a lane allowing to turn left or right.
-        //
-        SHAPE_ARROW_LEFT_RIGHT = 10;
-        
-        // This traffic light indicates that the assigned lane is open for
-        // driving.
-        SHAPE_ARROW_DOWN = 11;
-        
-        // This traffic light indicates a necessary lane change to the left
-        // ahead.
-        SHAPE_ARROW_DOWN_LEFT = 12;
-        
-        // This traffic light indicates a necessary lane change to the right
-        // ahead.
-        SHAPE_ARROW_DOWN_RIGHT = 13;
-        
-        // This traffic light indicates that the assigned lane is not open for
-        // driving.
-        SHAPE_ARROW_CROSS = 14;
-    }
-
+    // \brief A single traffic light bulb.
     //
-    // \brief Definition of light state for traffic lights.
-    // 
-    // Summarizes the relevant semantic information about the entire traffic
-    // light's state and NOT a description of the individual light bulbs.
-    //
-    message LightState
+    message TrafficLightBulb
     {
         // The color of the traffic light.
         //
         optional Color color = 1;
+
+        // The shape of the traffic light.
+        //
+        optional Icon icon = 2;
         
         // The operating mode of the traffic light.
         //
-        optional Mode mode = 2;
+        optional Mode mode = 3;
+        
+        // The value of the counter.
+        // Unit: [%] or [s] 
+        // 
+        // \note Set value only if traffic light bulb is a countdown counter.
+        optional double counter = 4;
         
         // Definition of colors for traffic lights.
         //
@@ -952,25 +904,114 @@ message TrafficLight
             //
             COLOR_OTHER = 1;
             
-            // Traffic light is off / inactive. In this case mode must also be
-            // set to \c MODE_OFF.
-            COLOR_OFF = 2;
-            
-            // Red light is on.
+            // Red light.
             //
-            COLOR_RED = 3;
+            COLOR_RED = 2;
             
-            // Red and yellow light are on at the same time.
+            // Orange-yellow light.
             //
-            COLOR_RED_YELLOW = 4;
+            COLOR_YELLOW = 3;
+                        
+            // Green light.
+            //
+            COLOR_GREEN = 4;
+                        
+            // Blue light.
+            //
+            COLOR_BLUE = 5;
+                        
+            // White light.
+            //
+            COLOR_WHITE = 6;
+        }
+
+        // Definition of traffic light bulb icon.
+        //
+        enum Icon
+        {
+            // Unknown icon of traffic light (must not be used in ground truth).
+            //
+            ICON_UNKNOWN = 0;
             
-            // Yellow light is on.
+            // Other (unspecified but known) icon of traffic light.
             //
-            COLOR_YELLOW = 5;
+            ICON_OTHER = 1;
             
-            // Green light is on.
+            // This is a normal traffic light without specification of e.g.
+            // direction.
+            ICON_NONE = 2;
+            
+            // This traffic light applies to the lane straight ahead.
             //
-            COLOR_GREEN = 6;
+            ICON_ARROW_STRAIGHT_AHEAD = 3;
+            
+            // This traffic light applies to left turns.
+            //
+            ICON_ARROW_LEFT = 4;
+            
+            // This traffic light applies to diagonal left turns.
+            //
+            ICON_ARROW_DIAG_LEFT = 5;
+            
+            // This traffic light applies to a lane allowing to drive straight
+            // ahead or to turn left.
+            ICON_ARROW_STRAIGHT_AHEAD_LEFT = 6;
+            
+            // This traffic light applies to right turns.
+            //
+            ICON_ARROW_RIGHT = 7;
+            
+            // This traffic light applies to diagonal right turns.
+            //
+            ICON_ARROW_DIAG_RIGHT = 8;
+            
+            // This traffic light applies to a lane allowing to drive straight
+            // ahead or to turn right.
+            ICON_ARROW_STRAIGHT_AHEAD_RIGHT = 9;
+            
+            // This traffic light applies to a lane allowing to turn left or
+            // right.
+            ICON_ARROW_LEFT_RIGHT = 10;
+            
+            // This traffic light indicates that the assigned lane is open for
+            // driving.
+            ICON_ARROW_DOWN = 11;
+            
+            // This traffic light indicates a necessary lane change to the left
+            // ahead.
+            ICON_ARROW_DOWN_LEFT = 12;
+            
+            // This traffic light indicates a necessary lane change to the right
+            // ahead.
+            ICON_ARROW_DOWN_RIGHT = 13;
+            
+            // This traffic light indicates that the assigned lane is not open
+            // for driving.
+            ICON_ARROW_CROSS = 14;
+            
+            // This traffic light is valid for pedestrians.
+            //
+            ICON_PEDESTRIAN = 15;
+            
+            // This traffic light is valid for bicyclists. 
+            //
+            ICON_BICYCLE = 16;
+            
+            // This traffic light is valid for pedestrians and bicyclists. 
+            //
+            ICON_PEDESTRIAN_AND_BICYCLE = 17;
+            
+            // This traffic light is valid for trams. 
+            //
+            ICON_TRAM = 18;
+            
+            // This traffic light counter in second. 
+            //
+            ICON_COUNTDOWN_SECONDS = 19;
+            
+            // This traffic light counter in percent. 
+            //
+            ICON_COUNTDOWN_PERCENT = 20;
         }
 
         // Definition of light modes for traffic lights.
@@ -985,39 +1026,22 @@ message TrafficLight
             //
             MODE_OTHER = 1;
             
-            // Traffic light is off / inactive. In this case color must also be
-            // set to \c COLOR_OFF.
+            // Traffic light is off.
+            //
             MODE_OFF = 2;
             
-            // Light is on and not blinking.
+            // Light is on and not flashing.
             //
             MODE_CONSTANT = 3;
             
-            // Light is blinking.
+            // Light is flashing.
             //
-            MODE_BLINKING = 4;
+            MODE_FLASHING = 4;
+            
+            // Light is counting.
+            //
+            MODE_COUNTING = 5;
         }
-    }
-
-    // Definition of states for the presence of a green arrow sign for right
-    // turns.
-    enum GreenArrowPresence
-    {
-        // The presence of a green arrow sign is unknown (must not be used in
-        // ground truth).
-        GREEN_ARROW_UNKNOWN = 0;
-        
-        // Other (unspecified but known) green arrow sign.
-        //
-        GREEN_ARROW_OTHER = 1;
-        
-        // No green arrow sign is present.
-        //
-        GREEN_ARROW_NOT_PRESENT = 2;
-        
-        // A green arrow sign is present.
-        //
-        GREEN_ARROW_PRESENT = 3;
     }
 }
 

--- a/osi_landmark.proto
+++ b/osi_landmark.proto
@@ -818,7 +818,7 @@ message TrafficLight
     // The base parameters of the traffic light.
     //
     // \c BaseStationary::orientation x-axis is view normal of the traffic 
-    // sign's icon. 
+    // light's icon. 
     optional BaseStationary base = 2;
     
     // The color of the traffic light.
@@ -826,8 +826,9 @@ message TrafficLight
     // \note If the color of the traffic light is known (from history or
     // geometrical arrangement) and the state \c TrafficLight::mode is
     // \c MODE_OFF then \c TrafficLight::color could remain unchanged. 
-    // If The traffic light displays different images in different colors,
-    // then \c TrafficLight::mode  
+    // If traffic light displays images in different colors and traffic light
+    // is off ( \c TrafficLight::mode =  \c MODE_OFF), then 
+    // \c TrafficLight::color = \c COLOR_OTHER .
     optional Color color = 3;
 
     // The icon of the traffic light.
@@ -967,17 +968,31 @@ message TrafficLight
         //
         ICON_PEDESTRIAN_AND_BICYCLE = 19;
         
-        // This traffic light is valid for trams. 
-        //
-        ICON_TRAM = 20;
-        
         // This traffic light counter in second. 
         //
-        ICON_COUNTDOWN_SECONDS = 21;
+        ICON_COUNTDOWN_SECONDS = 20;
         
         // This traffic light counter in percent. 
         //
-        ICON_COUNTDOWN_PERCENT = 22;
+        ICON_COUNTDOWN_PERCENT = 21;
+        
+        // This traffic light is valid for trams. 
+        // 
+        // \note There is no detailed traffic light specification for trams and  
+        // buses at the moment.
+        ICON_TRAM = 22;
+        
+        // This traffic light is valid for buses. 
+        //
+        // \note There is no detailed traffic light specification for trams and  
+        // buses at the moment.
+        ICON_BUS = 23;
+        
+        // This traffic light is valid for buses and trams. 
+        //
+        // \note There is no detailed traffic light specification for trams and  
+        // buses at the moment.
+        ICON_BUS_AND_TRAM = 24;
     }
 
     // Definition of light modes for traffic lights.

--- a/osi_landmark.proto
+++ b/osi_landmark.proto
@@ -806,6 +806,9 @@ message SupplementarySign
 //
 // \brief A traffic light.
 //
+// One traffic light message defines a single 'bulb' and not a box of several
+// bulbs, e.g. red, yellow, green are three separate traffic lights.
+//
 message TrafficLight
 {
     // The ID of the traffic light.
@@ -814,234 +817,196 @@ message TrafficLight
 
     // The base parameters of the traffic light.
     //
+    // \c BaseStationary::orientation x-axis is view normal of the traffic 
+    // sign's icon. 
     optional BaseStationary base = 2;
-
-    // Specifies the alignment of the individual light bulbs / sub-displays
-    // of this traffic light and determines the order in which they are given
-    // in the \c bulbs field. See \c TrafficLight::Arrangement for details.
-    //
-    optional Arrangement arrangement = 3;
     
-    // The individual light bulbs / sub-displays of the traffic light.
-    // See \c TrafficLight::Arrangement for details on the order of the entries
-    // of this field. For example, this field starts at the left of the traffic
-    // light if a horizontal arrangement (\c arrangement =
-    // \c ARRANGEMENT_LEFT_TO_RIGHT) is given.
+    // The color of the traffic light.
     //
-    repeated TrafficLightBulb bulbs = 4;
+    // \note If the color of the traffic light is known (from history or
+    // geometrical arrangement) and the state \c TrafficLight::mode is
+    // \c MODE_OFF then \c TrafficLight::color could remain unchanged. 
+    // If The traffic light displays different images in different colors,
+    // then \c TrafficLight::mode  
+    optional Color color = 3;
+
+    // The icon of the traffic light.
+    //
+    optional Icon icon = 4;
+    
+    // The operating mode of the traffic light.
+    //
+    optional Mode mode = 5;
+    
+    // The value of the countdown counter.
+    // Unit: [%] or [s] 
+    // 
+    // \note Set value only if traffic light bulb is a countdown counter.
+    optional double counter = 6;
     
     // The IDs of the lanes that the traffic light is assigned to.
     // Might be multiple if the traffic light is valid for multiple driving
     // lanes.
     //
-    repeated Identifier assigned_lanes = 5;
-    
+    repeated Identifier assigned_lanes = 7;
+         
+    // Definition of colors for traffic lights.
     //
-    // \brief Geometrical arrangement of the individual light bulbs of a traffic
-    // light.
-    //
-    enum Arrangement
+    enum Color
     {
-        // Arrangement is unknown (must not be used in ground truth).
+        // Color is unknown (must not be used in ground truth).
         //
-        ARRANGEMENT_UNKNOWN = 0;
+        COLOR_UNKNOWN = 0;
         
-        // Other (unspecified but known) arrangement.
+        // Other (unspecified but known) color.
         //
-        ARRANGEMENT_OTHER = 1;
+        COLOR_OTHER = 1;
         
-        // The light bulbs / sub-displays are arranged top to bottom, i.e. the
-        // entries in the \c TrafficLight::bulbs field start at the top of the
-        // physical traffic light.
+        // Red light.
         //
-        ARRANGEMENT_TOP_TO_BOTTOM = 2;
+        COLOR_RED = 2;
         
-        // The light bulbs / sub-displays are arranged left to right, i.e. the
-        // entries in the \c TrafficLight::bulbs field start at the left of the
-        // physical traffic light.
+        // Orange-yellow light.
         //
-        ARRANGEMENT_LEFT_TO_RIGHT = 3;
-        
-        // The light bulbs / sub-displays do not have a specific alignment, e.g.
-        // the traffic light consists of a single LED display unit that can
-        // show arbitrary content.
+        COLOR_YELLOW = 3;
+                    
+        // Green light.
         //
-        ARRANGEMENT_GENERIC = 4;
+        COLOR_GREEN = 4;
+                    
+        // Blue light.
+        //
+        COLOR_BLUE = 5;
+                    
+        // White light.
+        //
+        COLOR_WHITE = 6;
     }
-    
+
+    // Definition of traffic light bulb icon.
     //
-    // \brief A single traffic light bulb.
-    //
-    message TrafficLightBulb
+    enum Icon
     {
-        // The color of the traffic light.
+        // Unknown icon of traffic light (must not be used in ground truth).
         //
-        optional Color color = 1;
-
-        // The shape of the traffic light.
-        //
-        optional Icon icon = 2;
+        ICON_UNKNOWN = 0;
         
-        // The operating mode of the traffic light.
+        // Other (unspecified but known) icon of traffic light.
         //
-        optional Mode mode = 3;
+        ICON_OTHER = 1;
         
-        // The value of the counter.
-        // Unit: [%] or [s] 
-        // 
-        // \note Set value only if traffic light bulb is a countdown counter.
-        optional double counter = 4;
+        // This is a normal traffic light without specification of e.g.
+        // direction.
+        ICON_NONE = 2;
         
-        // Definition of colors for traffic lights.
+        // This traffic light applies to the lane straight ahead.
         //
-        enum Color
-        {
-            // Color is unknown (must not be used in ground truth).
-            //
-            COLOR_UNKNOWN = 0;
-            
-            // Other (unspecified but known) color.
-            //
-            COLOR_OTHER = 1;
-            
-            // Red light.
-            //
-            COLOR_RED = 2;
-            
-            // Orange-yellow light.
-            //
-            COLOR_YELLOW = 3;
-                        
-            // Green light.
-            //
-            COLOR_GREEN = 4;
-                        
-            // Blue light.
-            //
-            COLOR_BLUE = 5;
-                        
-            // White light.
-            //
-            COLOR_WHITE = 6;
-        }
+        ICON_ARROW_STRAIGHT_AHEAD = 3;
+        
+        // This traffic light applies to left turns.
+        //
+        ICON_ARROW_LEFT = 4;
+        
+        // This traffic light applies to diagonal left turns.
+        //
+        ICON_ARROW_DIAG_LEFT = 5;
+        
+        // This traffic light applies to a lane allowing to drive straight
+        // ahead or to turn left.
+        ICON_ARROW_STRAIGHT_AHEAD_LEFT = 6;
+        
+        // This traffic light applies to right turns.
+        //
+        ICON_ARROW_RIGHT = 7;
+        
+        // This traffic light applies to diagonal right turns.
+        //
+        ICON_ARROW_DIAG_RIGHT = 8;
+        
+        // This traffic light applies to a lane allowing to drive straight
+        // ahead or to turn right.
+        ICON_ARROW_STRAIGHT_AHEAD_RIGHT = 9;
+        
+        // This traffic light applies to a lane allowing to turn left or
+        // right.
+        ICON_ARROW_LEFT_RIGHT = 10;
+        
+        // This traffic light indicates that the assigned lane is open for
+        // driving.
+        ICON_ARROW_DOWN = 11;
+        
+        // This traffic light indicates a necessary lane change to the left
+        // ahead.
+        ICON_ARROW_DOWN_LEFT = 12;
+        
+        // This traffic light indicates a necessary lane change to the right
+        // ahead.
+        ICON_ARROW_DOWN_RIGHT = 13;
+        
+        // This traffic light indicates that the assigned lane is not open
+        // for driving.
+        ICON_ARROW_CROSS = 14;
+        
+        // This traffic light is valid for pedestrians.
+        //
+        ICON_PEDESTRIAN = 15;
+        
+        // This traffic light is valid for pedestrians with letters 'walk'.
+        //
+        ICON_WALK = 16;
+        
+        // This traffic light is valid for pedestrians with letters 'don't walk'.
+        //
+        ICON_DONT_WALK = 17;
+        
+        // This traffic light is valid for bicyclists. 
+        //
+        ICON_BICYCLE = 18;
+        
+        // This traffic light is valid for pedestrians and bicyclists. 
+        //
+        ICON_PEDESTRIAN_AND_BICYCLE = 19;
+        
+        // This traffic light is valid for trams. 
+        //
+        ICON_TRAM = 20;
+        
+        // This traffic light counter in second. 
+        //
+        ICON_COUNTDOWN_SECONDS = 21;
+        
+        // This traffic light counter in percent. 
+        //
+        ICON_COUNTDOWN_PERCENT = 22;
+    }
 
-        // Definition of traffic light bulb icon.
+    // Definition of light modes for traffic lights.
+    //
+    enum Mode
+    {
+        // Mode is unknown (must not be used in ground truth).
         //
-        enum Icon
-        {
-            // Unknown icon of traffic light (must not be used in ground truth).
-            //
-            ICON_UNKNOWN = 0;
-            
-            // Other (unspecified but known) icon of traffic light.
-            //
-            ICON_OTHER = 1;
-            
-            // This is a normal traffic light without specification of e.g.
-            // direction.
-            ICON_NONE = 2;
-            
-            // This traffic light applies to the lane straight ahead.
-            //
-            ICON_ARROW_STRAIGHT_AHEAD = 3;
-            
-            // This traffic light applies to left turns.
-            //
-            ICON_ARROW_LEFT = 4;
-            
-            // This traffic light applies to diagonal left turns.
-            //
-            ICON_ARROW_DIAG_LEFT = 5;
-            
-            // This traffic light applies to a lane allowing to drive straight
-            // ahead or to turn left.
-            ICON_ARROW_STRAIGHT_AHEAD_LEFT = 6;
-            
-            // This traffic light applies to right turns.
-            //
-            ICON_ARROW_RIGHT = 7;
-            
-            // This traffic light applies to diagonal right turns.
-            //
-            ICON_ARROW_DIAG_RIGHT = 8;
-            
-            // This traffic light applies to a lane allowing to drive straight
-            // ahead or to turn right.
-            ICON_ARROW_STRAIGHT_AHEAD_RIGHT = 9;
-            
-            // This traffic light applies to a lane allowing to turn left or
-            // right.
-            ICON_ARROW_LEFT_RIGHT = 10;
-            
-            // This traffic light indicates that the assigned lane is open for
-            // driving.
-            ICON_ARROW_DOWN = 11;
-            
-            // This traffic light indicates a necessary lane change to the left
-            // ahead.
-            ICON_ARROW_DOWN_LEFT = 12;
-            
-            // This traffic light indicates a necessary lane change to the right
-            // ahead.
-            ICON_ARROW_DOWN_RIGHT = 13;
-            
-            // This traffic light indicates that the assigned lane is not open
-            // for driving.
-            ICON_ARROW_CROSS = 14;
-            
-            // This traffic light is valid for pedestrians.
-            //
-            ICON_PEDESTRIAN = 15;
-            
-            // This traffic light is valid for bicyclists. 
-            //
-            ICON_BICYCLE = 16;
-            
-            // This traffic light is valid for pedestrians and bicyclists. 
-            //
-            ICON_PEDESTRIAN_AND_BICYCLE = 17;
-            
-            // This traffic light is valid for trams. 
-            //
-            ICON_TRAM = 18;
-            
-            // This traffic light counter in second. 
-            //
-            ICON_COUNTDOWN_SECONDS = 19;
-            
-            // This traffic light counter in percent. 
-            //
-            ICON_COUNTDOWN_PERCENT = 20;
-        }
-
-        // Definition of light modes for traffic lights.
+        MODE_UNKNOWN = 0;
+        
+        // Other (unspecified but known) mode.
         //
-        enum Mode
-        {
-            // Mode is unknown (must not be used in ground truth).
-            //
-            MODE_UNKNOWN = 0;
-            
-            // Other (unspecified but known) mode.
-            //
-            MODE_OTHER = 1;
-            
-            // Traffic light is off.
-            //
-            MODE_OFF = 2;
-            
-            // Light is on and not flashing.
-            //
-            MODE_CONSTANT = 3;
-            
-            // Light is flashing.
-            //
-            MODE_FLASHING = 4;
-            
-            // Light is counting.
-            //
-            MODE_COUNTING = 5;
-        }
+        MODE_OTHER = 1;
+        
+        // Traffic light is off.
+        //
+        MODE_OFF = 2;
+        
+        // Light is on and not flashing.
+        //
+        MODE_CONSTANT = 3;
+        
+        // Light is flashing.
+        //
+        MODE_FLASHING = 4;
+        
+        // Light is counting.
+        //
+        MODE_COUNTING = 5;
     }
 }
 


### PR DESCRIPTION
This PR addresses issue #70 .

Review and reformating of documentation.

Unifying enum names.

Change Traffic Lights from semantic representation (light box) to syntactic representation (light bulbs)