### PR TITLE
Add OSI Version field to all top-level messages

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -6,6 +6,7 @@ import "osi_common.proto";
 
 package osi;
 
+import "osi_version.proto";
 //
 // \brief Interface for sensor data, in contrast to interpreted data after 
 // object hypothesis and tracking.
@@ -18,6 +19,11 @@ package osi;
 //
 message FeatureData
 {
+
+    // The interface version used by the sender (simulation environment).
+    //
+    optional InterfaceVersion version = 1000;
+
     // Lidar detection list for multiple lidar sensors.
     //
     repeated LidarDetectionList multiple_lidar_detections = 1;
@@ -32,11 +38,6 @@ message FeatureData
 //
 message SensorDetectionHeader
 {
-    // Version number of used detection list messages ( \c SensorDetectionHeader, 
-    // \c LidarDetection, \c LidarDetectionList etc.).
-    // 
-    optional DetectionInterfaceVersion version = 1;
-
     // Time stamp at which the measurement was taken (not the time at which it
     // was processed or at which it is transmitted) in the global synchronized
     // time.
@@ -130,25 +131,6 @@ message SensorDetectionHeader
         // Sensor temporary available.
         //
         DATA_QUALIFIER_TEMPORARY_AVAILABLE = 6;
-    }
-
-    //
-    // \brief Version of detection messages ( \c SensorDetectionHeader, 
-    // \c LidarDetection, \c LidarDetectionList etc.).
-    //
-    message DetectionInterfaceVersion
-    {
-        // Major version number.
-        //
-        optional uint32 version_major = 1;
-        
-        // Minor version number.
-        //
-        optional uint32 version_minor = 2;
-        
-        // Patch version number.
-        //
-        optional uint32 version_patch = 3;
     }
 }
 

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -11,6 +11,7 @@ import "osi_groundtruth.proto";
 import "osi_sensorview.proto";
 import "osi_featuredata.proto";
 import "osi_hostvehicledata.proto";
+import "osi_version.proto";
 
 package osi;
 
@@ -26,6 +27,10 @@ package osi;
 //
 message SensorData
 {  
+    // The interface version used by the sender (simulation environment).
+    //
+    optional InterfaceVersion version = 1100;
+
     // The ID of the sensor at host vehicle's mounting_position.
     //
     // This ID can equal \c DetectionHeader::sensor_id, if SensorData holds only

--- a/osi_sensorinputconfiguration.proto
+++ b/osi_sensorinputconfiguration.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 option optimize_for = SPEED;
 
 import "osi_common.proto";
+import "osi_version.proto";
 
 package osi;
 
@@ -63,6 +64,10 @@ package osi;
 //
 message SensorInputConfiguration
 {
+    // The interface version used by the sender (simulation environment).
+    //
+    optional InterfaceVersion version = 1100;    
+    
     // The mounting position of the sensor (origin and orientation of the sensor
     // coordinate system) given in vehicle coordinates [1].
     //


### PR DESCRIPTION
This PR addresses issue #165.
This PR is in contradiction to PR #169. PR #169 would be obsolete.

Add OSI version message to all top-level messages and remove local version message (from SensorDetectionHeader, because FeatureData message is top-level message)