### PR TITLE
Generic Sensor Sub Views and Timestamps

### DIFF
--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -111,29 +111,47 @@ message SensorView
     //
     optional Identifier host_vehicle_id = 8;
 
+    // Generic SensorView(s).
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated GenericSensorView generic_sensor_view = 1000;
+
     // Radar-specific SensorView(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated RadarSensorView radar_sensor_view = 1000;
+    repeated RadarSensorView radar_sensor_view = 1001;
 
     // Lidar-specific SensorView(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated LidarSensorView lidar_sensor_view = 1001;
+    repeated LidarSensorView lidar_sensor_view = 1002;
 
     // Camera-specific SensorView(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated CameraSensorView camera_sensor_view = 1002;
+    repeated CameraSensorView camera_sensor_view = 1003;
 
     // Ultrasonic-specific SensorView(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated UltrasonicSensorView ultrasonic_sensor_view = 1003;
+    repeated UltrasonicSensorView ultrasonic_sensor_view = 1004;
+}
+
+//
+// \brief Definition of the generic sensor view.
+//
+// Generic sensor view data.
+//
+message GenericSensorView
+{
+    // Generic view configuration valid at the time the data was created.
+    //
+    optional GenericSensorViewConfiguration view_configuration = 1;
 }
 
 //

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -150,7 +150,7 @@ message SensorViewConfiguration
     // Unit: [s]
     // \note In the case of FMU packaging this will correspond to the
     // communication step size.
-    optional double update_cycle_time = 8;
+    optional Timestamp update_cycle_time = 8;
 
     // Initial update cycle offset of the sensor model.
     //
@@ -170,7 +170,7 @@ message SensorViewConfiguration
     // simulation start times, e.g. for partial resimulation.
     //
     // Unit: [s]
-    optional double update_cycle_offset = 9;
+    optional Timestamp update_cycle_offset = 9;
 
     // Simulation Start time
     //
@@ -179,7 +179,7 @@ message SensorViewConfiguration
     // the sensor model.
     //
     // Unit: [s]
-    optional double simulation_start_time = 10;
+    optional Timestamp simulation_start_time = 10;
 
     // Generic SensorView Configuration(s).
     //

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -181,29 +181,101 @@ message SensorViewConfiguration
     // Unit: [s]
     optional double simulation_start_time = 10;
 
+    // Generic SensorView Configuration(s).
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated GenericSensorViewConfiguration generic_sensor_view_configuration = 1000;
     // Radar-specific SensorView Configuration(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated RadarSensorViewConfiguration radar_sensor_view_configuration = 1000;
+    repeated RadarSensorViewConfiguration radar_sensor_view_configuration = 1001;
 
     // Lidar-specific SensorView Configuration(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated LidarSensorViewConfiguration lidar_sensor_view_configuration = 1001;
+    repeated LidarSensorViewConfiguration lidar_sensor_view_configuration = 1002;
 
     // Camera-specific SensorView Configuration(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated CameraSensorViewConfiguration camera_sensor_view_configuration = 1002;
+    repeated CameraSensorViewConfiguration camera_sensor_view_configuration = 1003;
 
     // Ultrasonic-specific SensorView Configuration(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated UltrasonicSensorViewConfiguration ultrasonic_sensor_view_configuration = 1003;
+    repeated UltrasonicSensorViewConfiguration ultrasonic_sensor_view_configuration = 1004;
+}
+
+//
+// \brief The configuration settings for the Generic Sensor View to be provided
+// by the environment simulation.
+//
+message GenericSensorViewConfiguration
+{
+    // The ID of the sensor at host vehicle's mounting_position.
+    //
+    // This is the ID of the physical sensor, to be used in its detected
+    // features output; it is distinct from the ID of its virtual sensor.
+    //
+    // The ID is to be provided by the environment simulation, the sensor
+    // model is not in a position to provide a useful default value.
+    //
+    optional Identifier sensor_id = 1;
+
+    // The physical mounting position of the sensor (origin and orientation
+    // of the sensor coordinate system) given in vehicle coordinates [1].
+    // The physical position pertains to this detector individually, and
+    // governs the sensor-relative coordinates in features detected by this
+    // detector.
+    //
+    // \arg \b x-direction of sensor coordinate system: sensor viewing direction
+    // \arg \b z-direction of sensor coordinate system: sensor (up)
+    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z
+    // right hand system
+    //
+    // \par References:
+    // [1] DIN ISO 8855:2013-11
+    //
+    // \note The origin of vehicle's coordinate system in world frame is
+    // ( \c Vehicle::base.position + Inverse_Rotation_yaw_pitch_roll(
+    // \c Vehicle::base.orientation) * \c Vehicle::bbcenter_to_rear ).
+    // The orientation of the vehicle's coordinate system is equal to the
+    // orientation of the vehicle's bounding box \c Vehicle::base.orientation.
+    // \note A default position can be provided by the sensor model (e.g. to
+    // indicate the position the model was validated for),
+    // but this is optional; the environment simulation must provide a valid
+    // mounting position (based on the vehicle configuration) when setting the
+    // view configuration.
+    //
+    optional MountingPosition mounting_position = 2;
+
+    // The root mean squared error of the mounting position.
+    //
+    optional MountingPosition mounting_position_rmse = 3;
+
+    // Field of View in horizontal orientation of the physical sensor.
+    //
+    // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
+    // azimuth in the sensor frame as defined in \c Spherical3d.
+    //
+    // Unit: [rad]
+    optional double field_of_view_horizontal = 4;
+
+    // Field of View in vertical orientation of the physical sensor.
+    //
+    // Viewing range: [-field_of_view_vertical/2, field_of_view_vertical/2]
+    // elevation in the sensor frame at zero azimuth as defined in
+    // \c Spherical3d.
+    //
+    // Unit: [rad]
+    optional double field_of_view_vertical = 5;
+
+    // TBD: Generic sensor specific configuration.
 }
 
 //
@@ -257,6 +329,7 @@ message RadarSensorViewConfiguration
     //
     // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
     // azimuth in the sensor frame as defined in \c Spherical3d.
+    //
     // Unit: [rad]
     optional double field_of_view_horizontal = 4;
 
@@ -388,6 +461,7 @@ message LidarSensorViewConfiguration
     //
     // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
     // azimuth in the sensor frame as defined in \c Spherical3d.
+    //
     // Unit: [rad]
     optional double field_of_view_horizontal = 4;
 
@@ -483,6 +557,7 @@ message CameraSensorViewConfiguration
     //
     // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
     // azimuth in the sensor frame as defined in \c Spherical3d.
+    //
     // Unit: [rad]
     optional double field_of_view_horizontal = 4;
 
@@ -520,6 +595,7 @@ message CameraSensorViewConfiguration
     // be one of the values the sensor model requested - or there
     // must be no value, indicating that the simulation environment
     // cannot provide image data in one of the requested formats.
+    //
     repeated ChannelFormat channel_format = 8;
 
     enum ChannelFormat {
@@ -639,6 +715,7 @@ message UltrasonicSensorViewConfiguration
     //
     // Viewing range: [-field_of_view_horizontal/2, field_of_view_horizontal/2]
     // azimuth in the sensor frame as defined in \c Spherical3d.
+    //
     // Unit: [rad]
     optional double field_of_view_horizontal = 4;
 


### PR DESCRIPTION
This PR adds generic sensor sub views (and sub configurations) to address physical sensors which either do not match the other technologies, or do not wish to use the services provided for those. This is a minimal PR, not splitting up ground-truth generation and making it view and sensor-coordinate specific.

This PR also addresses the use of doubles for times in SensorViewConfiguration, changing those to be Timestamps.