### PR TITLE
Extension adas vehicle driver inputs

### DIFF
--- a/osi_adas_function.proto
+++ b/osi_adas_function.proto
@@ -47,16 +47,20 @@ message AdasFunction
         optional EmergencyBrakeAssistant emergency_brake_assistant = 4;
 
         // Request that the driver has to take over.
-        // 0=Off; 1=On
+        //
+        // \note 0 = off; 1 = on.
         //
         optional bool driver_take_over_request = 5;
 
         // Color of the steering wheel (e.g. to show the driving mode).
-        // See osi_common_extension.
+        //
+        // \note See osi_common_extension.
         // 
         optional ColorformatRGB steering_wheel_lighting_color = 6;
 
-        // Requested state of the blindspot-lights (often in the side mirrors).
+        // Requested state of the blindspot-lights.
+        //
+        // \note Often visible in the side mirrors.
         //
         optional BlindSpotWarning blind_spot_warning = 7;
 
@@ -64,21 +68,30 @@ message AdasFunction
         //
         enum BlindSpotWarning
         {
+            // The state of the blind spot warning is unknown
+            // (must not be unsed in ground truth).
+            //
+            BLIND_SPOT_WARNING_UNKNOWN = 0;
+            
+            // Other (unspecified but known) blind spot warning.
+            //
+            BLIND_SPOT_WARNING_OTHER = 1;
+            
             // No warning.
             //
-            BLIND_SPOT_WARNING_NONE = 0;
+            BLIND_SPOT_WARNING_NONE = 2;
 
             // Left warning.
             //
-            BLIND_SPOT_WARNING_LEFT = 1;
+            BLIND_SPOT_WARNING_LEFT = 3;
 
             // Right warning.
             //
-            BLIND_SPOT_WARNING_RIGHT = 2;
+            BLIND_SPOT_WARNING_RIGHT = 4;
 
             // Warning on both sides.
             //
-            BLIND_SPOT_WARNING_BOTH = 3;
+            BLIND_SPOT_WARNING_BOTH = 5;
         }
     }
 
@@ -93,31 +106,36 @@ message AdasFunction
     message FunctionRequests
     {
         // All information about the trajectory the vehicle should follow.
-        // See osi_common_extension.
+        //
+        // \note See osi_common_extension.
         //
         optional Trajectory trajectory = 1;
 
         // Angle, angle-speed and torque.
-        // See osi_common_extension.
+        //
+        // \note See osi_common_extension.
         //
         optional SteeringWheel steering_wheel = 2;
 
         // Factor to scale the steeringtorque of the function output.
-        // 0 = no force of the function, 0.5 = half the force, 1 = 100% Torque
+        //
+        // \note 0 = no force of the function, 0.5 = half the force, 1 = 100% torque.
         //
         // Range: [0, 1] 
         //
         optional double steering_override_factor = 3;
 
         // Acceleration-, brakepedal and clutch.
-        // See osi_common_extension.
+        //
+        // \note See osi_common_extension.
         //
         optional Pedalry pedalry = 4;
 
         // Position of the handbrake.
-        // A value of 0% means fully released and 100% means fully pressed
         //
-        // Unit: [%]
+        // \note A value of 0.0 means fully released and 1.0 means fully pressed.
+        //
+        // Range: [0, 1] 
         //
         optional double handbrake_position = 5;
 
@@ -129,21 +147,30 @@ message AdasFunction
         //
         enum Indicators
         {
+            // The state of the indicator is unknown
+            // (must not be unsed in ground truth).
+            //
+            INDICATORS_UNKNOWN = 0;
+            
+            // Other (unspecified but known) indicator state.
+            //
+            INDICATORS_OTHER = 1;
+            
             // No indicator.
             //
-            INDICATORS_NONE = 0;
+            INDICATORS_NONE = 2;
 
             // Left-indicator.
             //
-            INDICATORS_LEFT = 1;
+            INDICATORS_LEFT = 3;
 
             // Right-indicator.
             //
-            INDICATORS_RIGHT = 2;
+            INDICATORS_RIGHT = 4;
 
             // Warning lights.
             //
-            INDICATORS_ALL = 3;
+            INDICATORS_ALL = 5;
         }
     }
 }

--- a/osi_adas_function.proto
+++ b/osi_adas_function.proto
@@ -100,10 +100,12 @@ message AdasFunction
         // Angle, angle-speed and torque.
         // See osi_common_extension.
         //
-        optional Steeringwheel steeringwheel = 2;
+        optional SteeringWheel steering_wheel = 2;
 
         // Factor to scale the steeringtorque of the function output.
-        // 0-1 (0 = no force of the function, 0.5 = half the force, 1 = 100% Torque).
+        // 0 = no force of the function, 0.5 = half the force, 1 = 100% Torque
+        //
+        // Range: [0, 1] 
         //
         optional double steering_override_factor = 3;
 
@@ -113,15 +115,17 @@ message AdasFunction
         optional Pedalry pedalry = 4;
 
         // Position of the handbrake.
-        // 0-100 (percentage of position: Released - fully pressed)
+        // A value of 0% means fully released and 100% means fully pressed
         //
-        optional double handbrake = 5;
+        // Unit: [%]
+        //
+        optional double handbrake_position = 5;
 
-        // This is a description of the possible indicatorstates.
+        // This is a description of the possible indicator states.
         //
         optional Indicators indicators = 6;
 
-        // This is a description of the possible indicatorstates.
+        // Description of the possible indicator states.
         //
         enum Indicators
         {
@@ -150,7 +154,7 @@ message AdasFunction
 //
 message HadPilot
 {
-    // Activationstate of the function.
+    // Activation state of the function.
     //
     optional bool is_activated = 1;
 
@@ -169,7 +173,7 @@ message HadPilot
 //
 message LongitudinalControl
 {
-    // Activationstate of the function.
+    // Activation state of the function.
     //
     optional bool is_activated = 1;
 
@@ -194,7 +198,7 @@ message LongitudinalControl
 //
 message LateralControl
 {
-    // Activationstate of the function.
+    // Activation state of the function.
     //
     optional bool is_activated = 1;
 }
@@ -205,7 +209,7 @@ message LateralControl
 //
 message EmergencyBrakeAssistant
 {
-    // Activationstate of the function.
+    // Activation state of the function.
     //
     optional bool is_activated = 1;
 }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -430,25 +430,25 @@ message BaseMoving
 }
 
 //
-// \brief A description for the steeringwheel.
+// \brief A description for the steering wheel.
 //
-message Steeringwheel
+message SteeringWheel
 {
-    // Angle of the steeringwheel. 
+    // Angle of the steering wheel. 
     // 0=Central (Straight); Left>0; 0>Right.
     //
     // Unit: [rad]
     //
     optional double angle = 1;
 
-    // Angle-speed of the steeringwheel.
+    // Angle-speed of the steering wheel.
     // 0=Central (Straight); Left>0; 0>Right.
     //
     // Unit: [rad/s]
     //
     optional double angular_speed = 2;
 
-    // Torque of the steeringwheel to the hand.
+    // Torque of the steering wheel to the hand.
     // 0=Central (Straight); Left>0; 0>Right.
     //
     // Unit: [N*m]
@@ -479,7 +479,8 @@ message Pedalry
 }
 
 //
-// \brief This is a message to describe, which trajectory the vehicle should follow.
+// \brief This is a message to describe, which trajectory the vehicle should
+// follow.
 //
 //
 message Trajectory
@@ -610,7 +611,8 @@ enum Gear
     //
     GEAR_P = 22;
 
-    // The car has an automatic transmission, but the driver shifts up by his own.
+    // The car has an automatic transmission, but the driver shifts up by his
+    // own.
     //
     GEAR_UP = 30;
 
@@ -618,7 +620,8 @@ enum Gear
     //
     GEAR_MID = 31;
 
-    // The car has an automatic transmission, but the driver shifts down by his own.
+    // The car has an automatic transmission, but the driver shifts down by his
+    // own.
     //
     GEAR_DOWN = 32;
 }

--- a/osi_driver_inputs.proto
+++ b/osi_driver_inputs.proto
@@ -15,7 +15,8 @@ package osi3;
 message DriverInputs
 {
     //
-    // The first set of signals are states the driver can (usually) directly set.
+    // The first set of signals are states the driver can (usually) directly
+    // set.
     //
     optional DriverInitializedStates driver_initialized_states = 1;
 
@@ -25,64 +26,66 @@ message DriverInputs
     optional DriverRequests driver_requests = 2;
 
     //
-    // \brief The first set of signals are states the driver can (usually) directly set.
+    // \brief The first set of signals are states the driver can (usually)
+    // directly set.
     //
     message DriverInitializedStates
     {
-        // State of the driver seat-belt. It is often an initial condition to start an ADAS-Function.
-        // 0=Open; 1=Closed
+        // State of the driver seat-belt. It is often an initial condition to
+        // start an ADAS-Function.
         //
-        optional bool seat_belt = 1;
+        optional bool is_seat_belt_fastened = 1;
 
-        // State of the doors. It is often an initial condition to start an ADAS-Function.
-        // 0=Open; 1=Closed
+        // State of the doors. It is often an initial condition to start an
+        // ADAS-Function.
         //
-        optional bool doors = 2;
+        optional bool are_doors_closed = 2;
 
-        // Hands-On-Detection.
-        // 0=HandsOff; 1=HandsOn
+        // Hands Off Detection.
         //
-        optional bool hands_on_detection = 3;
+        optional bool are_hands_off = 3;
 
-        // State of the ignition. It is often an initial condition to start an ADAS-Function.
-        // 0=Off; 1=On
+        // State of the ignition. It is often an initial condition to start an
+        // ADAS-Function.
         //
-        optional bool ignition = 4;
+        optional bool is_ignition_on = 4;
 
         // State of the warning lights.
-        // 0=Off; 1=On
         //
-        optional bool warning_lights = 5;
+        optional bool are_warning_lights_on = 5;
 
         // Angle, angle-speed and torque.
         // See osi_common_extension.
         //
-        optional Steeringwheel steeringwheel = 6;
+        optional SteeringWheel steering_wheel = 6;
 
-        // Acceleration-, brakepedal and clutch.
+        // Acceleration-, brake pedal and clutch.
         // See osi_common_extension.
         //
         optional Pedalry pedalry = 7;
 
         // Position of the handbrake.
-        // 0-100 (percentage of position: Released - fully pressed)
+        // A value of 0% means fully released and 100% means fully pressed
         //
         // Unit: [%]
         //
-        optional double handbrake = 8;
+        optional double handbrake_position = 8;
 
-        // Position of the gearlever.
+        // Position of the gear lever.
         // See osi_common_extension.
         //
         optional Gear gear_lever = 9;
     }
 
     // 
-    // \brief The second set of signals are requests addressed to an external function.
+    // \brief The second set of signals are requests addressed to an external
+    // function.
     // The ADAS-function can react to a request by setting its own states.
     // The osi_adas_function.proto is widely complementary to this proto.
-    // For e.g. the driver wants to activate a function, but the initial-conditions of the
-    // ADAS-function are not fullfilled, the request is without an effect to the driving behaviour.
+    // For e.g. the driver wants to activate a function, but the
+    // initial-conditions of the
+    // ADAS-function are not fullfilled, the request is without an effect to the
+    // driving behaviour.
     //
     message DriverRequests
     {
@@ -98,17 +101,16 @@ message DriverInputs
         //
         optional LateralControl lateral_control = 3;
 
-        // Wished states of the driver regarding the function Emergency-Brake-Assistant.
+        // Wished states of the driver regarding the function
+        // Emergency-Brake-Assistant.
         //
         optional EmergencyBrakeAssistant emergency_brake_assistant = 4;
 
         // Request to an ADAS-Function for a lane change.
-        // 0=EgoLane; 1=Left; 2=Right
         //
         optional LaneChangeRequest lane_change_request = 5;
 
         // Request to an ADAS-Function for a lane change.
-        // 0=EgoLane; 1=Left; 2=Right
         //
         enum LaneChangeRequest
         {

--- a/osi_vehicle.proto
+++ b/osi_vehicle.proto
@@ -7,9 +7,10 @@ import "osi_common.proto";
 package osi3;
 
 //
-// \brief Interface to the vehicle-model. So where the movement of a car is calculated, 
-// but also the behaviour of some components of the car itself.
-// Consists of four messages: VehicleKinematics, VehiclePowertrain, VehicleSteeringwheel and VehicleWheels.
+// \brief Interface to the vehicle-model. So where the movement of a car is
+// calculated, but also the behaviour of some components of the car itself.
+// Consists of four messages: VehicleKinematics, VehiclePowertrain,
+// VehicleSteeringWheel and VehicleWheels.
 //
 message OsiVehicle
 {
@@ -28,9 +29,9 @@ message OsiVehicle
 
     //
     // Interface to the vehicle-model.
-    // The focus here is on the steeringwheel.
+    // The focus here is on the steering wheel.
     //
-    optional VehicleSteeringwheel vehicle_steeringwheel = 3;
+    optional VehicleSteeringWheel vehicle_steering_wheel = 3;
 
     //
     // Interface to the vehicle-model.
@@ -39,7 +40,8 @@ message OsiVehicle
     optional VehicleWheels vehicle_wheels = 4;
 
     //
-    // \brief So this is the interface, that describes how the vehicle is moving.
+    // \brief So this is the interface, that describes how the vehicle is
+    // moving.
     // All coordinates and orientations are relative to the global ground truth
     // coordinate system.
     //
@@ -49,27 +51,28 @@ message OsiVehicle
         //
         optional Dimension3d dimension = 1;
 
-        // The reference point for position and orientation: the center (x,y,z) of
-        // the bounding box.
+        // The reference point for position and orientation: the center (x,y,z)
+        //of the bounding box.
         //
         optional Vector3d position = 2;
 
-        // The relative velocity of the moving object w.r.t. its parent frame and
-        // parent velocity.
-        // The velocity becomes global/absolute if the parent frame does not move.
+        // The relative velocity of the moving object w.r.t. its parent frame
+        // and parent velocity.
+        // The velocity becomes global/absolute if the parent frame does not
+        // move.
         //
         // <tt>#position (t) := #position (t-dt)+ #velocity *dt</tt>
         //
         optional Vector3d velocity = 3;
 
-        // The relative acceleration of the moving object w.r.t. its parent frame
-        // and parent acceleration.
+        // The relative acceleration of the moving object w.r.t. its parent
+        // frame and parent acceleration.
         // The acceleration becomes global/absolute if the parent frame is not
         // accelerating.
         //
-        // <tt> #position (t) := #position (t-dt)+ #velocity *dt+ #acceleration /2*dt^2</tt>
+        // <tt>#position (t) := #position (t-dt)+ #velocity *dt+ #acceleration /2*dt^2</tt>
         //
-        // <tt> #velocity (t) := #velocity (t-dt)+ #acceleration *dt</tt>
+        // <tt>#velocity (t) := #velocity (t-dt)+ #acceleration *dt</tt>
         //
         optional Vector3d acceleration = 4;
 
@@ -77,14 +80,14 @@ message OsiVehicle
         //
         // <tt>Origin_base_moving_entity := Rotation_yaw_pitch_roll(#orientation)*(Origin_parent_coordinate_system - #position)</tt>
         //
-        // \note There may be some constraints how to align the orientation w.r.t.
-        // to some stationary object's or entity's definition.
+        // \note There may be some constraints how to align the orientation
+        //w.r.t. to some stationary object's or entity's definition.
         //
         optional Orientation3d orientation = 5;
 
         // The relative orientation rate of the moving object w.r.t. its parent
-        // frame and parent orientation rate in the center point of the bounding box
-        // (origin of the bounding box frame).
+        // frame and parent orientation rate in the center point of the bounding
+        // box (origin of the bounding box frame).
         //
         // <tt>Rotation_yaw_pitch_roll(#orientation (t)) := Rotation_yaw_pitch_roll(#orientation_rate *dt)*Rotation_yaw_pitch_roll(#orientation (t-dt))</tt>
         //
@@ -92,9 +95,9 @@ message OsiVehicle
         //
         optional Orientation3d orientation_rate = 6;
 
-        // The relative orientation rate acceleration of the moving object w.r.t. its parent
-        // frame and parent orientation rate in the center point of the bounding box
-        // (origin of the bounding box frame).
+        // The relative orientation rate acceleration of the moving object
+        // w.r.t. its parent frame and parent orientation rate in the center
+        // point of the bounding box (origin of the bounding box frame).
         //
         // <tt>Rotation_yaw_pitch_roll(#orientation (t)) := Rotation_yaw_pitch_roll(#orientation_rate *dt)*Rotation_yaw_pitch_roll(#orientation (t-dt))</tt>
         //
@@ -148,21 +151,22 @@ message OsiVehicle
         optional Gear gear_gear_lever = 6;
         
         // The actual gear of the transmission.
-        // E.g. gear_lever can be in "D" and transmission in "4", but not the other way around.
+        // E.g. gear_lever can be in "D" and transmission in "4", but not the
+        // other way around.
         //
         optional Gear gear_transmission = 7;
     }
 
     //
     // \brief Interface to the vehicle-model.
-    // The focus here is on the steeringwheel.
+    // The focus here is on the steering wheel.
     //
-    message VehicleSteeringwheel
+    message VehicleSteeringWheel
     {
         // Angle, angle-speed and torque.
         // See osi_common_extension.
         //
-        optional Steeringwheel steeringwheel = 1;
+        optional SteeringWheel steering_wheel = 1;
 
         // Spring-stiffness of the steering in Nm/deg.
         //
@@ -241,7 +245,8 @@ message OsiVehicle
 
         // Contains the camber of each wheel.
         // 
-        // Negative camber if the bottom of the wheel is farther out than the top.
+        // Negative camber if the bottom of the wheel is farther out than the
+        // top.
         // For more information: https://en.wikipedia.org/wiki/Camber_angle.
         //
         // Unit: [rad]


### PR DESCRIPTION
I did some consistency updates that are, in my opinion, better choices in term of readability and _confuseless_ style.

- renamed `Steeringwheel` to `Steering Wheel` and Activationstate to `Activation state` (the proper English names), in _snake_case_ and _CapWord_,
- wrapped the lines to 80 characters as in the other .proto files,
- renamed boolean attribute to `is_...` and `are_...` to improve readability and reduce confusion,
- renamed `handbrake` attribute to `handbrake_position` to specify what is it about,
- change hand_on_detection to hand_**off**_detection, which is the right official name for this kind of system — that also reverse the boolean state. There is a choice to make between OSI-message consistency (_all the attributes need to be true to start the vehicle_) and reality consistency (_all the attributes need to conform to the state of reality_). I think the second choice is better to not confuse the user each time (s)he switches between OSI and sensor models for example.