### PR TITLE
Add proto3 syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,46 +61,113 @@ addons:
         - doxygen-gui
         - graphviz
 
-# Change directory back to default build directory.
-before_script:
-    - cd "${TRAVIS_BUILD_DIR}"
 
-# Run the build script and generate documentation.
-script:
-    - mkdir -p build
-    - cd build
-    - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install -D CMAKE_INSTALL_PREFIX:PATH=${TESTINST_DIR} ..
-    - cmake --build .
-    - cd ..
-    - python setup.py build
-    - python setup.py sdist
-    - cd build
-    - cmake --build . --target install
-    - cd ..
-    - cp VERSION VERSION.SAVED
-    - echo "" >> VERSION
-    - echo "VERSION_PATCH = \"GitHub_MasterBranch\"" >> VERSION
-    - cd build
-    - cmake -D FILTER_PROTO2CPP_PY_PATH=${DEPS_DIR}/proto2cpp ..
-    - echo "EXCLUDE_PATTERNS = */osi3/*" >> Doxyfile
-    - echo "GENERATE_TREEVIEW = YES" >> Doxyfile
-    - doxygen
-    - cd ..
-    - python -m unittest discover tests
-    - mv VERSION.SAVED VERSION
-    - sh convert-to-proto3.sh
-    - mkdir -p build3
-    - cd build3
-    - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
-    - cmake --build .
-    - cd ..
+jobs:
+  include:    
+    # Run the build script and generate documentation.
+    - stage: test OSI protobuf
 
-# Deploy the documentation on github (only for master branch).
-deploy:
-    provider: pages
-    skip_cleanup: true
-    local_dir: doc/html
-    keep-history: true
-    github_token: ${GH_REPO_TOKEN}
-    on: 
-      branch: master 
+      name: 'Test protobuf 2.6.1 syntax'
+      script:
+          - cd "${TRAVIS_BUILD_DIR}"
+          - mkdir -p build
+          - cd build
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install -D CMAKE_INSTALL_PREFIX:PATH=${TESTINST_DIR} ..
+          - cmake --build .
+          - cd ..
+          - python setup.py build
+          - python setup.py sdist
+          - cd build
+          - cmake --build . --target install
+          - cd ..
+          - cp VERSION VERSION.SAVED
+          - echo "" >> VERSION
+          - echo "VERSION_PATCH = \"GitHub_MasterBranch\"" >> VERSION
+          - cd build
+          - cmake -D FILTER_PROTO2CPP_PY_PATH=${DEPS_DIR}/proto2cpp ..
+          - echo "EXCLUDE_PATTERNS = */osi3/*" >> Doxyfile
+          - echo "GENERATE_TREEVIEW = YES" >> Doxyfile
+          - doxygen
+          - cd ..
+          - python -m unittest discover tests
+          - mv VERSION.SAVED VERSION
+          - sh convert-to-proto3.sh
+          - mkdir -p build3
+          - cd build3
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
+          - cmake --build .
+          - cd ..
+      
+    - script:
+          - cd "${TRAVIS_BUILD_DIR}"
+          - bash convert-to-proto3.sh
+          - rm *.pb2
+          - mkdir -p build
+          - cd build
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install -D CMAKE_INSTALL_PREFIX:PATH=${TESTINST_DIR} ..
+          - cmake --build .
+          - cd ..
+          - python setup.py build
+          - python setup.py sdist
+          - cd build
+          - cmake --build . --target install
+          - cd ..
+          - cp VERSION VERSION.SAVED
+          - echo "" >> VERSION
+          - echo "VERSION_PATCH = \"GitHub_MasterBranch\"" >> VERSION
+          - cd build
+          - cmake -D FILTER_PROTO2CPP_PY_PATH=${DEPS_DIR}/proto2cpp ..
+          - echo "EXCLUDE_PATTERNS = */osi3/*" >> Doxyfile
+          - echo "GENERATE_TREEVIEW = YES" >> Doxyfile
+          - doxygen
+          - cd ..
+          - python -m unittest discover tests
+          - mv VERSION.SAVED VERSION
+          - sh convert-to-proto3.sh
+          - mkdir -p build3
+          - cd build3
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
+          - cmake --build .
+          - cd ..
+      name: 'Test protobuf 3.0.0 syntax'
+
+    - stage: deploy
+      script:
+          - cd "${TRAVIS_BUILD_DIR}"
+          - mkdir -p build
+          - cd build
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install -D CMAKE_INSTALL_PREFIX:PATH=${TESTINST_DIR} ..
+          - cmake --build .
+          - cd ..
+          - python setup.py build
+          - python setup.py sdist
+          - cd build
+          - cmake --build . --target install
+          - cd ..
+          - cp VERSION VERSION.SAVED
+          - echo "" >> VERSION
+          - echo "VERSION_PATCH = \"GitHub_MasterBranch\"" >> VERSION
+          - cd build
+          - cmake -D FILTER_PROTO2CPP_PY_PATH=${DEPS_DIR}/proto2cpp ..
+          - echo "EXCLUDE_PATTERNS = */osi3/*" >> Doxyfile
+          - echo "GENERATE_TREEVIEW = YES" >> Doxyfile
+          - doxygen
+          - cd ..
+          - python -m unittest discover tests
+          - mv VERSION.SAVED VERSION
+          - sh convert-to-proto3.sh
+          - mkdir -p build3
+          - cd build3
+          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
+          - cmake --build .
+          - cd ..
+
+    # Deploy the documentation on github (only for master branch).
+      deploy:        
+          provider: pages
+          skip_cleanup: true
+          local_dir: doc/html
+          keep-history: true
+          github_token: ${GH_REPO_TOKEN}
+          on: 
+          branch: master 

--- a/tests/test_invalid_message.py
+++ b/tests/test_invalid_message.py
@@ -296,6 +296,11 @@ class TestInvalidMessage(unittest.TestCase):
                 saveStatement = ""
 
                 for line in fin:
+
+                    # Skipping test on multiplicity for protobuf 3.0.0
+                    if '"proto3"' in line:
+                        break
+
                     i += 1
 
                     # Divide statement and comment. Concatenate multi line statements.


### PR DESCRIPTION
#### Reference to a related issue in the repository

No related issue. Just for more test coverage in the CI pipeline which includes also the protobuf 3 syntax through the usage of the script [convert-to-proto3.sh](https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/convert-to-proto3.sh).

#### Add a description

_What is this change?_
This PR divides the travis ci into two stages one for testing and one for depolying. Inside the stage testing there will be executed two jobs in parallel. One job is for testing the build with protobuf 2 syntax the other job is for testing the build with protobuf 3. The deploy stage has the same code as the protobuf 2 test because currently you can't share files between jobs or stages see quote below from [here](https://docs.travis-ci.com/user/build-stages/#data-persistence-between-stages-and-jobs):

> It is important to note that jobs do not share storage, as each job runs in a fresh VM or container. If your jobs need to share files (e.g., using build artifacts from the “Test” stage for deployment in the subsequent “Deploy” stage), you need to use an external storage mechanism such as S3 and a remote scp server.

_What does it fix?_
Covers the testing for the protobuf 3 syntax if it is able to build.

_How has it been tested?_
In my fork [here](https://travis-ci.org/vkresch/open-simulation-interface/builds/607564264?utm_medium=notification&utm_source=github_status) you can see the builds of each stage. See also the current travis build.

#### Mention a member
@jdsika pls review. 

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.