### PR TITLE
Review documentation (issue #97)

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -194,7 +194,7 @@ message MountingPosition
 // 
 // Azimuth and elevation are defined as the rotations that would have to be 
 // applied to the local frame (e.g sensor frame definition in 
-// \c DetectionHeader) to make its x-axis point towards the referenced point
+// \c SensorDetectionHeader) to make its x-axis point towards the referenced point
 // or to align it with the referenced vector. The rotations are to be performed
 // \b azimuth \b first (around the z-axis) and \b elevation \b second (around 
 // the new y-axis) to follow the definition of \c Orientation3D. For the

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -9,10 +9,10 @@ package osi;
 // \brief A cartesian 3D vector for positions, velocities or accelerations or
 // its uncertainties.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for accelerations.
-//
 // The coordinate system is defined as right-handed. 
 //
+// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// accelerations.
 message Vector3d
 {
     // The x coordinate.
@@ -35,8 +35,8 @@ message Vector3d
 // \brief A cartesian 2D vector for positions, velocities or accelerations or
 // its uncertainties.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for accelerations.
-//
+// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// accelerations.
 message Vector2d
 {
     // The x coordinate.
@@ -67,9 +67,11 @@ message Timestamp
     optional int64 seconds = 1;
 
     // The number of nanoseconds since the start of the last second. 
+    // 
+    // Range: [0, 999.999.999]
     //
     // Unit: [ns]
-    optional int32 nanos = 2;
+    optional uint32 nanos = 2;
 }
 
 //
@@ -118,12 +120,12 @@ message Dimension3d
 // Roll/Pitch are 0 if the objects xy-plane is parallel to its parent's xy-plane.
 // Yaw is 0 if the object's local x-axis is parallel to its parent's x-axis.
 //
-// Rotation_yaw_pitch_roll = Rotation_roll*Rotation_pitch*Rotation_yaw
+// <tt>Rotation_yaw_pitch_roll = Rotation_roll*Rotation_pitch*Rotation_yaw</tt>
 //
-// vector_global_coord_system := Inverse_Rotation_yaw_pitch_roll(orientation)*(vector_local_coord_system) + local_origin.position
+// <tt>vector_global_coord_system := Inverse_Rotation_yaw_pitch_roll(orientation)*(vector_local_coord_system) + local_origin.position</tt>
 
 //
-// \note This definition changed in OSI version 3.0.0. Previous OSI versions 
+// \attention This definition changed in OSI version 3.0.0. Previous OSI versions 
 // (V2.xx) had an other definition.
 //
 // \par References: 
@@ -180,7 +182,8 @@ message MountingPosition
     optional Vector3d position = 1;
 
     // Orientation offset relative to the specified reference coordinate system.
-    // Origin_sensor := Rotation_yaw_pitch_roll(MountingPosition.orientation)*(Origin_reference_coordinate_system - MountingPosition.position)
+    //
+    // <tt>Origin_sensor := Rotation_yaw_pitch_roll(MountingPosition.orientation)*(Origin_reference_coordinate_system - MountingPosition.position)</tt>
     optional Orientation3d orientation = 2;
 }
 
@@ -191,13 +194,13 @@ message MountingPosition
 // 
 // Azimuth and elevation are defined as the rotations that would have to be 
 // applied to the local frame (e.g sensor frame definition in 
-// \c OSI:DetectionHeader) to make its x-axis point towards the referenced point
+// \c DetectionHeader) to make its x-axis point towards the referenced point
 // or to align it with the referenced vector. The rotations are to be performed
 // \b azimuth \b first (around the z-axis) and \b elevation \b second (around 
-// the new y-axis) to follow the definition of \c OSI:Orientation3D. For the
+// the new y-axis) to follow the definition of \c Orientation3D. For the
 // sense of each rotation, the right-hand rule applies.
 //
-// vector_cartesian := Rotation(elevation)*Rotation(azimuth)*Unit_vector_x*distance
+// <tt>vector_cartesian := Rotation(elevation)*Rotation(azimuth)*Unit_vector_x*distance</tt>
 message Spherical3d
 {
     // The radial distance.
@@ -219,8 +222,8 @@ message Spherical3d
 //
 // \brief The base attributes of a stationary object or entity.
 // 
-// This includes the \c OSI::StationaryObject, \c OSI::TrafficSign,
-// \c OSI::TrafficLight, \c OSI::RoadMarking messages.
+// This includes the \c StationaryObject , \c TrafficSign ,
+// \c TrafficLight , \c RoadMarking messages.
 //
 // All coordinates and orientations are relative to the global ground truth
 // coordinate system.
@@ -238,7 +241,7 @@ message BaseStationary
     // The relative orientation of the stationary object w.r.t. its parent
     // frame.
     //
-    // Origin_base_stationary_entity := Rotation_yaw_pitch_roll(BaseStationary.orientation)*(Origin_parent_coordinate_system - BaseStationary.position)
+    // <tt>Origin_base_stationary_entity := Rotation_yaw_pitch_roll(BaseStationary.orientation)*(Origin_parent_coordinate_system - BaseStationary.position)</tt>
     //
     // \note There may be some constraints how to align the orientation w.r.t. 
     // to some stationary object's or entity's definition.
@@ -285,7 +288,7 @@ message BaseMoving
 
     // The relative orientation of the moving object w.r.t. its parent frame.
     //
-    // Origin_base_moving_entity := Rotation_yaw_pitch_roll(BaseMoving.orientation)*(Origin_parent_coordinate_system - BaseMoving.position)
+    // <tt>Origin_base_moving_entity := Rotation_yaw_pitch_roll(BaseMoving.orientation)*(Origin_parent_coordinate_system - BaseMoving.position)</tt>
     //
     // \note There may be some constraints how to align the orientation w.r.t.
     // to some stationary object's or entity's definition.
@@ -295,7 +298,7 @@ message BaseMoving
     // parent velocity.
     // The velocity becomes global/absolute if the parent frame does not move.
     //
-    // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt 
+    // <tt>BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt</tt>
     optional Vector3d velocity = 4;
 
     // The relative acceleration of the moving object w.r.t. its parent frame
@@ -303,15 +306,16 @@ message BaseMoving
     // The acceleration becomes global/absolute if the parent frame is not
     // accelerating.
     //
-    // BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt+acceleration/2*dt^2
-    // BaseMoving.velocity(t) := BaseMoving.velocity(t-dt)+acceleration*dt 
+    // <tt>BaseMoving.position(t) := BaseMoving.position(t-dt)+velocity*dt+acceleration/2*dt^2</tt>
+    //
+    // <tt>BaseMoving.velocity(t) := BaseMoving.velocity(t-dt)+acceleration*dt</tt>
     optional Vector3d acceleration = 5;
 
     // The relative orientation rate of the moving object w.r.t. its parent
     // frame and parent orientation rate in the center point of the bounding box
     // (origin of the bounding box frame).
     //
-    // Rotation_yaw_pitch_roll(BaseMoving.orientation(t)) := Rotation_yaw_pitch_roll(BaseMoving.orientation_rate*dt)*Rotation_yaw_pitch_roll(BaseMoving.orientation(t-dt))
+    // <tt>Rotation_yaw_pitch_roll(BaseMoving.orientation(t)) := Rotation_yaw_pitch_roll(BaseMoving.orientation_rate*dt)*Rotation_yaw_pitch_roll(BaseMoving.orientation(t-dt))</tt>
     //
     // \note BaseMoving.orientation(t) is \b not equal BaseMoving.orientation(t-dt)+BaseMoving.orientation_rate*dt
     optional Orientation3d orientation_rate = 6;

--- a/osi_datarecording.proto
+++ b/osi_datarecording.proto
@@ -7,33 +7,36 @@ import "osi_sensordata.proto";
 package osi;
 
 //
-// \brief (Time) Series of SensorData messages that may be used for data recording or internal buffering by some sensor models.
+// \brief (Time) Series of SensorData messages that may be used for data
+// recording or internal buffering by some sensor models.
 //
 message SensorDataSeries
 {
     // List of sensor data messages for subsequent timesteps.
     //
-    repeated SensorData sensor_data = 1;
+    repeated SensorData sensor_data_list = 1;
 }
 
 //
-// \brief List of SensorData interface copies, one for each sensor in the vehicle.
-// 
+// \brief List of SensorData interface copies, one for each sensor in the
+//  vehicle.
+//
 // Can be used to bundle output of multiple sensors in one transmission.
 //
 message SensorDataList
 {
     // List of sensor data for multiple sensors at a specific timestep.
     //
-    repeated SensorData sensor = 1;
+    repeated SensorData sensors = 1;
 }
 
 //
-// \brief List of sensors where each element contains a time series of SensorData messages.
+// \brief List of sensors where each element contains a time series of
+// SensorData messages.
 //
 message SensorDataSeriesList
 {
     // List of sensor data for multiple sensors at subsequent timesteps.
     //
-    repeated SensorDataSeries sensor = 1;
+    repeated SensorDataSeries sensors = 1;
 }

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -356,7 +356,7 @@ message DetectedObjectHeader
     }
 
     //
-    // \brief Version of detected object messages ( \c OSI::DetectedObject
+    // \brief Version of detected object messages ( \c DetectedObject
     // etc.).
     //
     message InterfaceVersion

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -13,27 +13,27 @@ package osi;
 // All information regarding the environment is given with respect to the sensor 
 // coordinate system specified in \c DetectionHeader::mounting_position. 
 // When simulating multiple sensors, each sensor has an individual copy of 
-// \c OSI::FeatureData in its own reference frame. This allows an independent 
+// \c FeatureData in its own reference frame. This allows an independent 
 // treatment of the sensors.
 //
 message FeatureData
 {
     // Lidar detection list for multiple lidar sensors.
     //
-    repeated LidarDetectionList lidar_detection_list = 1;
+    repeated LidarDetectionList multiple_lidar_detections = 1;
 
-    // Radar detection list for multiple lidar sensors.
+    // Radar detection list for multiple radar sensors.
     //
-    repeated RadarDetectionList radar_detection_list = 2;
+    repeated RadarDetectionList multiple_radar_detections = 2;
 }
 
 //
-// \brief The header attributes of each detection.
+// \brief The header attributes of each sensor's detection list.
 //
-message DetectionHeader
+message SensorDetectionHeader
 {
-    // Version number of used detecion list messages ( \c OSI::DetectionHeader, 
-    // \c OSI::LidarDetection, \c OSI::LidarDetectionList etc.).
+    // Version number of used detection list messages ( \c DetectionHeader, 
+    // \c LidarDetection, \c LidarDetectionList etc.).
     // 
     optional DetectionInterfaceVersion version = 1;
 
@@ -46,14 +46,14 @@ message DetectionHeader
     optional Timestamp measurement_time = 2;
 
     // Monotonous counter to identify the exact cycle. 
-    // Generally the detecion function is called periodic and 
+    // Generally the detection function is called periodic and 
     // \c DetectionHeader::cycle_counter corresponds to the number of periods.
     optional uint64 cycle_counter = 3;
 
 
     // Mounting position of the sensor (origin and orientation of the sensor 
     // frame). Both origin and orientation are given in and with respect to the 
-    // host vehicle coordinate system (see: \c OSI::Vehicle vehicle reference
+    // host vehicle coordinate system (see: \c Vehicle vehicle reference
     // point).
     //
     // The sensor frame's x-axis is pointing in the central viewing direction of 
@@ -89,7 +89,7 @@ message DetectionHeader
     // The current number of valid detections in the detections list.
     //
     // \note This value has to be set if the list contains invalid detections.    
-    optional uint32 number_of_detections = 7;
+    optional uint32 number_of_valid_detections = 7;
 
     // \brief Data qualifier communicates the overall availability of the 
     // interface.
@@ -126,8 +126,8 @@ message DetectionHeader
     }
 
     //
-    // \brief Version of detection messages ( \c OSI::DetectionHeader, 
-    // \c OSI::LidarDetection, \c OSI::LidarDetectionList, etc.).
+    // \brief Version of detection messages ( \c DetectionHeader, 
+    // \c LidarDetection, \c LidarDetectionList etc.).
     //
     message DetectionInterfaceVersion
     {
@@ -145,7 +145,153 @@ message DetectionHeader
     }
 }
 
-// Definition of common detection classifications. 
+//
+// \brief A list of lidar detection from one sensor.
+//
+message LidarDetectionList
+{
+    // Header attributes of lidar detection from one lidar sensor.
+    //
+    optional SensorDetectionHeader header = 1;
+
+    // List of lidar detections.
+    //
+    repeated LidarDetection detections = 2;
+}
+
+//
+// \brief A point or vertical line in a lidar point cloud.
+//
+message LidarDetection
+{
+    // Existence probability of the detection not based on history. Value does 
+    // not depend on any past experience with similar detections.
+    //
+    // \note Used as confidence measure where a low value means less confidence 
+    // and a high value indicates strong confidence.
+    optional double existence_probability = 1;
+
+    // ID of the detected object this detection is associated to.
+    // 
+    // \note ID = MAX(uint64) indicates no reference to an object.
+    optional Identifier object_id = 2;
+
+    // Measured position of the detection, given in spherical coordinates in the 
+    // sensor coordinate system.
+    //
+    optional Spherical3d position = 3;
+
+    // Root mean squared error of the measured position of the detection.
+    //
+    optional Spherical3d position_rmse = 4;
+
+    // Height value, which is required when multiple scan points are vertically 
+    // clustered. Only vertical clustering is allowed (z-axis).
+    //
+    // Unit: [m]
+    optional double height = 5;
+
+    // Root mean squared error of the object height.
+    //
+    // Unit: [m]
+    optional double height_rmse = 6;
+
+    // Intensity or equivalent value of the detection's echo.
+    //
+    // Unit: [%]
+    optional double intensity = 7;
+
+    // The free space probability in the range [0.0, 1.0] from the origin of the 
+    // sensor up to this detection, as given by the distance.
+    // 
+    // Range: [0.0, 1.0]
+    optional double free_space_probability = 8;
+
+    // Basic classification of the detection.
+    // 
+    optional DetectionClassification classification = 9;
+   
+}
+
+//
+// \brief A list of radar detections from one sensor.
+//
+message RadarDetectionList
+{    
+    // Header attributes of radar detection from one radar sensor.
+    //
+    optional SensorDetectionHeader header = 1;
+
+    // List of radar detections constituting the radar detection list.
+    //
+    repeated RadarDetection detections = 2;
+}
+
+//
+// \brief A radar detection.
+//
+message RadarDetection
+{
+    // Existence probability of the detection not based on history. Value does 
+    // not depend on any past experience with similar detections.
+    //
+    // \note Use as confidence measure where a low value means less confidence 
+    // and a high value indicates 
+    // strong confidence.
+    optional double existence_probability = 1;
+
+    // ID of the detected object this detection is associated to.
+    // 
+    // \note ID = MAX(uint64) indicates no reference to an object.
+    optional Identifier object_id = 2;
+
+    // Measured position of the detection, given in spherical coordinates in the
+    // sensor coordinate system.
+    //
+    optional Spherical3d position = 3;
+
+    // Root mean squared error of the measured position of the detection.
+    // 
+    optional Spherical3d position_rmse = 4;
+
+    // Absolute radial (in direction to the sensor) velocity of the detection.
+    // 
+    // Unit: [m/s]
+    optional double radial_velocity = 5;
+
+    // Root mean squared error of the object measured radial velocity.
+    // 
+    // Unit: [m/s]
+    optional double radial_velocity_rmse = 6;
+
+    // The radar cross section (RCS) of the radar detection.
+    //
+    // Unit: [dB m^2].
+    optional double rcs = 7;
+
+    // The signal to noise ratio (SNR) of the radar detection.
+    //
+    // Unit: [dB m^2].
+    optional double snr = 8;
+
+    // Describes the possibility whether more than one object may have led to 
+    // this detection.
+    // 
+    optional double point_target_probability = 9;
+
+    // Ambiguity Information: 
+    // Each ambiguous measurement generates one Ambiguity ID. Ambiguity is 
+    // indicated by an identical ambiguity ID. 
+    // 
+    // \note Unambiguous measurements have the ambiguity ID 0.
+    optional Identifier ambiguity_id = 10;
+
+    // Basic classification of the detection.
+    // 
+    optional DetectionClassification classification = 11;
+}
+
+// Definition of a basic detection classifications. 
 // 
 enum DetectionClassification
 {
@@ -173,141 +319,4 @@ enum DetectionClassification
     // Underdrivable (sign gantry etc.).
     //
     DETECTION_CLASSIFICATION_UNDERDRIVABLE = 5;
-}
-
-
-//
-// \brief A list of lidar detection from one sensor.
-//
-message LidarDetectionList
-{
-    // Header attributes of lidar detection.
-    //
-    optional DetectionHeader header = 1;
-
-    // List of lidar detections.
-    //
-    repeated LidarDetection detection = 2;
-}
-
-//
-// \brief A point or vertical line in a lidar point cloud.
-//
-message LidarDetection
-{
-    // Existence probability of the detection not based on history. Value does 
-    // not depend on any past experience with similar detections.
-    //
-    // \note Used as confidence measure where a low value means less confidence 
-    // and a high value indicates strong confidence.
-    optional double existence_probability = 1;
-
-    // ID of the object this detection is associated to; ID = MAX(uint64) 
-    // indicates no reference to an object.
-    //
-    optional Identifier object_id = 2;
-
-    // Measured position of the detection, given in spherical coordinates in the 
-    // sensor coordinate system.
-    //
-    optional Spherical3d position = 3;
-
-    // Root mean squared error of the measured position of the detection.
-    //
-    optional Spherical3d position_rmse = 4;
-
-    // Height value, which is required when multiple scan points are vertically 
-    // clustered. Only vertical clustering is allowed (z-axis).
-    optional double height = 5;
-
-    // Root mean squared error of the object height.
-    // 
-    optional double height_rmse = 6;
-
-    // Intensity or equivalent value of the detection's echo.
-    // Unit: [%]
-    optional double intensity = 7;
-
-    // The free space probability in the range [0.0, 1.0] from the origin of the 
-    // sensor up to this detection, as given by the distance.
-    // 
-    optional double free_space_probability = 8;
-
-    // Attributes of the detection.
-    // 
-    optional DetectionClassification classification = 9;
-   
-}
-
-//
-// \brief A list of radar detections from one sensor.
-//
-message RadarDetectionList
-{    
-    // Header attributes of radar detection.
-    //
-    optional DetectionHeader header = 1;
-
-    // List of radar detections constituting the radar detection list.
-    //
-    repeated RadarDetection detection = 2;
-}
-
-//
-// \brief A radar detection.
-//
-message RadarDetection
-{
-    // Existence probability of the detection not based on history. Value does 
-    // not depend on any past experience with similar detections.
-    //
-    // \note Use as confidence measure where a low value means less confidence 
-    // and a high value indicates 
-    // strong confidence.
-    optional double existence_probability = 1;
-
-    // ID of the object this detection is associated to; ID = MAX(uint64) 
-    // indicates no reference to an object.
-    // 
-    optional Identifier object_id = 2;
-
-    // Measured position of the detection, given in spherical coordinates in the
-    // sensor coordinate system.
-    //
-    optional Spherical3d position = 3;
-
-    // Root mean squared error of the measured position of the detection.
-    // 
-    optional Spherical3d position_rmse = 4;
-
-    // Absolute radial (in direction to the sensor) velocity of the detection.
-    // 
-    optional double radial_velocity = 5;
-
-    // Root mean squared error of the object measured radial velocity.
-    // 
-    optional double radial_velocity_rmse = 6;
-
-    // The radar cross section (RCS) of the radar detection.
-    // Unit: [dB m^2].
-    optional double rcs = 7;
-
-    // The signal to noise ratio (SNR) of the radar detection.
-    // Unit: [dB m^2].
-    optional double snr = 8;
-
-    // Describes the possibility whether more than one object may have led to 
-    // this detection.
-    // 
-    optional double point_target_probability = 9;
-
-    // Ambiguity Information: 
-    // Each ambiguous measurement generates one Ambiguity ID. Ambiguity is 
-    // indicated by an identical Ambiguity ID. 
-    // Unambiguous measurements have the Amiguity ID 0.
-    optional Identifier ambiguity_id = 10;
-
-    // Attributes of the detection.
-    // 
-    optional DetectionClassification classification = 11;
 }

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -11,7 +11,7 @@ package osi;
 // object hypothesis and tracking.
 //
 // All information regarding the environment is given with respect to the sensor 
-// coordinate system specified in \c DetectionHeader::mounting_position. 
+// coordinate system specified in \c SensorDetectionHeader::mounting_position. 
 // When simulating multiple sensors, each sensor has an individual copy of 
 // \c FeatureData in its own reference frame. This allows an independent 
 // treatment of the sensors.
@@ -32,7 +32,7 @@ message FeatureData
 //
 message SensorDetectionHeader
 {
-    // Version number of used detection list messages ( \c DetectionHeader, 
+    // Version number of used detection list messages ( \c SensorDetectionHeader, 
     // \c LidarDetection, \c LidarDetectionList etc.).
     // 
     optional DetectionInterfaceVersion version = 1;
@@ -41,13 +41,14 @@ message SensorDetectionHeader
     // was processed or at which it is transmitted) in the global synchronized
     // time.
     //
-    // \note See SensorData::timestamp and SensorData::last_measurement_time
-    // for detailed discussions on the semantics of time-related fields.
+    // \note See \c SensorData::timestamp and
+    // \c SensorData::last_measurement_time for detailed discussions on the 
+    // semantics of time-related fields.
     optional Timestamp measurement_time = 2;
 
     // Monotonous counter to identify the exact cycle. 
     // Generally the detection function is called periodic and 
-    // \c DetectionHeader::cycle_counter corresponds to the number of periods.
+    // \c SensorDetectionHeader::cycle_counter corresponds to the number of periods.
     optional uint64 cycle_counter = 3;
 
 
@@ -126,7 +127,7 @@ message SensorDetectionHeader
     }
 
     //
-    // \brief Version of detection messages ( \c DetectionHeader, 
+    // \brief Version of detection messages ( \c SensorDetectionHeader, 
     // \c LidarDetection, \c LidarDetectionList etc.).
     //
     message DetectionInterfaceVersion

--- a/osi_landmark.proto
+++ b/osi_landmark.proto
@@ -20,12 +20,12 @@ message TrafficSign
 
     // The base parameters of the traffic sign.
     //
-    // The orientation of the bounding box \c OSI::TrafficSign::base.orientation
-    // is defined as follows: 
-    // The z-axis of the given \c OSI::BaseStationary::orientation is the vector
+    // The orientation of the bounding box \c TrafficSign::base
+    // ( \c BaseStationary::orientation ) is defined as follows: 
+    // The z-axis of the given \c BaseStationary::orientation is the vector
     // from the bottom to the top of the traffic sign's 2D image plate. 
     // (Normally it is equal to the ground truth z-axis.)
-    // The x-axis of the given \c OSI::BaseStationary::orientation is view 
+    // The x-axis of the given \c BaseStationary::orientation is view 
     // normal of the traffic sign's image. 
     // This x-axis points from the traffic sign's image in the direction from
     // where a 'viewer' could see the traffic sign image. 
@@ -61,7 +61,7 @@ message TrafficSign
     // temporarily constructed right-handed local coordinate system: 
     // Set z-axis to match the z-axis of the ground truth coordinate system.
     // Set x-axis to the view normal of the traffic sign's image
-    // (\c OSI::TrafficSign::base.orientation x-axis).
+    // (\c TrafficSign::base \c BaseStationary::orientation x-axis).
     // Right: direction of the local coordinate system's positive y-axis.
     // Left: opposite direction of the local coordinate system's y-axis i.e. 
     // negative y-axis´,
@@ -74,11 +74,11 @@ message TrafficSign
     
     // Additional supplementary signs, e.g. time limits, modifying the traffic
     // sign.
-    repeated SupplementarySign supplementary_sign = 8;
+    repeated SupplementarySign supplementary_signs = 8;
 
     // The IDs of the lanes that the traffic sign is assigned to.
     // May be multiple if the traffic sign is valid for multiple lanes.
-    repeated Identifier assigned_lane = 9;
+    repeated Identifier assigned_lanes = 9;
 
     // Definition of traffic sign types.
     // Numbers are given according to German StVO.
@@ -89,6 +89,7 @@ message TrafficSign
     // \arg https://www.gesetze-im-internet.de/stvo_2013/anlage_2.html (Vorschriftzeichen)
     // \arg https://www.gesetze-im-internet.de/stvo_2013/anlage_3.html (Richtzeichen)
     // \arg https://www.gesetze-im-internet.de/stvo_2013/anlage_4.html (Verkehrseinrichtungen)
+    // \arg https://traffic-rules.com/ 
     enum Type
     {
         // Type of traffic sign is unknown (must not be used in ground truth).
@@ -99,219 +100,234 @@ message TrafficSign
         //
         TYPE_OTHER = 1;
         
-        // Start of speed limit (StVO 274).
-        //
+        // Start of speed limit (StVO 274) \c TrafficSign::value and
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/274-60.png
         TYPE_SPEED_LIMIT_BEGIN = 2;
         
-        // End of speed limit (StVO 278).
-        //
+        // End of speed limit (StVO 278) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/278-60.png
         TYPE_SPEED_LIMIT_END = 3;
         
         // Town entrance (StVO 310).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/310.png
         TYPE_TOWN_BEGIN = 4;
         
         // Town exit (StVO 311).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/311.png
         TYPE_TOWN_END = 5;
         
-        // Start of zone with speed limit 30 (StVO 274.1).
-        //
-        TYPE_ZONE_30_BEGIN = 6;
+        // Start of zone with speed limit (StVO 274.1) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/274.1.png
+        TYPE_SPEED_LIMIT_ZONE_BEGIN = 6;
         
-        // End of zone with speed limit 30 (StVO 274.2).
-        //
-        TYPE_ZONE_30_END = 7;
+        // End of zone with speed limit (StVO 274.2) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/274.2.png
+        TYPE_SPEED_LIMIT_ZONE_END = 7;
         
-        // Start of mandatory minimum speed (StVO 275).
-        //
+        // Start of mandatory minimum speed (StVO 275) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/275.png
         TYPE_MINIMUM_SPEED_BEGIN = 8;
         
-        // End of mandatory minimum speed (StVO 279).
-        //
+        // End of mandatory minimum speed (StVO 279) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/279.png
         TYPE_MINIMUM_SPEED_END = 9;
         
         // Start of area with calmed / reduced traffic
         // (verkehrsberuhigter Bereich - StVO 325.1).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/325.1.png
         TYPE_TRAFFIC_CALMED_DISTRICT_BEGIN = 10;
         
         // End of area with calmed / reduced traffic
         // (verkehrsberuhigter Bereich - StVO 325.2).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/325.2.png
         TYPE_TRAFFIC_CALMED_DISTRICT_END = 11;
         
         // Start of area without traffic to reduce harmful air pollution
         // (StVO 270.1).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/270.1.png
         TYPE_ENVIRONMENTAL_ZONE_BEGIN = 12;
         
         // End of area without traffic to reduce harmful air pollution
         // (StVO 270.2).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/270.2.png
         TYPE_ENVIRONMENTAL_ZONE_END = 13;
         
         // Start of overtaking ban (StVO 276).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/276.png
         TYPE_OVERTAKING_BAN_BEGIN = 14;
         
         // End of overtaking ban (StVO 280).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/280.png
         TYPE_OVERTAKING_BAN_END = 15;
         
         // Start of overtaking ban for trucks (StVO 277).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/277.png
         TYPE_OVERTAKING_BAN_FOR_TRUCKS_BEGIN = 16;
         
         // End of overtaking ban for trucks (StVO 281).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/281.png
         TYPE_OVERTAKING_BAN_FOR_TRUCKS_END = 17;
         
         // End of all speed and overtaking restrictions (StVO 282).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/282.png
         TYPE_ALL_RESTRICTIONS_END = 18;
         
         // Begin of priority road with right of way (StVO 306).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/306.png
         TYPE_RIGHT_OF_WAY_BEGIN = 19;
         
         // End of priority road with right of way (StVO 307).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/307.png
         TYPE_RIGHT_OF_WAY_END = 20;
         
         // Right of way at the next intersection (StVO 301).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/301.png
         TYPE_RIGHT_OF_WAY_NEXT_INTERSECTION = 21;
         
         // "Right before left" rule at the next intersection (StVO 102).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/102.png
         TYPE_RIGHT_BEFORE_LEFT_NEXT_INTERSECTION = 22;
         
         // Begin of no parking zone (StVO 290.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/290.1.png
         TYPE_NO_PARKING_ZONE_BEGIN = 23;
         
         // End of no parking zone (StVO 290.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/290.2.png
         TYPE_NO_PARKING_ZONE_END = 24;
         
         // No parking sign (StVO 286).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/286.png
         TYPE_NO_PARKING = 25;
         
         // No stopping sign (StVO 283).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/283.png
         TYPE_NO_STOPPING = 26;
         
         // Begin of parking zone (StVO 314.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/314.1.png
         TYPE_CAR_PARKING_ZONE_BEGIN = 27;
 
         // End of parking zone (StVO 314.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/314.2.png
         TYPE_CAR_PARKING_ZONE_END = 28;
 
         // Parking space (StVO 314).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/314.png
         TYPE_CAR_PARKING = 29;
         
         // Give way sign (StVO 205).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/205.png
         TYPE_GIVE_WAY = 30;
         
         // Stop sign (StVO 206).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/206.png
         TYPE_STOP = 31;
         
         // Danger sign (StVO 101).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/101.png
         TYPE_DANGER_SPOT = 32;
         
         // Road works sign (StVO 123)
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/123.png
         TYPE_ROAD_WORKS = 33;
         
-        // Steep hill downwards (StVO 108).
-        //
+        // Steep hill downwards (StVO 108) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/108-10.png
         TYPE_HILL_DOWNWARDS = 34;
         
-        // Steep hill upwards (StVO 110).
-        //
+        // Steep hill upwards (StVO 110) \c TrafficSign::value and 
+        // \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/110-12.png
         TYPE_HILL_UPWARDS = 35;
         
         // Prescribed left turn (StVO 209.1).
-        //
+        // See e.g.:
         TYPE_PRESCRIBED_LEFT_TURN = 36;
         
         // Prescribed right turn (StVO 209.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/209.png
         TYPE_PRESCRIBED_RIGHT_TURN = 37;
         
         // Prescribed driving straight ahead (StVO 209.3).
-        //
+        // See e.g.: 
         TYPE_PRESCRIBED_STRAIGHT_AHEAD = 38;
         
         // Prescribed left way (StVO 211.1).
-        //
+        // See e.g.: 
         TYPE_PRESCRIBED_LEFT_WAY = 39;
         
         // Prescribed right way (StVO 211.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/211.png
         TYPE_PRESCRIBED_RIGHT_WAY = 40;
         
         // Prescribed left turn and driving straight ahead (StVO 214.1).
-        //
+        // See e.g.: 
         TYPE_PRESCRIBED_LEFT_TURN_AND_STRAIGHT_AHEAD = 41;
         
         // Prescribed right turn and driving straight ahead (StVO 214.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/214.png
         TYPE_PRESCRIBED_RIGHT_TURN_AND_STRAIGHT_AHEAD = 42;
         
         // Prescribed left and right turn (StVO 214.3).
-        //
+        // See e.g.: 
         TYPE_PRESCRIBED_LEFT_TURN_AND_RIGHT_TURN = 43;
 
         // Prescribed left turn, right turn and driving straight ahead (required
         // for logical signs as road marking).
+        // See e.g.: 
         TYPE_PRESCRIBED_LEFT_TURN_RIGHT_TURN_AND_STRAIGHT_AHEAD = 44;
 
         // One-way road to the left (StVO 220.1).
-        //
+        // See e.g.: 
         TYPE_ONEWAY_LEFT = 45;
 
         // One-way road to the right (StVO 220.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/220-20.png
         TYPE_ONEWAY_RIGHT = 46;
 
+        // Entry not allowed (StVO 267).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/267.png
+        TYPE_DO_NOT_ENTER = 47;
+
         // No U turn left (StVO 272).
-        //
-        TYPE_NO_U_TURN_LEFT = 47;
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/272.png
+        TYPE_NO_U_TURN_LEFT = 48;
 
         // No U turn right ().
         //
-        TYPE_NO_U_TURN_RIGHT = 48;
+        TYPE_NO_U_TURN_RIGHT = 49;
 
         // Prescribed U turn left ().
         //
-        TYPE_PRESCRIBED_U_TURN_LEFT = 49;
+        TYPE_PRESCRIBED_U_TURN_LEFT = 50;
 
         // Prescribed U turn right ().
         //
-        TYPE_PRESCRIBED_U_TURN_RIGHT = 50;
+        TYPE_PRESCRIBED_U_TURN_RIGHT = 51;
 
-        // Left lane limitation or end of left lane (StVO 531.2x). 
-        //
-        TYPE_ANNOUNCE_LEFT_LANE_END = 51;
+        // End of left lane (StVO 531.2x). 
+        // See e.g.: 
+        // \note No speed limitation
+        TYPE_ANNOUNCE_LEFT_LANE_END = 52;
 
-        // Right lane limitation or end of right lane (StVO 531.1x). 
-        //
-        TYPE_ANNOUNCE_RIGHT_LANE_END = 52;
-
-        // Entry not allowed (StVO 267).
-        //
-        TYPE_DO_NOT_ENTER = 53;
+        // End of right lane (StVO 531.1x). 
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/531-10.png
+        // \note No speed limitation
+        TYPE_ANNOUNCE_RIGHT_LANE_END = 53;
 
         // Roundabout (StVO 215).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/215.png
         TYPE_ROUNDABOUT = 54;
 
-        // Bus only lane begin. 
+        // Bus only lane begin (). 
         //
         TYPE_BUS_LANE_BEGIN = 55;
 
@@ -320,112 +336,150 @@ message TrafficSign
         TYPE_BUS_LANE_END = 56;
         
         // Entry prohibited for all vehicle types (StVO 250).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/250.png
         TYPE_PROHIBITED_FOR_ALL = 57;
         
         // Entry prohibited for all motor vehicles (StVO 251).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/251.png
         TYPE_PROHIBITED_FOR_MOTOR_VEHICLES = 58;
         
         // Entry prohibited for trucks (StVO 253).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/253.png
         TYPE_PROHIBITED_FOR_TRUCKS = 59;
         
         // Entry prohibited for bicycles (StVO 254).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/254.png
         TYPE_PROHIBITED_FOR_BICYCLES = 60;
         
         // Entry prohibited for motor bikes (StVO 255).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/255.png
         TYPE_PROHIBITED_FOR_MOTOR_AND_BIKES = 61;
         
         // Entry prohibited for pedestrians (StVO 259).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/259.png
         TYPE_PROHIBITED_FOR_PEDESTRIANS = 62;
         
         // Entry prohibited for all motor vehicles and bikes (StVO 260).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/260.png
         TYPE_PROHIBITED_FOR_MOTOR_VEHICLES_BIKES = 63;
         
         // Begin of highway (StVO 330.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/330.1.png
         TYPE_HIGHWAY_BEGIN = 64;
         
         // End of highway (StVO 330.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/330.2.png
         TYPE_HIGHWAY_END = 65;
         
         // Highway exit sign (StVO 333).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/333.png
         TYPE_HIGHWAY_EXIT = 66;
         
-        // Pole indicating highways exit in e.g. 100m (StVO 450). See additional
-        // value and its unit.
+        // Pole indicating highways exit in e.g. 100m (StVO 450).
+        // \c TrafficSign::value and \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/450-51.png
         TYPE_POLE_EXIT = 67;
         
         // Pole for warning and guiding purposes (red/white stripes - StVO 605).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/605-10.png
         TYPE_POLE_WARNING = 68;
         
         // Begin of expressway for motor vehicles (StVO 331.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/331.1.png
         TYPE_EXPRESSWAY_BEGIN = 69;
         
         // End of expressways for motor vehicles (StVO 331.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/331.2.png
         TYPE_EXPRESSWAY_END = 70;
                 
         // Priority must be given to vehicles from the opposite direction
         // (StVO 208).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/208.png
         TYPE_PRIORITY_TO_OPPOSITE_DIRECTION = 71;
         
         // Traffic has priority over vehicles from the opposite direction
         // (StVO 308).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/308.png
         TYPE_PRIORITY_OVER_OPPOSITE_DIRECTION = 72;
         
         // Priority must be given to vehicles from the opposite direction
-        // (StVO 208). Upside down.
+        // (StVO 208 Upside down).
+        // See e.g.: 
         TYPE_PRIORITY_TO_OPPOSITE_DIRECTION_UPSIDE_DOWN = 73;
         
         // Traffic has priority over vehicles from the opposite direction
-        // (StVO 308). Upside down.
+        // (StVO 308 Upside down).
+        // See e.g.: 
         TYPE_PRIORITY_OVER_OPPOSITE_DIRECTION_UPSIDE_DOWN = 74;
         
         // Minimum safety distance for trucks (StVO 273).
-        //
+        // \c TrafficSign::value and \c TrafficSign::value_unit .
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/273.png
         TYPE_MINIMUM_DISTANCE_FOR_TRUCKS = 75;
         
         // Traffic light ahead sign (StVO 131).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/131.png
         TYPE_ATTENTION_TRAFFIC_LIGHT = 76;
         
-        // Pedestrian crossing (StVO 350).
-        //
+        // Pedestrian crossing (StVO 350) - crosswalk.
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/350-10.png
         TYPE_PEDESTRIAN_CROSSING_INFO = 77;
         
         // Warning sign for a left turn (StVO 103.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/103-10.png
         TYPE_TURN_LEFT = 78;
         
         // Warning sign for a right turn (StVO 103.2).
-        //
+        // See e.g.: 
         TYPE_TURN_RIGHT = 79;
         
         // Warning sign for a double turn (first left turn) (StVO 105.1).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/105-10.png
         TYPE_DOUBLE_TURN_LEFT = 80;
         
         // Warning sign for a double turn (first right turn) (StVO 105.2).
-        //
+        // See e.g.: 
         TYPE_DOUBLE_TURN_RIGHT = 81;
         
         // Drive past on the left side (StVO 222.1).
-        //
+        // See e.g.: 
         TYPE_PASS_LEFT = 82;
         
         // Drive past on the right side (StVO 222.2).
-        //
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/222.png
         TYPE_PASS_RIGHT = 83;
+        
+        // Tunnel ahead (StVO 327).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/327.png
+        TYPE_TUNNEL = 84;
+        
+        // Emergency stopping place left ().
+        // See e.g.: 
+        TYPE_EMERGENCY_STOPPING_LEFT = 85;
+        
+        // Emergency stopping place right (StVO 328).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/328.png
+        TYPE_EMERGENCY_STOPPING_RIGHT = 86;
+        
+        // Warning for two-way-traffic (after one-way lane) (StVO 125).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/125.png
+        TYPE_WARNING_TWO_WAY_TRAFFIC = 87;
+        
+        // Warning for road narrowing (StVO 120).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/120.png
+        TYPE_WARNING_ROAD_NARROWING = 88;
+        
+        // Warning for road narrowing on the left (StVO 121.2).
+        // See e.g.: 
+        TYPE_WARNING_ROAD_NARROWING_LEFT = 89;
+        
+        // Warning for road narrowing on the right (StVO 121.1).
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/121-10.png
+        TYPE_WARNING_ROAD_NARROWING_RIGHT = 90;
+
+        // Lane for buses (StVO 245). 
+        // See e.g.: https://www.dvr.de/bilder/stvo/gt/245.png
+        TYPE_BUS_LANE = 91;
     }
 
     // Definition of the variability of the traffic sign.
@@ -487,65 +541,77 @@ message TrafficSign
         // truth).
         UNIT_UNKNOWN = 0;
 
-        // Other (unspecified but known) uUnit of the sign's value.
+        // Other (unspecified but known) unit of the sign's value.
         //
         UNIT_OTHER = 1;
 
         // Value without unit.
-        // Unit []
+        //
+        // Unit: []
         UNIT_NO_UNIT = 2;
 
         // Velocity 
-        // Unit [km/h]
+        //
+        // Unit: [km/h]
         UNIT_KILOMETER_PER_HOUR = 3;
 
         // Velocity 
-        // Unit [mph]
         //
+        // Unit: [mph]
         UNIT_MILE_PER_HOUR = 4;
 
         // Length
-        // Unit [m]
+        //
+        // Unit: [m]
         UNIT_METER = 5;
 
         // Length
-        // Unit [km]
+        //
+        // Unit: [km]
         UNIT_KILOMETER = 6;
 
         // Length
-        // Unit [ft]
+        //
+        // Unit: [ft]
         UNIT_FEET = 7;
 
         // Length
-        // Unit [mile]
+        //
+        // Unit: [mile]
         UNIT_MILE = 8;
 
         // Weight
-        // Unit [t]
+        //
+        // Unit: [t]
         UNIT_METRIC_TON = 9;
 
         // Weight 
         // Long ton UK 1,016.047 kg
-        // Unit [tn. l.]
+        //
+        // Unit: [tn. l.]
         UNIT_LONG_TON = 10;
 
         // Weight 
         // Short ton USA 907.1847 kg
-        // Unit [tn. sh.]
+        //
+        // Unit: [tn. sh.]
         UNIT_SHORT_TON = 11;
 
         // Time of day 
         // Hour since midnight
-        // Unit [min]
+        //
+        // Unit: [min]
         UNIT_MINUTES = 12;
 
         // Day of the week 
         // Days since monday. Monday = 0; Tuesday = 1; ...
-        // Unit []
+        //
+        // Unit: []
         UNIT_DAY = 13;
 
         // Percentage
-        // Unit [%]
+        //
+        // Unit: [%]
         UNIT_PERCENTAGE = 14;
     }
 }
@@ -596,7 +662,7 @@ message SupplementarySign
     optional Position position_supplementary = 10;
 
     // Definition of supplementary sign types.
-    // See \c OSI::TrafficSign.Type for further information.
+    // See \c TrafficSign::Type for further information.
     enum Type
     {
         // Type of supplementary sign is unknown (must not be used in ground
@@ -766,7 +832,7 @@ message TrafficLight
     // The IDs of the lanes that the traffic light is assigned to.
     // Might be multiple if the traffic light is valid for multiple driving
     // lanes.
-    repeated Identifier assigned_lane = 7;
+    repeated Identifier assigned_lanes = 7;
 
     // Definition of traffic light types.
     //
@@ -958,8 +1024,8 @@ message TrafficLight
 //
 // \brief A road surface marking.
 // 
-// Lane markings are excluded and defined as \c OSI::LaneBoundary messages 
-// as part of the \c OSI::Lanes .
+// Lane markings are excluded and defined as \c LaneBoundary messages 
+// as part of the \c Lanes .
 //
 // All coordinates and orientations are relative to the global ground truth
 // coordinate system.
@@ -1026,7 +1092,7 @@ message RoadMarking
 
     // The ID(s) of the lane(s) that the road marking is assigned to.
     // May be multiple if the road marking goes across multiple lanes.
-    repeated Identifier assigned_lane = 9;
+    repeated Identifier assigned_lanes = 9;
 
     // Definition of road marking types.
     //

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -27,14 +27,15 @@ message Lane
 {
     // The ID of the lane.
     // Example: 3 (see reference picture).
+    //
     // \note Note ID is global unique.
     optional Identifier id = 1;
 
     // The type of the lane.
-    // Example: Lane::Type::NORMAL (see reference picture)
+    // Example: \c Lane::type = \c Type::TYPE_DRIVING (see reference picture)
     optional Type type = 2;
 
-    // The lane's center line.
+    // The lane's center line (as a list of segments).
     //
     // This is the line, that a typical vehicle is supposed to follow. Thus, if
     // the road narrows (e.g. at a construction site) this line is supposed to
@@ -52,8 +53,8 @@ message Lane
     //
     // \image html line_approximation_error.png "Approximation error as green line."
     //
-    // \note The center_line is defined only for \c Lane::type = \c TYPE_DRIVING
-    // and one \c Lane::lane_pairing pair.
+    // \note The center_line is defined only for \c Lane::type =
+    // \c Type::TYPE_DRIVING and one \c Lane::lane_pairings pair.
     repeated Vector3d center_line = 3;
 
     // Definition of the intended driving direction.
@@ -65,7 +66,7 @@ message Lane
     // line points.
     //
     // \note The center_line_is_driving_direction is defined for \c Lane::type =
-    // TYPE_DRIVING.
+    // \c Type::TYPE_DRIVING .
     optional bool center_line_is_driving_direction = 4;
 
     // List of IDs of all lane segments that are directly adjacent to the lane 
@@ -77,8 +78,8 @@ message Lane
     // the reference picture.
     //
     // \note The left_adjacent_lane_id is undefined for \c Lane::type =
-    // TYPE_INTERSECTION.
-    repeated Identifier left_adjacent_lane_id = 5;
+    // \c Type::TYPE_INTERSECTION .
+    repeated Identifier left_adjacent_lane_id_list = 5;
 
     // List of IDs of all lane segments that are directy adjacent to the lane on
     // the right side (w.r.t. intended driving direction). Note that lengths of 
@@ -90,8 +91,8 @@ message Lane
     // 7.
     //
     // \note The right_adjacent_lane_id is undefined for \c Lane::type = 
-    // TYPE_INTERSECTION.
-    repeated Identifier right_adjacent_lane_id = 6;
+    // \c Type::TYPE_INTERSECTION .
+    repeated Identifier right_adjacent_lane_id_list = 6;
 
     // The antecessor/successor lane pairings of this lane. There can be
     // multiple pairings with the same antecessor and different successor lanes
@@ -99,27 +100,27 @@ message Lane
     // The antecessor lanes end in the same point that this lane starts from.
     // The successor lanes start in the same point that this lane ends in.
     // Example:
-    repeated LanePairing lane_pairing = 7;
+    repeated LanePairing lane_pairings = 7;
 
     // The ID of the right boundary ID of the right lane ID w.r.t. the driving
     // direction. Empty for intersections.
     //
     // \note The right_lane_boundary_id is undefined for \c Lane::type =
-    // TYPE_INTERSECTION.
-    repeated Identifier right_lane_boundary_id = 8;
+    // \c Type::TYPE_INTERSECTION .
+    repeated Identifier right_lane_boundary_id_list = 8;
 
     // The ID of the left boundary ID of the left lane ID w.r.t. the driving
     // direction. Empty for intersections.
     //
     // \note The left_lane_boundary_id is udefined for \c Lane::type =
-    // TYPE_INTERSECTION.
-    repeated Identifier left_lane_boundary_id = 9;
+    // \c Type::TYPE_INTERSECTION .
+    repeated Identifier left_lane_boundary_id_list = 9;
 
     // The ID of the free boundary ID.
     //
-    // \note Lanes with \c Lane::type = TYPE_INTERSECTION use only free lane
-    // boundaries
-    repeated Identifier free_lane_boundary_id = 10;
+    // \note Lanes with \c Lane::type = \c Type::TYPE_INTERSECTION use only free
+    // lane boundaries.
+    repeated Identifier free_lane_boundary_id_list = 10;
 
     // A lane framing describes the surroundings of the lane segment.
     //
@@ -184,19 +185,23 @@ message Lane
     message RoadCondition
     {
         // The temperature of the roads surface in Kelvin.
+        //
         // Unit: [K]
         optional double surface_temperature = 1;
 
         // The height of the water film on top of the surface in mm.
+        //
         // Unit: [mm]
         optional double surface_water_film = 2;
 
         // The temperature where the water on top of the surface would start
         // to freeze or dew in Kelvin.
+        //
         // Unit: [K]
         optional double surface_freezing_point = 3;
 
         // The percentage of ice covering the road.
+        //
         // Unit: [%]
         optional double surface_ice = 4;
 
@@ -279,18 +284,19 @@ message LaneBoundary
     //
     optional Identifier id = 1;
 
-    // The list of individual points defining the location of the lane boundary.
+    // The list of individual points defining the location of the lane boundary
+    // (as a list of segments).
     //
-    // Since a \c OSI::BoundaryPoint is part of a sequence, only the position
+    // Since a \c BoundaryPoint is part of a sequence, only the position
     // attribute has to be set for each instance. All other values will be
-    // reused from the previous \c OSI::BoundaryPoint in the sequence or set to
+    // reused from the previous \c BoundaryPoint in the sequence or set to
     // default values if there is none or it was never set. For dashed lines,
-    // one \c OSI::BoundaryPoint has to be at the start and another at the end
+    // one \c BoundaryPoint has to be at the start and another at the end
     // of each dashed line segment. For Botts' dots lines, one 
-    // \c OSI::BoundaryPoint position has to define each Botts' dot.
+    // \c BoundaryPoint position has to define each Botts' dot.
     //
-    // \attention For \c OSI::BoundaryPoint the same rules regarding maximum 
-    // distance and approximation error apply as for \c OSI::Lane::center_line.
+    // \attention For \c BoundaryPoint the same rules regarding maximum 
+    // distance and approximation error apply as for \c Lane::center_line.
     repeated BoundaryPoint boundary_line = 2;
 
     // The type of the lane boundary.
@@ -355,7 +361,7 @@ message LaneBoundary
 
     // The color of the lane boundary in case of a lane markings.
     // Lane markings that alternate in color must be represented by individual
-    // \c OSI::LaneBoundary segments.
+    // \c LaneBoundary segments.
     enum Color
     {
         // Color of marking is unknown. Value must not be used in ground truth.
@@ -402,23 +408,23 @@ message LaneBoundary
 //
 message BoundaryPoint
 {
-    // The position of the \c OSI::BoundaryPoint.
+    // The position of the \c BoundaryPoint.
     //
     optional Vector3d position = 1;
 
     // The overall width of the lane boundary at the position of the
-    // \c OSI::BoundaryPoint.
+    // \c BoundaryPoint .
     // Used for lines forming lane markings.
     //
     // \note Field need not be set if it is defined previous. 
-    // See \c OSI::LaneBoundary.
+    // See \c LaneBoundary.
     optional double boundary_width = 2;
 
     // The overall height of the lane boundary at the position of the
-    // \c OSI::BoundaryPoint.
+    // \c BoundaryPoint .
     // Used for guard rails, curbstone, or similar.
     //
     // \note Field need not be set if it is defined previous.
-    // See \c OSI::LaneBoundary.
+    // See \c LaneBoundary .
     optional double boundary_height = 3;
 }

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -277,7 +277,7 @@ message MovingObject
 
 //
 // \brief A simulated object that is neither a moving object (vehicle or 
-// \c OSI::MovingObject e.g. pedestrian or animal) nor a stationary object 
+// \c MovingObject e.g. pedestrian or animal) nor a stationary object 
 // (traffic sign, traffic light).
 //
 // StationaryObject excludes traffic lights and traffic signs

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -15,12 +15,14 @@ import "osi_hostvehicledata.proto";
 package osi;
 
 //
-// \brief The virtual sensor information derived from GroundTruth and potentially processed by sensor-models.
+// \brief The virtual sensor information derived from \c GroundTruth and 
+// potentially processed by sensor-models.
 //
-// The virtual sensor information is supposed to imitate the output of a real sensor. All information regarding the
-// environment is given with respect to the sensor coordinate system specified in \c SensorData::mounting_position. 
-// When simulating multiple sensors, each sensor has an individual copy of the SensorData interface. This allows an
-// independent treatment of the sensors.
+// The virtual sensor information is supposed to imitate the output of a real 
+// sensor. All information regarding the environment is given with respect to 
+// the sensor coordinate system specified in \c SensorData::mounting_position. 
+// When simulating multiple sensors, each sensor has an individual copy of the 
+// \c SensorData interface. This allows an independent treatment of the sensors.
 //
 message SensorData
 {  
@@ -43,7 +45,7 @@ message SensorData
     // The time that the actual measurement was performed (which will usually
     // correspond with the timestamp of the GroundTruth the sensor model
     // processed to arrive at these results) can be found in the additional
-    // field SensorData::last_measurement_time.
+    // field \c SensorData::last_measurement_time.
     //
     // For an ideal zero latency sensor the two timestamps would be the same
     // and would correspond with the timestamp from the current GroundTruth
@@ -100,9 +102,9 @@ message SensorData
     // The timestamp of the last real-world measurement (e.g. GT input) that
     // this set of sensor data takes into account.  This in effect is the last
     // time instance of reality the measurements correspond to.  See field
-    // SensorData::timestamp for a detailed discussion.  This value is also
-    // the upper bound to the DetectedObjectHeader::measurement_time and the
-    // feature data DetectionHeader::measurement_time fields.
+    // \c SensorData::timestamp for a detailed discussion.  This value is also
+    // the upper bound to the \c DetectedObjectHeader::measurement_time and the
+    // feature data \c SensorDetectionHeader::measurement_time fields.
     // 
     optional Timestamp last_measurement_time = 8;
     

--- a/osi_sensorspecific.proto
+++ b/osi_sensorspecific.proto
@@ -7,17 +7,20 @@ import "osi_common.proto";
 package osi;
 
 //
-// \brief Message encapsulates all data for detected objects that is specific to radar sensors.
+// \brief Message encapsulates all data for detected objects that is specific to
+// radar sensors.
 //
 message RadarSpecificObjectData
 {
-    // The radar cross section (RCS) of the detected object. Unit: [dB m^2].
+    // The radar cross section (RCS) of the detected object. 
     //
+    // Unit: [dB m^2]
     optional double rcs = 1;
 }
 
 //
-// \brief Message encapsulates all data for detected objects that is specific to lidar sensors.
+// \brief Message encapsulates all data for detected objects that is specific to
+// lidar sensors.
 //
 message LidarSpecificObjectData
 {
@@ -25,7 +28,8 @@ message LidarSpecificObjectData
 }
 
 //
-// \brief Message encapsulates all data for detected objects that is specific to camera sensors.
+// \brief Message encapsulates all data for detected objects that is specific to
+// camera sensors.
 //
 message CameraSpecificObjectData
 {
@@ -33,7 +37,8 @@ message CameraSpecificObjectData
 }
 
 //
-// \brief Message encapsulates all data for detected objects that is specific to ultrasonic sensors.
+// \brief Message encapsulates all data for detected objects that is specific to
+// ultrasonic sensors.
 //
 message UltrasonicSpecificObjectData
 {

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -21,7 +21,7 @@ message SensorView
 
     // The data timestamp of the simulation environment. Zero time is arbitrary
     // but must be identical for all messages. Zero time does not need to
-    // coincide with the unix epoch. Recommended is the starting time point of
+    // coincide with the UNIX epoch. Recommended is the starting time point of
     // the simulation.
     //
     // \note For sensor view data this timestamp coincides both with the
@@ -51,8 +51,8 @@ message SensorView
 // \brief Radar Sensor View
 //
 // Radar-Specific Sensor View Data
-message RadarSensorView {
-    
+message RadarSensorView 
+{
     // Radar Input Configuration valid at the time the data was created
     //
     optional RadarSensorInputConfiguration radar_sensor_input_configuration = 1;
@@ -62,31 +62,35 @@ message RadarSensorView {
     // This field includes one entry for each ray, in left-to-right,
     // top-to-bottom order (think scan lines in a TV).
     //
-    repeated Reflection reflection = 2;
+    repeated Reflection reflections = 2;
 
     //
     // \brief The radar reflection.
     //    
-    message Reflection {
+    message Reflection 
+    {
         // Relative signal level of the reflection
         //
         // This takes the combined_antenna_diagram (losses in TX and RX)
         // as well as the signal losses due to scattering and absorption
         // into account, and will, when multiplied by TX power yield the
         // actual RX power.
+        //
         // Unit: [dB]
         optional double signal_strength = 1;
         
         // Time of flight
         //
         // This is the time of flight of the reflection, which is directly
-        // proportional to the distance travelled. 
+        // proportional to the distance traveled. 
+        //
         // Unit: [s]
         optional double time_of_flight = 2;
         
         // Doppler shift
         //
         // Shift in frequency based on the specified TX frequency
+        //
         // Unit: [Hz]
         optional double doppler_shift = 3;
         
@@ -94,6 +98,7 @@ message RadarSensorView {
         //
         // Horizontal angle of incidence of the source of the reflection
         // at the TX antenna.
+        //
         // Unit: [rad]
         optional double source_horizontal_angle = 4;
         
@@ -101,6 +106,7 @@ message RadarSensorView {
         //
         // Vertical angle of incidence of the source of the reflection
         // at the TX antenna.
+        //
         // Unit: [rad]
         optional double source_vertical_angle = 5;
     }
@@ -110,8 +116,8 @@ message RadarSensorView {
 // \brief Lidar Sensor View
 //
 // Lidar-Specific Sensor View Data
-message LidarSensorView {
-
+message LidarSensorView 
+{
     // Lidar Input Configuration valid at the time the data was created
     //
     optional LidarSensorInputConfiguration lidar_sensor_input_configuration = 1;
@@ -126,26 +132,30 @@ message LidarSensorView {
     //
     // \brief The lidar reflection.
     //
-    message Reflection {
+    message Reflection 
+    {
         // Relative signal level of the reflection
         //
         // This takes the combined_antenna_diagram (losses in TX and RX)
         // as well as the signal losses due to scattering and absorption
         // into account, and will, when multiplied by TX power yield the
         // actual RX power.
+        //
         // Unit: [dB]
         optional double signal_strength = 1;
             
         // Time of flight
         //
         // This is the time of flight of the reflection, which is directly
-        // proportional to the distance travelled. 
+        // proportional to the distance traveled. 
+        //
         // Unit: [s]
         optional double time_of_flight = 2;
             
         // Doppler shift
         //
         // Shift in frequency based on the specified TX frequency
+        //
         // Unit: [Hz]
         optional double doppler_shift = 3;
     }
@@ -155,7 +165,8 @@ message LidarSensorView {
 // \brief Camera Sensor View
 //
 // Camera-Specific Sensor View Data
-message CameraSensorView {
+message CameraSensorView 
+{
     
     // Camera Input Configuration valid at the time the data was created
     //
@@ -173,7 +184,8 @@ message CameraSensorView {
 // \brief Ultrasonic Sensor View
 //
 // Ultrasonic-Specific Sensor View Data
-message UltrasonicSensorView {
+message UltrasonicSensorView 
+{
 
     // Ultrasonic Input Configuration valid at the time the data was created
     //


### PR DESCRIPTION
This PR addresses issue #97.

Review doxygen links.
Review documentation layout in proto (80 chars).
Review doxgen commands.
Remove typos
**Rename DetectionHeader --> SensorDetectionHeader**

Review TrafficSignTyps and **add some traffic signs.**
Add references to traffic sign images.
**Generalize traffic signs** (30km/h zone --> speed limit zone & value & value_unit)

Rename **repeated field names (plural or list as suffix).**
Add units to message field documentation.