### PR TITLE
Units correctly written in osi_common.proto.

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -10,26 +10,26 @@ package osi3;
 //
 // The coordinate system is defined as right-handed.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// Units are m for positions, m/s for velocities and m/s^2 for
 // accelerations.
 //
 message Vector3d
 {
     // The x coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double x = 1;
 
     // The y coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double y = 2;
 
     // The z coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double z = 3;
 }
@@ -38,20 +38,20 @@ message Vector3d
 // \brief A cartesian 2D vector for positions, velocities or accelerations or
 // its uncertainties.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// Units are m for positions, m/s for velocities and m/s^2 for
 // accelerations.
 //
 message Vector2d
 {
     // The x coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double x = 1;
 
     // The y coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double y = 2;
 }
@@ -70,7 +70,7 @@ message Timestamp
     // The number of seconds since the start of e.g. the simulation / system /
     // vehicle.
     //
-    // Unit: [s]
+    // Unit: s
     //
     optional int64 seconds = 1;
 
@@ -78,7 +78,7 @@ message Timestamp
     //
     // Range: [0, 999.999.999]
     //
-    // Unit: [ns]
+    // Unit: ns
     //
     optional uint32 nanos = 2;
 }
@@ -98,19 +98,19 @@ message Dimension3d
 {
     // The length of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double length = 1;
 
     // The width of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double width = 2;
 
     // The height of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double height = 3;
 }
@@ -119,10 +119,10 @@ message Dimension3d
 // \brief A 3D orientation, orientation rate or orientation acceleration (i.e.
 // derivatives) or its uncertainties denoted in euler angles.
 //
-// Units are [rad] for orientation [rad/s] for rates and [rad/s^2] for
+// Units are rad for orientation, rad/s for rates, and rad/s^2 for
 // accelerations
 //
-// The preferred angular range is (-pi, pi]. The coordinate system is defined as
+// The preferred angular range is [-pi, pi]. The coordinate system is defined as
 // right-handed.
 // For the sense of each rotation, the right-hand rule applies.
 //
@@ -152,19 +152,19 @@ message Orientation3d
 {
     // The roll angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double roll = 1;
 
     // The pitch angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double pitch = 2;
 
     // The yaw angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double yaw = 3;
 }
@@ -232,19 +232,19 @@ message Spherical3d
 {
     // The radial distance.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double distance = 1;
 
     // The azimuth (horizontal) angle.
     //
-    // Unit: [rad]
+    // Unit: rad
     //
     optional double azimuth = 2;
 
     // The elevation (vertical) angle.
     //
-    // Unit: [rad]
+    // Unit: rad
     //
     optional double elevation = 3;
 }


### PR DESCRIPTION
#### Reference to a related issue in the repository
Part of the solution for #362.

#### Add a description
Changes the first file "osi_common.proto" so that documentation has the correct unit-writing in the comments.

**Some questions to ask**:
It is only part of the complete bug fix for the documentation, to be clarified before more action on all files is taken.
The question is now, if it is fine like this, before I continue.

#### Mention a member
@jdsika should know the problem from our conversation about it on telephone.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x]  I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.