### PR TITLE
Revert breakage in ce92c013 to CMake build of SO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ install(TARGETS ${PROJECT_NAME}_pic
         EXPORT ${PROJECT_NAME}_targets
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
-add_library(${PROJECT_NAME} STATIC $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
+add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}


### PR DESCRIPTION
Commit ce92c01340262e70674be02a65fbdcc4e983a96b changed the
open_simulation_interface target from being a shared library to a static
library (for which we already have the open_simulation_interface_static
target). This reverses that part of the patch.

This seems to be an inadvertant change that slipped through the cracks, and needs to be fixed quickly, since it breaks all users of the shared library (i.e. everyone building on Linux/Unix systems, and even some using the DLL on Windows).

This is an urgent fix, since this more or less breaks 3.1.0 for most consumers, so should be included in a quick 3.1.1 followup release (making the current 3.1.1 planned release a 3.1.2).