### PR TITLE
Remove redundant build3 proto3 syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,13 +91,6 @@ jobs:
           - doxygen
           - cd ..
           - python3 -m unittest discover tests
-          - mv VERSION.SAVED VERSION
-          - sh convert-to-proto3.sh
-          - mkdir -p build3
-          - cd build3
-          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
-          - cmake --build .
-          - cd ..
 
     - script:
           - cd "${TRAVIS_BUILD_DIR}"
@@ -123,13 +116,6 @@ jobs:
           - doxygen
           - cd ..
           - python3 -m unittest discover tests
-          - mv VERSION.SAVED VERSION
-          - sh convert-to-proto3.sh
-          - mkdir -p build3
-          - cd build3
-          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
-          - cmake --build .
-          - cd ..
       name: 'Test protobuf 3.0.0 syntax'
 
     - stage: deploy
@@ -155,13 +141,6 @@ jobs:
           - doxygen
           - cd ..
           - python3 -m unittest discover tests
-          - mv VERSION.SAVED VERSION
-          - sh convert-to-proto3.sh
-          - mkdir -p build3
-          - cd build3
-          - cmake -D CMAKE_PREFIX_PATH:PATH=${DEPS_DIR}/protobuf/install ..
-          - cmake --build .
-          - cd ..
 
     # Deploy the documentation on github (only for master branch).
       deploy:

--- a/doc/description.rst
+++ b/doc/description.rst
@@ -65,7 +65,7 @@ resulting libraries will use proto3, with the on-the-wire format
 remaining compatible between proto2 and proto3 libraries.
 
 .. note::
-	In the current OSI proto2 files their are no "required" fields or "[default = xx] values assigned. 
+	In the current OSI proto2 files there are no "required" fields or "[default = xx] values assigned. 
 	This is intentional since the use is prohibited for now. The reason for that is the conversion from proto2 to proto3 which would require to remove defaults or required attributes and therefore change the meaning of the proto file (and thus also the valid on-the-wire protocol) silently, and is thus dangerous.
 
 OSI Trace Files

--- a/doc/description.rst
+++ b/doc/description.rst
@@ -64,6 +64,10 @@ all proto files to proto3 syntax. If this is run prior to building, the
 resulting libraries will use proto3, with the on-the-wire format
 remaining compatible between proto2 and proto3 libraries.
 
+.. note::
+	In the current OSI proto2 files their are no "required" fields or "[default = xx] values assigned. 
+	This is intentional since the use is prohibited for now. The reason for that is the conversion from proto2 to proto3 which would require to remove defaults or required attributes and therefore change the meaning of the proto file (and thus also the valid on-the-wire protocol) silently, and is thus dangerous.
+
 OSI Trace Files
 ---------------
 


### PR DESCRIPTION
#### Reference to a related issue in the repository
After reviewing improvements to the repository I noticed some redundant code in the ci pipeline. I also added some documentation concerning the conversion of proto2 files to proto3 files (Resolves https://github.com/OpenSimulationInterface/open-simulation-interface/issues/257).

#### Add a description
This PR removes redundant code from the CI pipeline which checked the proto3 syntax build. Since we now have split this build syntax check into two jobs which run in parallel these lines of code are not needed anymore.

#### Mention a member
@jdsika pls review and merge :)

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.