### PR TITLE
Add proto3 support via script to map file syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ script:
     - cd build
     - cmake --build . --target install
     - cd ..
+    - cp VERSION VERSION.SAVED
     - echo "" >> VERSION
     - echo "VERSION_PATCH = \"GitHub_MasterBranch\"" >> VERSION
     - cd build
@@ -82,6 +83,13 @@ script:
     - doxygen
     - cd ..
     - python test_cases_doc.py
+    - mv VERSION.SAVED VERSION
+    - sh convert-to-proto3.sh
+    - mkdir -p build3
+    - cd build3
+    - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
+    - cmake --build .
+    - cd ..
 
 # Deploy the documentation on github (only for master branch).
 deploy:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The compatibility of both recorded files and code remains.
 - Clarification of text passages explaining the message content
 
 
+Proto3 Support
+--------------
+
+For users that need to use proto3 syntax, for example because the language
+binding of choice only supports proto3 syntax out of the box, a shell script
+called `convert-to-proto3.sh` is supplied that converts all proto files to
+proto3 syntax. If this is run prior to building, the resulting libaries will
+use proto3, with the on-the-wire format remaining compatible between proto2
+and proto3 libraries.
+
 Packaging
 ---------
 

--- a/convert-to-proto3.sh
+++ b/convert-to-proto3.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This shell script converts all proto files to proto3 syntax, which can
+# then be used as a stand in for the proto2 syntax files. The resulting
+# on-the-wire format should be compatible with the proto2-based formats
+# in all respects.
+#
+# Call this script prior to building normally if you want/need to use
+# proto3 syntax, e.g. for language bindings that do not support proto2,
+# like C#.
+
+test -f osi_version.proto && rm osi_version.proto
+
+for f in osi_version.proto.in osi_*.proto
+do
+    mv $f $f.pb2 && sed -e 's/syntax *= *"proto2";/syntax = "proto3";/' -e 's/^\([ \t]*\)optional /\1/' $f.pb2 > $f
+done
+
+mv CMakeLists.txt CMakeLists.txt.pb2 && sed -e 's/find_package(Protobuf 2.6.1 REQUIRED)/find_package(Protobuf 3.0.0 REQUIRED)/' CMakeLists.txt.pb2 > CMakeLists.txt


### PR DESCRIPTION
This change allows usage of the OSI definitions on proto3 syntax,
while remaining on-the-wire-compatible with the official proto2
syntax.

Note that Travis CI build is also amended to build both proto2
and proto3 versions so that portability fails will be detected early.