### PR TITLE
Added Emergency and Service vehicle illumination.

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -539,16 +539,16 @@ message MovingObject
             //
             optional BrakeLightState brake_light_state = 7;
 
-            // State of the (rear) license plate illumination
+            // State of the (rear) license plate illumination.
             //
             optional GenericLightState license_plate_illumination_rear = 8;
 
-            // Lighting of Emergency Vehicles (Ambulances, Fire Engines, Police, etc.) 
+            // Lighting of emergency vehicles (ambulance, fire engine, police car, etc.).
             // Must be set only if a vehicle is allowed to use this illumination type. 
             // 
             optional GenericLightState emergency_vehicle_illumination = 9;
 
-            // Lighting of Service Vehicles (Snow removal, garbage trucks, towing vehicles, slow or wide vehicles) 
+            // Lighting of service vehicles (snow removal, garbage truck, towing vehicle, slow or wide vehicle, etc.). 
             // Must be set only if a vehicle is allowed to use this illumination type. 
             // 
             optional GenericLightState service_vehicle_illumination = 10;
@@ -604,18 +604,18 @@ message MovingObject
                 //
                 GENERIC_LIGHT_STATE_ON = 3;
                 
-                // Light is flashing blue
-                // To be used for emergency vehicles
+                // Light is flashing blue.
+                // To be used for emergency vehicles.
                 //
                 GENERIC_LIGHT_STATE_FLASHING_BLUE = 4;
 
-                // Light is flashing blue and red
-                // To be used for emergency vehicles 
+                // Light is flashing blue and red.
+                // To be used for emergency vehicles.
                 //
                 GENERIC_LIGHT_STATE_FLASHING_BLUE_AND_RED = 5;
 
                 // Light is flashing amber. 
-                // To be used for service vehicles 
+                // To be used for service vehicles.
                 //
                 GENERIC_LIGHT_STATE_FLASHING_AMBER = 6;
             }

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -543,6 +543,16 @@ message MovingObject
             //
             optional GenericLightState license_plate_illumination_rear = 8;
 
+            // Lighting of Emergency Vehicles (Ambulances, Fire Engines, Police, etc.) 
+            // Must be set only if a vehicle is allowed to use this illumination type. 
+            // 
+            optional GenericLightState emergency_vehicle_illumination = 9;
+
+            // Lighting of Service Vehicles (Snow removal, garbage trucks, towing vehicles, slow or wide vehicles) 
+            // Must be set only if a vehicle is allowed to use this illumination type. 
+            // 
+            optional GenericLightState service_vehicle_illumination = 10;
+
             // Definition of indicator states.
             //
             enum IndicatorState
@@ -593,6 +603,21 @@ message MovingObject
                 // Light is on.
                 //
                 GENERIC_LIGHT_STATE_ON = 3;
+                
+                // Light is flashing blue
+                // To be used for emergency vehicles
+                //
+                GENERIC_LIGHT_STATE_FLASHING_BLUE = 4;
+
+                // Light is flashing blue and red
+                // To be used for emergency vehicles 
+                //
+                GENERIC_LIGHT_STATE_FLASHING_BLUE_AND_RED = 5;
+
+                // Light is flashing amber. 
+                // To be used for service vehicles 
+                //
+                GENERIC_LIGHT_STATE_FLASHING_AMBER = 6;
             }
 
             // Definition of brake light states.


### PR DESCRIPTION
The discussion in issue #294 

This pull request enables to patch missing emergency vehicle and service vehicle. 

The concept is as follows: **the fact that a vehicle is either emergency vehicle or a service vehicle can be inferred from the state of the light.** 

