### PR TITLE
Add proj4 string to GroundTruth fixes #276

### DIFF
--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -131,4 +131,14 @@ message GroundTruth
     // - [2] [Wikipedia ISO 3166/1] (https://en.wikipedia.org/wiki/ISO_3166-1)
     //
     optional uint32 country_code = 13;
+
+    // Projection string that allows to transform all coordinates in GroundTruth
+    // into a different cartographic projection.
+    //
+    // The string follows the proj.4 project rules [1].
+    //
+    // \par References:
+    // - [1] [Proj.4 Projections] (https://proj4.org/usage/projections.html)
+    //
+    optional string proj_string = 16;
 }

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -140,5 +140,5 @@ message GroundTruth
     // \par References:
     // - [1] [Proj.4 Projections] (https://proj4.org/usage/projections.html)
     //
-    optional string proj_string = 16;
+    optional string proj_string = 14;
 }

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -135,7 +135,7 @@ message GroundTruth
     // Projection string that allows to transform all coordinates in GroundTruth
     // into a different cartographic projection.
     //
-    // The string follows the proj.4 project rules [1].
+    // The string follows the PROJ.4 project rules for projections [1].
     //
     // \par References:
     // - [1] [Proj.4 Projections] (https://proj4.org/usage/projections.html)


### PR DESCRIPTION
Using field number 16 because the projection string will not be a small field, so `14,15` can be used in future releases for `repeated` or smaller fields.