### PR TITLE
Fixing bibtex citation

### DIFF
--- a/doc/description.rst
+++ b/doc/description.rst
@@ -138,13 +138,12 @@ scientific work:
 
 .. code-block:: latex
 
-    @misc{osi.2017, author = {Hanke, Timo and
-    Hirsenkorn, Nils and {van[STRIKEOUT:Driesten}, Carlo and
-    {Garcia]\ Ramos}, Pilar and Schiementz, Mark and Schneider, Sebastian},
-    year = {2017}, title = {{Open Simulation Interface: A generic interface
-    for the environment perception of automated driving functions in virtual
-    scenarios.}}, url = {http://www.hot.ei.tum.de/forschung/automotive-veroeffentlichungen/},
-    note = {{Accessed: 2017-08-28}} }
+    @misc{osi.2017,
+	author = {Hanke, Timo and Hirsenkorn, Nils and {van~Driesten}, Carlo and {Garcia~Ramos}, Pilar and Schiementz, Mark and Schneider, Sebastian and Biebl, Erwin},
+	year = {2017},
+	title = {{Open Simulation Interface: A generic interface for the environment perception of automated driving functions in virtual scenarios.}},
+	url = {https://www.hot.ei.tum.de/forschung/automotive-veroeffentlichungen/},
+	note = {{Accessed: 2019-11-05}}}
 
 .. _here: https://github.com/OpenSimulationInterface/osi-sensor-model-packaging
 .. _online: https://opensimulationinterface.github.io/open-simulation-interface/


### PR DESCRIPTION
#### Reference to a related issue in the repository
Resolves https://github.com/OpenSimulationInterface/open-simulation-interface/issues/100.

#### Add a description
Correcting the bibtex citation in the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/description.html#citing). The new change will be seen tomorrow when the next cron job will be executed.

#### Mention a member
@jdsika @PhRosenberger pls check and merge.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.