### PR TITLE
Interface version removed in messages (issue #165)

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -32,11 +32,6 @@ message FeatureData
 //
 message SensorDetectionHeader
 {
-    // Version number of used detection list messages ( \c SensorDetectionHeader, 
-    // \c LidarDetection, \c LidarDetectionList etc.).
-    // 
-    optional DetectionInterfaceVersion version = 1;
-
     // Time stamp at which the measurement was taken (not the time at which it
     // was processed or at which it is transmitted) in the global synchronized
     // time.
@@ -130,25 +125,6 @@ message SensorDetectionHeader
         // Sensor temporary available.
         //
         DATA_QUALIFIER_TEMPORARY_AVAILABLE = 6;
-    }
-
-    //
-    // \brief Version of detection messages ( \c SensorDetectionHeader, 
-    // \c LidarDetection, \c LidarDetectionList etc.).
-    //
-    message DetectionInterfaceVersion
-    {
-        // Major version number.
-        //
-        optional uint32 version_major = 1;
-        
-        // Minor version number.
-        //
-        optional uint32 version_minor = 2;
-        
-        // Patch version number.
-        //
-        optional uint32 version_patch = 3;
     }
 }
 

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -15,10 +15,6 @@ package osi;
 //
 message SensorView
 {
-    // The interface version used by the sender (simulation environment).
-    //
-    optional InterfaceVersion version = 1;
-
     // The data timestamp of the simulation environment. Zero time is arbitrary
     // but must be identical for all messages. Zero time does not need to
     // coincide with the UNIX epoch. Recommended is the starting time point of


### PR DESCRIPTION
Remove OSI interface version in messages. The interface version is not necessary due to the compatibility requirements of the OSI versioning.