### PR TITLE
Improving coding style along with units

### DIFF
--- a/osi_adas_function.proto
+++ b/osi_adas_function.proto
@@ -157,7 +157,8 @@ message HadPilot
     // This is the speed the function targets.
     // E.g.: At the point of activation, the actual speed could be 80 km/h, 
     // but the function tries to accelerate to 130 km/h.
-    // In [km/h].
+    //
+    // Unit: [km/h]
     //
     optional double targeted_speed = 2;
 }
@@ -175,12 +176,14 @@ message LongitudinalControl
     // This is the speed the function targets.
     // E.g.: At the point of activation, the actual speed could be 80 km/h, 
     // but the function tries to accelerate to 130 km/h.
-    // In [km/h].
+    //
+    // Unit: [km/h]
     //
     optional double targeted_speed = 2;
 
     // The timegap describes the minimumdistance to the next vehicle in front.
-    // In [s].
+    //
+    // Unit: [s]
     //
     optional double timegap = 3;
 }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -435,20 +435,23 @@ message BaseMoving
 message Steeringwheel
 {
     // Angle of the steeringwheel. 
+    // 0=Central (Straight); Left>0; 0>Right.
     //
-    // Unit: [rad]: 0=Central (Straight); Left>0; 0>Right.
+    // Unit: [rad]
     //
     optional double angle = 1;
 
     // Angle-speed of the steeringwheel.
+    // 0=Central (Straight); Left>0; 0>Right.
     //
-    // Unit: [rad/s]: 0=Central (Straight); Left>0; 0>Right.
+    // Unit: [rad/s]
     //
     optional double angular_speed = 2;
 
     // Torque of the steeringwheel to the hand.
+    // 0=Central (Straight); Left>0; 0>Right.
     //
-    // Unit: [Nm]: 0=Central (Straight); Left>0; 0>Right.
+    // Unit: [N*m]
     //
     optional double torque = 3;
 }
@@ -482,7 +485,8 @@ message Pedalry
 message Trajectory
 {
     // Contains the timestamp where the trajectorypoint should be reached.
-    // In [s].
+    //
+    // Unit: [s]
     //
     optional Timestamp timestamp = 1;
 
@@ -495,27 +499,32 @@ message Trajectory
     optional double targeted_pos_y = 3;
 
     // Direction of the vehicle at the timestamp.
-    // In [Rad].
+    //
+    // Unit: [rad]
     //
     optional double trackangle = 4;
 
     // Contains the curvature at the timestamp.
-    // In [1/m].
+    //
+    // Unit: [1/m]
     //
     optional double curvature = 5;
 
     // Contains the curvaturechange at the timestamp.
-    // In [1/m*s].
+    //
+    // Unit: [1/m*s]
     //
     optional double curvaturechange = 6;
 
     // Contains the velocity of the vehicle at the timestamp.
-    // In [m/s].
+    //
+    // Unit: [m/s]
     //
     optional double velocity = 7;
 
     // Contains the acceleration of the vehicle at the timestamp.
-    // In [m/s^2].
+    //
+    // Unit: [m/s^2]
     //
     optional double acceleration = 8;
 

--- a/osi_driver_inputs.proto
+++ b/osi_driver_inputs.proto
@@ -67,6 +67,8 @@ message DriverInputs
         // Position of the handbrake.
         // 0-100 (percentage of position: Released - fully pressed)
         //
+        // Unit: [%]
+        //
         optional double handbrake = 8;
 
         // Position of the gearlever.

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -57,8 +57,10 @@ message EnvironmentalConditions
     optional double wind_speed = 8;
 
     // Contains the direction of the wind (global weather).
-    // In [Degree]. Wind direction is measured in degrees clockwise from due north.
-    // Like on a windrose. E.g.: A wind blowing from the north has a wind direction of 0 Degree.
+    // Wind direction is measured in degrees clockwise from due north.
+    // Like on a windrose. E.g.: A wind blowing from the north has a wind direction of 0°.
+    //
+    // Unit: [deg]
     //
     optional double wind_direction = 9;
 

--- a/osi_vehicle.proto
+++ b/osi_vehicle.proto
@@ -115,21 +115,31 @@ message OsiVehicle
 
         // Rounds per minute of the crankshaft.
         //
+        // Unit: [1/min]
+        //
         optional double engine_rpm = 2;
 
         // Torque in Nm.
+        //
+        // Unit: [N*m]
         //
         optional double engine_torque = 3;
 
         // Consumption in liters per 100 km.
         //
+        // Unit: [l]
+        //
         optional double engine_consumption = 4;
 
         // Consumption in liters per 100 km.
         //
+        // Unit: [l]
+        //
         optional double fuel_consumption = 4;
 
-        // Consumption of electrical or hybrid vehicle 
+        // Consumption of electrical or hybrid vehicle per 100 km
+        //
+        // Unit: [kWh]
         //
         optional double electrical_energy_consumption = 5;
 
@@ -154,15 +164,21 @@ message OsiVehicle
         //
         optional Steeringwheel steeringwheel = 1;
 
-        // Spring-stiffness of the steering in Nm/Deg.
+        // Spring-stiffness of the steering in Nm/deg.
+        //
+        // Unit: [N*m/deg]
         //
         optional double stw_springstiffness = 2;
 
-        // Damping of the steering in Nm*s/Deg.
+        // Damping of the steering in Nm*s/deg.
+        //
+        // Unit: [N*m*s/deg]
         //
         optional double stw_damping = 3;
 
         // Friction of the steering in Nm.
+        //
+        // Unit: [N*m]
         //
         optional double stw_friction = 4;
     }
@@ -200,37 +216,47 @@ message OsiVehicle
         // Contains the friction-coefficient of each wheel.
         // Dimensionless.
         //
+        // Unit: []
+        //
         optional double friction_coefficient = 1;
 
         // Contains the z-coordinate (contact-point) of each wheel.
         // Dimensionless.
         //
+        // Unit: []
+        //
         optional double contact_point = 2;
 
         // Contains the rotational speed of each wheel per second.
-        // In [Rad/s].
+        //
+        // Unit: [rad/s]
         //
         optional double rotational_speed = 3;
 
         // Contains the steering angle of each wheel.
-        // In [Rad].
+        //
+        // Unit: [rad]
         //
         optional double steeringangle = 4;
 
         // Contains the camber of each wheel.
-        // In [Rad].
+        // 
         // Negative camber if the bottom of the wheel is farther out than the top.
         // For more information: https://en.wikipedia.org/wiki/Camber_angle.
+        //
+        // Unit: [rad]
         //
         optional double camber = 5;
 
         // Contains the tirepressure of each tire.
-        // In [Pascal].
+        //
+        // Unit: [Pa]
         // 
         optional double tirepressure = 6;
 
         // Contains the springdeflection in z-direction for each wheel.
-        // In [mm].
+        //
+        // Unit: [mm]
         //
         optional double springdeflection = 7;
     }


### PR DESCRIPTION
Still need to be checked:

Do we let a redundancy in the comment? For example:

```
        // Consumption in liters per 100 km.
        //
        // Unit: [l]
```

I would say "too much is better than not enough", and it is not very annoying or disagreeing with any coding style.