### PR TITLE
Documentation/units not in brackets

### DIFF
--- a/doc/commenting.rst
+++ b/doc/commenting.rst
@@ -146,7 +146,7 @@ Then you describe the field by adding an explanation.
     //
     message EnvironmentalConditions
     {
-        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 [Pa]).
+        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 Pa).
         //
         optional double atmospheric_pressure = 1;
     }
@@ -165,9 +165,9 @@ Next you decide the unit of the field.
     //
     message EnvironmentalConditions
     {
-        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 [Pa]).
+        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 Pa).
         //
-        // Unit: [Pa]
+        // Unit: Pa
         //
         optional double atmospheric_pressure = 1;
     }
@@ -186,9 +186,9 @@ You can optionally add a note to the field to describe the field better.
     //
     message EnvironmentalConditions
     {
-        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 [Pa]).
+        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 Pa).
         //
-        // Unit: [Pa]
+        // Unit: Pa
         //
         // \note 100000 Pa = 1 bar
         //
@@ -209,9 +209,9 @@ If you want to provide a reference to a DIN or to web page which helps in unders
     //
     message EnvironmentalConditions
     {
-        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 [Pa]).
+        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 Pa).
         //
-        // Unit: [Pa]
+        // Unit: Pa
         //
         // \note 100000 Pa = 1 bar
         //
@@ -235,9 +235,9 @@ Finally you can provide a set of rules which this field needs to be followed. Th
     //
     message EnvironmentalConditions
     {
-        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 [Pa]).
+        // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325 Pa).
         //
-        // Unit: [Pa]
+        // Unit: Pa
         //
         // \note 100000 Pa = 1 bar
         //

--- a/doc/commenting.rst
+++ b/doc/commenting.rst
@@ -21,7 +21,7 @@ Commenting on messages
 ------------------------
 When writing comments specifying messages please use the following template:
 
-.. code-block:: proto
+.. code-block:: protobuf
 
     // <Add your single line comment like this>
     //
@@ -32,7 +32,7 @@ When writing comments specifying messages please use the following template:
 Doxygen will interpret a comment consisting just of one single line as a brief description.
 However to keep the style of the documentation coherent there should not be any brief description when commenting on fields and enums. That is why adding one more empty line when commenting becomes necessary. There is no need for an extra empty line if you are commenting more than one line anyways.
 
-.. code-block:: proto
+.. code-block:: protobuf
     
     // <If you write two or more lines of comments...>
     // <... you do not need to add an empty line>
@@ -306,7 +306,7 @@ Commenting with doxygen references
 ------------------------------------
 If you need to reference to another message etc., you can achieve that by just using the exact same name of this message (upper and lower case sensitive) in your comment and put '\c' in front of the message name.
 
-.. code-block:: proto
+.. code-block:: protobuf
 
     // A reference to \c GroundTruth message.
 
@@ -314,7 +314,7 @@ If you want to reference a nested message, use '::' instead of '.' as separators
 
 If you want to reference message fields and enums add '#' to the enum/field name.
 
-.. code-block:: proto
+.. code-block:: protobuf
 
     // A reference to a enum e.g. \c #COLOR_GREEN.
 

--- a/doc/commenting.rst
+++ b/doc/commenting.rst
@@ -7,6 +7,10 @@ During the building process of open simulation interface (using the `proto2cpp <
 
 For any additional comment styles see `list <http://www.doxygen.nl/manual/commands.html>`_ of doxygen commands.
 
+Reference for writing values and units: ISO 80000-1: 2009, Quantities and units – Part 1: General
+Nice summary: [Rohde & Schwarz: Der korrekte Umgang mit Größen, Einheiten und Gleichungen ](https://karriere.rohde-schwarz.de/fileadmin/customer/downloads/PDF/Der_korrekte_Umgang_mit_Groessen_Einheiten_und_Gleichungen_bro_de_01.pdf
+)
+
 
 Commenting with block syntax
 -----------------------------
@@ -17,7 +21,7 @@ Commenting on messages
 ------------------------
 When writing comments specifying messages please use the following template:
 
-.. code-block:: protobuf
+.. code-block:: proto
 
     // <Add your single line comment like this>
     //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -10,26 +10,26 @@ package osi3;
 //
 // The coordinate system is defined as right-handed.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// Units are m for positions, m/s for velocities, and m/s^2 for
 // accelerations.
 //
 message Vector3d
 {
     // The x coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double x = 1;
 
     // The y coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double y = 2;
 
     // The z coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double z = 3;
 }
@@ -38,20 +38,20 @@ message Vector3d
 // \brief A cartesian 2D vector for positions, velocities or accelerations or
 // its uncertainties.
 //
-// Units are [m] for positions, [m/s] for velocities and [m/s^2] for
+// Units are m for positions, m/s for velocities, and m/s^2 for
 // accelerations.
 //
 message Vector2d
 {
     // The x coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double x = 1;
 
     // The y coordinate.
     //
-    // Unit: [m] [m/s] or [m/s^2]
+    // Unit: m, m/s, or m/s^2
     //
     optional double y = 2;
 }
@@ -70,7 +70,7 @@ message Timestamp
     // The number of seconds since the start of e.g. the simulation / system /
     // vehicle.
     //
-    // Unit: [s]
+    // Unit: s
     //
     optional int64 seconds = 1;
 
@@ -78,7 +78,7 @@ message Timestamp
     //
     // Range: [0, 999.999.999]
     //
-    // Unit: [ns]
+    // Unit: ns
     //
     optional uint32 nanos = 2;
 }
@@ -98,19 +98,19 @@ message Dimension3d
 {
     // The length of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double length = 1;
 
     // The width of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double width = 2;
 
     // The height of the box.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double height = 3;
 }
@@ -119,10 +119,10 @@ message Dimension3d
 // \brief A 3D orientation, orientation rate or orientation acceleration (i.e.
 // derivatives) or its uncertainties denoted in euler angles.
 //
-// Units are [rad] for orientation [rad/s] for rates and [rad/s^2] for
+// Units are rad for orientation, rad/s for rates, and rad/s^2 for
 // accelerations
 //
-// The preferred angular range is (-pi, pi]. The coordinate system is defined as
+// The preferred angular range is [-pi, pi]. The coordinate system is defined as
 // right-handed.
 // For the sense of each rotation, the right-hand rule applies.
 //
@@ -152,19 +152,19 @@ message Orientation3d
 {
     // The roll angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double roll = 1;
 
     // The pitch angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double pitch = 2;
 
     // The yaw angle/rate/acceleration.
     //
-    // Unit: [rad] [rad/s] or [rad/s^2]
+    // Unit: rad, rad/s, or rad/s^2
     //
     optional double yaw = 3;
 }
@@ -232,19 +232,19 @@ message Spherical3d
 {
     // The radial distance.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double distance = 1;
 
     // The azimuth (horizontal) angle.
     //
-    // Unit: [rad]
+    // Unit: rad
     //
     optional double azimuth = 2;
 
     // The elevation (vertical) angle.
     //
-    // Unit: [rad]
+    // Unit: rad
     //
     optional double elevation = 3;
 }

--- a/osi_datarecording.proto
+++ b/osi_datarecording.proto
@@ -12,7 +12,7 @@ package osi3;
 //
 message SensorDataSeries
 {
-    // List of sensor data messages for subsequent timesteps.
+    // List of sensor data messages for subsequent time steps.
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
@@ -25,7 +25,7 @@ message SensorDataSeries
 //
 message SensorDataSeriesList
 {
-    // List of sensor data for multiple sensors at subsequent timesteps.
+    // List of sensor data for multiple sensors at subsequent time steps.
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -42,7 +42,7 @@ message DetectedItemHeader
     // \f$ Timestamp - Age := \f$ 'point in time' when the object has
     // been observed for the first time.
     //
-    // Unit: [s]
+    // Unit: s
     //
     optional double age = 4;
 

--- a/osi_detectedtrafficsign.proto
+++ b/osi_detectedtrafficsign.proto
@@ -122,7 +122,7 @@ message DetectedTrafficSign
             GEOMETRY_SQUARE = 5;
 
             // Traffic sign that has a pole geometry. (height is bigger than
-            // width e.g. pole indicating highways exit in xx [m]). (4 corners)
+            // width e.g. pole indicating highways exit in xx m). (4 corners)
             //
             GEOMETRY_POLE = 6;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -190,7 +190,7 @@ message EnvironmentalConditions
     // 1 lm/m^2 [5].
     // lm ("lumen") is the SI derived unit of luminous flux and a measure of
     // the total quantity of visible light emitted by a source. The lumen is
-    // defined in relation to cd ("candela") as 1 lm =1 cd sr, where sr
+    // defined in relation to cd ("candela") as 1 lm = 1 cd sr, where sr
     // denotes steradian, the unit of solid angle used in 3D geometry analogous
     // to the radian.
     //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -40,15 +40,15 @@ message EnvironmentalConditions
     optional int64 unix_timestamp = 8;
 
     // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325
-    // [Pa]).
+    // Pa).
     //
-    // Unit: [Pa]
+    // Unit: Pa
     //
     optional double atmospheric_pressure = 3;
 
     // Temperature in Kelvin at z=0.0 in world frame.
     //
-    // Unit: [K]
+    // Unit: K
     //
     optional double temperature = 4;
 
@@ -58,7 +58,7 @@ message EnvironmentalConditions
     // humidity can be easily derived from relative_humidity, given that the
     // temperature and atmospheric_pressure are known.
     //
-    // Unit: [%]
+    // Unit: %
     optional double relative_humidity = 5;
 
     // Description of the precipitation.
@@ -70,7 +70,7 @@ message EnvironmentalConditions
     optional Fog fog = 7;
 
     // Definition of discretized precipitation states according to [1].
-    // (I = Intensity of precipitation in mm per hour [mm/h])
+    // (I = Intensity of precipitation in mm per hour mm/h)
     //
     // \par References:
     // - [1] PAULAT, Marcus, et al. A gridded dataset of hourly precipitation
@@ -88,31 +88,31 @@ message EnvironmentalConditions
         //
         PRECIPITATION_OTHER = 1;
 
-        // No precipitation, when I in [0,0.1[ [mm/h]
+        // No precipitation, when I in [0,0.1[ mm/h
         //
         PRECIPITATION_NONE = 2;
 
-        // Very light intensity of precipitation, when I in [0.1,0.5[ [mm/h]
+        // Very light intensity of precipitation, when I in [0.1,0.5[ mm/h
         //
         PRECIPITATION_VERY_LIGHT = 3;
 
-        // Light intensity of precipitation, when I in [0.5,1.9[ [mm/h]
+        // Light intensity of precipitation, when I in [0.5,1.9[ mm/h
         //
         PRECIPITATION_LIGHT = 4;
 
-        // Moderate intensity of precipitation, when I in [1.9,8.1[ [mm/h]
+        // Moderate intensity of precipitation, when I in [1.9,8.1[ mm/h
         //
         PRECIPITATION_MODERATE = 5;
 
-        // Heavy intensity of precipitation, when I in [8.1,34[ [mm/h]
+        // Heavy intensity of precipitation, when I in [8.1,34[ mm/h
         //
         PRECIPITATION_HEAVY = 6;
 
-        // Very heavy intensity of precipitation, when I in [34,149[ [mm/h]
+        // Very heavy intensity of precipitation, when I in [34,149[ mm/h
         //
         PRECIPITATION_VERY_HEAVY = 7;
 
-        // Extreme intensity of precipitation, when I in [149,infinity[ [mm/h]
+        // Extreme intensity of precipitation, when I in [149,infinity[ mm/h
         //
         PRECIPITATION_EXTREME = 8;
     }
@@ -120,7 +120,7 @@ message EnvironmentalConditions
     // Definition of discretized fog states according to [2].
     // The bandwidth of thick and dense fog was adjusted to fit the German StVO
     // regarding rear fog lights [3].
-    // (V = Visibility in meters [m])
+    // (V = Visibility in meters m)
     //
     // Visibility is defined as the length of the atmosphere over which a beam
     // of light travels before its luminous flux is reduced to 5% of its
@@ -146,35 +146,35 @@ message EnvironmentalConditions
         //
         FOG_OTHER = 1;
 
-        // Excellent visibility, when V in [40000,infinity[ [m]
+        // Excellent visibility, when V in [40000,infinity[ m
         //
         FOG_EXCELLENT_VISIBILITY = 2;
 
-        // Good visibility, when V in [10000,40000[ [m]
+        // Good visibility, when V in [10000,40000[ m
         //
         FOG_GOOD_VISIBILITY = 3;
 
-        // Moderate visibility, when V in [4000,10000[ [m]
+        // Moderate visibility, when V in [4000,10000[ m
         //
         FOG_MODERATE_VISIBILITY = 4;
 
-        // Poor visibility, when V in [2000,4000[ [m]
+        // Poor visibility, when V in [2000,4000[ m
         //
         FOG_POOR_VISIBILITY = 5;
 
-        // Mist, when V in [1000,2000[ [m]
+        // Mist, when V in [1000,2000[ m
         //
         FOG_MIST = 6;
 
-        // Fog, when V in [200,1000[ [m]
+        // Fog, when V in [200,1000[ m
         //
         FOG_LIGHT = 7;
 
-        // Thick fog, when V in [50,200[ [m]
+        // Thick fog, when V in [50,200[ m
         //
         FOG_THICK = 8;
 
-        // Dense fog, when V in [0,50[ [m]
+        // Dense fog, when V in [0,50[ m
         // (allowed to use rear fog light according to [3])
         //
         FOG_DENSE = 9;
@@ -185,12 +185,12 @@ message EnvironmentalConditions
     // emitted by the vehicle itself. It can include sun/moon light, light from
     // other cars, street lights etc.
     //
-    // Lux [lx] is the SI unit of luminance or illumination of an area of exact
-    // one square meter, which is equal to one lumen per square meter 1 [lx] =
-    // 1 [lm/m^2] [5].
-    // The lumen [lm] is the SI derived unit of luminous flux and a measure of
+    // lx ("Lux") is the SI unit of luminance or illumination of an area of exact
+    // one square meter, which is equal to one lumen per square meter 1 lx =
+    // 1 lm/m^2 [5].
+    // lm ("lumen") is the SI derived unit of luminous flux and a measure of
     // the total quantity of visible light emitted by a source. The lumen is
-    // defined in relation to the candela [cd] as 1 [lm] =1 [cd sr] where [sr]
+    // defined in relation to cd ("candela") as 1 lm =1 cd sr, where sr
     // denotes steradian, the unit of solid angle used in 3D geometry analogous
     // to the radian.
     //
@@ -206,9 +206,9 @@ message EnvironmentalConditions
     // USA](http://www.wsdot.wa.gov/research/reports/fullreports/847.1.pdf)
     // - [8] [Canadian IES-RP-8 standards for road lighting - municipality of
     // Saint-Gedeon-de-.
-    // Beauce](http://sslnet.ca/wp-content/uploads/2011/10/LTE-RT-2011-0076-Anglais.pdf)
+    // Beauce] (http://sslnet.ca/wp-content/uploads/2011/10/LTE-RT-2011-0076-Anglais.pdf)
     // - [9] [European standards for road
-    // lighting](http://courtneystrong.com/wp-content/uploads/2017/07/css-sl1-class-and-quality-of-street-lighting.pdf)
+    // lighting] (http://courtneystrong.com/wp-content/uploads/2017/07/css-sl1-class-and-quality-of-street-lighting.pdf)
     //
     enum AmbientIllumination
     {
@@ -220,59 +220,59 @@ message EnvironmentalConditions
         //
         AMBIENT_ILLUMINATION_OTHER = 1;
 
-        // Level 1 illumination in ]0.001, 0.01[ [lx]
+        // Level 1 illumination in ]0.001, 0.01[ lx
         // E.g. Night with no artificial light.
         //
         // \note Use \c #AMBIENT_ILLUMINATION_LEVEL1 if illumination is less
-        // than 0.001 [lx]
+        // than 0.001 lx
         //
         AMBIENT_ILLUMINATION_LEVEL1 = 2;
 
-        // Level 2 illumination in [0.01, 1[ [lx]
+        // Level 2 illumination in [0.01, 1[ lx
         // E.g. Night full moon / Deep twilight.
         //
         AMBIENT_ILLUMINATION_LEVEL2 = 3;
 
-        // Level 3 illumination in [1, 3[ [lx]
+        // Level 3 illumination in [1, 3[ lx
         // E.g. Deep to average twilight / Minimum lighting on local low
         // pedestrian conflict roads.
         //
         AMBIENT_ILLUMINATION_LEVEL3 = 4;
 
-        // Level 4 illumination in [3, 10[ [lx]
+        // Level 4 illumination in [3, 10[ lx
         // E.g. Average to full twilight / Minimum lighting on collector roads /
         // Minimum lighting on major and expressway roads with low to average
         // pedestrian conflict.
         //
         AMBIENT_ILLUMINATION_LEVEL4 = 5;
 
-        // Level 5 illumination in [10, 20[ [lx]
+        // Level 5 illumination in [10, 20[ lx
         // E.g. Minimum lighting on major and expressway roads with high
         // pedestrian conflict.
         //
         AMBIENT_ILLUMINATION_LEVEL5 = 6;
 
-        // Level 6 illumination in [20, 400[ [lx]
+        // Level 6 illumination in [20, 400[ lx
         // E.g. Roads with more lighting / Very dark overcast day to sunrise or
         // sunset on a clear day.
         //
         AMBIENT_ILLUMINATION_LEVEL6 = 7;
 
-        // Level 7 illumination in [400, 1000[ [lx]
+        // Level 7 illumination in [400, 1000[ lx
         // E.g. Sunrise or sunset on a clear day / Overcast day.
         //
         AMBIENT_ILLUMINATION_LEVEL7 = 8;
 
-        // Level 8 illumination in [1000, 10000[ [lx]
+        // Level 8 illumination in [1000, 10000[ lx
         // E.g. Average to full daylight.
         //
         AMBIENT_ILLUMINATION_LEVEL8 = 9;
 
-        // Level 9 illumination in [10000, 120000[ [lx]
+        // Level 9 illumination in [10000, 120000[ lx
         // E.g. Full daylight to intense sunlight.
         //
         // \note Use \c #AMBIENT_ILLUMINATION_LEVEL9 if illumination is more
-        // than 120000 [lx]
+        // than 120000 lx
         //
         AMBIENT_ILLUMINATION_LEVEL9 = 10;
     }
@@ -288,7 +288,7 @@ message EnvironmentalConditions
     //
     message TimeOfDay
     {
-        // The number of seconds [s] that have passed since midnight local time.
+        // The number of seconds in s that have passed since midnight local time.
         // Used e.g. for determining the current state of the circadian rhythm
         // of a driver.
         //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -278,25 +278,25 @@ message RadarDetection
 
     // Absolute radial (in direction to the sensor) velocity of the detection.
     //
-    // Unit: [m/s]
+    // Unit: m/s
     //
     optional double radial_velocity = 5;
 
     // Root mean squared error of the object measured radial velocity.
     //
-    // Unit: [m/s]
+    // Unit: m/s
     //
     optional double radial_velocity_rmse = 6;
 
     // The radar cross section (RCS) of the radar detection.
     //
-    // Unit: [dB m^2]
+    // Unit: dB m^2
     //
     optional double rcs = 7;
 
     // The signal to noise ratio (SNR) of the radar detection.
     //
-    // Unit: [dB]
+    // Unit: dB
     //
     optional double snr = 8;
 
@@ -374,19 +374,19 @@ message LidarDetection
     // The height value which is required when multiple scan points are
     // vertically clustered. Only vertical clustering is allowed (z-axis).
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double height = 5;
 
     // Root mean squared error of the object height.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double height_rmse = 6;
 
     // Intensity or equivalent value of the detection's echo.
     //
-    // Unit: [%]
+    // Unit: %
     //
     optional double intensity = 7;
 
@@ -413,7 +413,7 @@ message UltrasonicDetectionSpecificHeader
 {
     // Maximal range of the ultrasonic sensor.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double max_range = 1;
 
@@ -502,7 +502,7 @@ message UltrasonicDetection
 
     // Measured distance (radius) of the detection.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double distance = 3;
 }
@@ -542,13 +542,13 @@ message UltrasonicIndirectDetection
 
     // First parameter b of an ellipsoid equation.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double ellipsoid_radial = 3;
 
     // Second parameter b of an ellipsoid equation.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double ellipsoid_axial = 4;
 

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -124,8 +124,6 @@ message GroundTruth
     // ISO Code 3166/1 [1,2].
     // E.g. Germany = 276, USA = 840.
     //
-    // Unit: []
-    //
     // \par References:
     // - [1] [International Standard ISO 3166-1: Codes for the representation of
     // names of countries and their subdivisions - Part 1: Country codes, third

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -348,26 +348,26 @@ message Lane
         {
             // The temperature of the roads surface in Kelvin.
             //
-            // Unit: [K]
+            // Unit: K
             //
             optional double surface_temperature = 1;
 
             // The height of the water film on top of the surface in mm.
             //
-            // Unit: [mm]
+            // Unit: mm
             //
             optional double surface_water_film = 2;
 
             // The temperature where the water on top of the surface would start
             // to freeze or dew in Kelvin.
             //
-            // Unit: [K]
+            // Unit: K
             //
             optional double surface_freezing_point = 3;
 
             // The percentage of ice covering the road.
             //
-            // Unit: [%]
+            // Unit: %
             //
             optional double surface_ice = 4;
 
@@ -378,29 +378,29 @@ message Lane
             // 20 mm/m (a very rough road).
             //
             // Estimated value ranges (IRI):
-            // 0.0 [mm/m] absolutely perfect evenness
-            // 0.3 -  1.8 [mm/m] airport runways and superhighways
-            // 1.4 -  3.4 [mm/m] new pavements
-            // 2.2 -  5.7 [mm/m] older pavements
-            // 3.2 -  9.8 [mm/m] maintained unpaved roads
-            // 4.0 - 11.0 [mm/m] damaged pavements
+            // 0.0 mm/m absolutely perfect evenness
+            // 0.3 -  1.8 mm/m airport runways and superhighways
+            // 1.4 -  3.4 mm/m new pavements
+            // 2.2 -  5.7 mm/m older pavements
+            // 3.2 -  9.8 mm/m maintained unpaved roads
+            // 4.0 - 11.0 mm/m damaged pavements
             // 8.0 - >
-            // 20 [mm/m] rough unpaved roads
+            // 20 mm/m rough unpaved roads
             //
             // Speed of normal use (IRI):
-            // 30 [km/h] - 20   [mm/m]
-            // 50 [km/h] - 14.5 [mm/m]
-            // 60 [km/h] - 10.0 [mm/m]
-            // 80 [km/h] -  8.5 [mm/m]
-            // 100 [km/h] -  3.4 [mm/m]
+            // 30 km/h - 20   mm/m
+            // 50 km/h - 14.5 mm/m
+            // 60 km/h - 10.0 mm/m
+            // 80 km/h -  8.5 mm/m
+            // 100 km/h -  3.4 mm/m
             //
             // Road conditions (IRI);
-            // 15 [mm/m] erosion gulleys and deep depressions
-            // 11 [mm/m] frequent shallow depressions, some deep
-            // 9 [mm/m] frequent minor depressions
-            // 5 [mm/m] surface imperfections
+            // 15 mm/m erosion gulleys and deep depressions
+            // 11 mm/m frequent shallow depressions, some deep
+            // 9 mm/m frequent minor depressions
+            // 5 mm/m surface imperfections
             //
-            // Unit: [mm/m]
+            // Unit: mm/m
             //
             // \par References:
             // - [1] SAYERS, M.W.; KARAMIHAS, S.M. Little Book of Profiling,
@@ -416,7 +416,7 @@ message Lane
             // 0.5m. It is given as the standard height deviation of fine
             // roughness
             //
-            // Unit: [m]
+            // Unit: m
             //
             // \par References:
             // - [1] SAYERS, M.W.; KARAMIHAS, S.M. Little Book of Profiling,

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -195,19 +195,19 @@ message StationaryObject
             //
             DENSITY_SOLID = 2;
 
-            // Perforation max. ]0; 100] [mm]
+            // Perforation max. ]0; 100] mm
             //
             DENSITY_SMALL_MESH = 3;
 
-            // Perforation max. ]100; 500] [mm]
+            // Perforation max. ]100; 500] mm
             //
             DENSITY_MEDIAN_MESH = 4;
 
-            // Perforation max. ]500; 5000] [mm]
+            // Perforation max. ]500; 5000] mm
             //
             DENSITY_LARGE_MESH = 5;
 
-            // Perforation max. ]5000; infinity] [mm]
+            // Perforation max. ]5000; infinity[ mm
             //
             DENSITY_OPEN = 6;
         }
@@ -383,13 +383,11 @@ message MovingObject
         // Median radius of the wheels measured from a center of the wheel
         // including tire.
         //
-        // Unit: [m]
+        // Unit: m
         //
         optional double radius_wheel = 2;
 
         // Number of independent wheels.
-        //
-        // Unit: []
         //
         optional uint32 number_wheels = 3;
 
@@ -407,7 +405,7 @@ message MovingObject
         //
         optional Vector3d bbcenter_to_front = 5;
 
-        // Static minimal distance in [m] of under-body plane to ground
+        // Static minimal distance in m of under-body plane to ground
         // surface plane (i.e. disregarding driving dynamic effects or road
         // surface effects) under neutral load conditions. Can be useful to
         // approximate the clear area under a vehicle that a sensor can see

--- a/osi_sensorspecific.proto
+++ b/osi_sensorspecific.proto
@@ -14,7 +14,7 @@ message RadarSpecificObjectData
 {
     // The radar cross section (RCS) of the detected object.
     //
-    // Unit: [dB m^2]
+    // Unit: dB m^2
     //
     optional double rcs = 1;
 }
@@ -48,14 +48,14 @@ message UltrasonicSpecificObjectData
     // Maximum measured distance from one sensor which leads to the calculation
     // of this object.
     //
-    // Unit: [m]
+    // Unit: m
     //
     optional double maximum_measurement_distance_sensor = 1;
 
     // This value indicates the propability height for the classification in the
     // calculated object.
     //
-    // Unit: [%]
+    // Unit: %
     //
     optional double probability = 2;
 

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -196,7 +196,7 @@ message RadarSensorView
         // into account, and will, when multiplied by TX power yield the
         // actual RX power.
         //
-        // Unit: [dB]
+        // Unit: dB
         //
         optional double signal_strength = 1;
 
@@ -205,7 +205,7 @@ message RadarSensorView
         // This is the time of flight of the reflection, which is directly
         // proportional to the distance traveled.
         //
-        // Unit: [s]
+        // Unit: s
         //
         optional double time_of_flight = 2;
 
@@ -213,7 +213,7 @@ message RadarSensorView
         //
         // Shift in frequency based on the specified TX frequency.
         //
-        // Unit: [Hz]
+        // Unit: Hz
         //
         optional double doppler_shift = 3;
 
@@ -222,7 +222,7 @@ message RadarSensorView
         // Horizontal angle of incidence of the source of the reflection
         // at the TX antenna.
         //
-        // Unit: [rad]
+        // Unit: rad
         //
         optional double source_horizontal_angle = 4;
 
@@ -231,7 +231,7 @@ message RadarSensorView
         // Vertical angle of incidence of the source of the reflection
         // at the TX antenna.
         //
-        // Unit: [rad]
+        // Unit: rad
         //
         optional double source_vertical_angle = 5;
     }
@@ -268,7 +268,7 @@ message LidarSensorView
         // into account, and will, when multiplied by TX power yield the
         // potential RX power (disregarding any other RX/TX losses).
         //
-        // Unit: [dB]
+        // Unit: dB
         //
         optional double signal_strength = 1;
 
@@ -277,7 +277,7 @@ message LidarSensorView
         // This is the time of flight of the reflection, which is directly
         // proportional to the distance traveled.
         //
-        // Unit: [s]
+        // Unit: s
         //
         optional double time_of_flight = 2;
 
@@ -285,7 +285,7 @@ message LidarSensorView
         //
         // Shift in frequency based on the specified TX frequency.
         //
-        // Unit: [Hz]
+        // Unit: Hz
         //
         optional double doppler_shift = 3;
 
@@ -294,7 +294,7 @@ message LidarSensorView
         // The normal of the transmitted beam to the object, roadmarking etc
         // encounter. \note data is in Lidar coordinate system
         //
-        // Unit: [unit vector]
+        // Unit: unit vector
         //
         optional Vector3d normal_to_surface = 5;
 

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -122,7 +122,7 @@ message SensorViewConfiguration
     // that the simulation environment has to provide.
     // Viewing range: [- \c #field_of_view_horizontal/2,  \c
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
-    // Spherical3d. Unit: [rad]
+    // Spherical3d. Unit: rad
     optional double field_of_view_horizontal = 5;
 
     // Field of View in vertical orientation of the sensor.
@@ -133,7 +133,7 @@ message SensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 6;
 
     // Maximum range of the sensor
@@ -141,7 +141,7 @@ message SensorViewConfiguration
     // This determines the limit of the cone of interest of ground truth
     // that the simulation environment has to provide.
     //
-    // Unit: [m]
+    // Unit: m
     optional double range = 7;
 
     // The update cycle time of the sensor model.
@@ -149,7 +149,7 @@ message SensorViewConfiguration
     // This specifies the rate at which the sensor model is provided with
     // new input data.
     //
-    // Unit: [s]
+    // Unit: s
     // \note In the case of FMU packaging this will correspond to the
     // communication step size.
     optional Timestamp update_cycle_time = 8;
@@ -171,7 +171,7 @@ message SensorViewConfiguration
     // stable phase position of the offset in the case of changing
     // simulation start times, e.g. for partial resimulation.
     //
-    // Unit: [s]
+    // Unit: s
     optional Timestamp update_cycle_offset = 9;
 
     // Simulation Start time
@@ -180,7 +180,7 @@ message SensorViewConfiguration
     // has chosen. This field has no defined meaning if provided by
     // the sensor model.
     //
-    // Unit: [s]
+    // Unit: s
     optional Timestamp simulation_start_time = 10;
 
     // Generic Sensor View Configuration(s).
@@ -274,7 +274,7 @@ message GenericSensorViewConfiguration
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
     // Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_horizontal = 4;
 
     // Field of View in vertical orientation of the physical sensor.
@@ -283,7 +283,7 @@ message GenericSensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 5;
 
     // TBD: Generic sensor specific configuration.
@@ -345,7 +345,7 @@ message RadarSensorViewConfiguration
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
     // Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_horizontal = 4;
 
     // Field of View in vertical orientation of the physical sensor.
@@ -354,7 +354,7 @@ message RadarSensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 5;
 
     // Number of rays to cast across horizontal field of view (azimuth).
@@ -385,7 +385,7 @@ message RadarSensorViewConfiguration
     // through frequency adjustments. For material and geometry interaction
     // purposes the frequency is also relevant.
     //
-    // Unit: [Hz]
+    // Unit: Hz
     optional double emitter_frequency = 9;
 
     // This represents the TX antenna diagram
@@ -409,19 +409,19 @@ message RadarSensorViewConfiguration
         // Horizontal deflection (azimuth) of entry in sensor/antenna
         // coordinates.
         //
-        // Unit: [rad]
+        // Unit: rad
         optional double horizontal_angle = 1;
 
         // Vertical deflection (elevation) of entry in sensor/antenna
         // coordinates.
         //
-        // Unit: [rad]
+        // Unit: rad
         optional double vertical_angle = 2;
 
         // Response of antenna at this point (positive dB is gain,
         // negative dB is attenuation).
         //
-        // Unit: [dB]
+        // Unit: dB
         optional double response = 3;
     }
 }
@@ -481,7 +481,7 @@ message LidarSensorViewConfiguration
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
     // Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_horizontal = 4;
 
     // Field of View in vertical orientation of the physical sensor.
@@ -490,7 +490,7 @@ message LidarSensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 5;
 
     // Number of rays to cast across horizontal field of view.
@@ -521,7 +521,7 @@ message LidarSensorViewConfiguration
     // through frequency adjustments. For material and geometry interaction
     // purposes the frequency is also relevant.
     //
-    // Unit: [Hz]
+    // Unit: Hz
     optional double emitter_frequency = 9;
 
     // Number of pixels in frame.
@@ -601,7 +601,7 @@ message CameraSensorViewConfiguration
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
     // Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_horizontal = 4;
 
     // Field of View in vertical orientation of the physical sensor.
@@ -610,7 +610,7 @@ message CameraSensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 5;
 
     // Number of pixels to produce across horizontal field of view.
@@ -767,7 +767,7 @@ message UltrasonicSensorViewConfiguration
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
     // Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_horizontal = 4;
 
     // Field of View in vertical orientation of the physical sensor.
@@ -776,7 +776,7 @@ message UltrasonicSensorViewConfiguration
     // #field_of_view_vertical/2] elevation in the sensor frame at zero azimuth
     // as defined in \c Spherical3d.
     //
-    // Unit: [rad]
+    // Unit: rad
     optional double field_of_view_vertical = 5;
 
     // TBD: Ultrasonic Sensor specific configuration.

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -56,7 +56,7 @@ message TrafficLight
         optional Mode mode = 3;
 
         // The value of the countdown counter.
-        // Unit: [%] or [s]
+        // Unit: % or s
         //
         // \note Set value only if traffic light bulb is a countdown counter.
         //

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -37,91 +37,87 @@ message TrafficSignValue
 
         // Value without unit.
         //
-        // Unit: []
-        //
         UNIT_NO_UNIT = 2;
 
         // Velocity.
         // Kilometers per hour.
         //
-        // Unit: [km/h]
+        // Unit: km/h
         //
         UNIT_KILOMETER_PER_HOUR = 3;
 
         // Velocity.
         // Miles per hour.
         //
-        // Unit: [mph]
+        // Unit: mph
         //
         UNIT_MILE_PER_HOUR = 4;
 
         // Length.
         // Meter.
         //
-        // Unit: [m]
+        // Unit: m
         //
         UNIT_METER = 5;
 
         // Length.
         // Kilometer.
         //
-        // Unit: [km]
+        // Unit: km
         //
         UNIT_KILOMETER = 6;
 
         // Length.
         // Feet.
         //
-        // Unit: [ft]
+        // Unit: ft
         //
         UNIT_FEET = 7;
 
         // Length.
         // Mile.
         //
-        // Unit: [mile]
+        // Unit: mile
         //
         UNIT_MILE = 8;
 
         // Weight.
         // Ton.
         //
-        // Unit: [t]
+        // Unit: t
         //
         UNIT_METRIC_TON = 9;
 
         // Weight.
-        // Long ton UK 1,016.047 [kg].
+        // Long ton UK 1,016.047 kg.
         //
-        // Unit: [tn. l.]
+        // Unit: tn. l.
         //
         UNIT_LONG_TON = 10;
 
         // Weight.
-        // Short ton USA 907.1847 [kg].
+        // Short ton USA 907.1847 kg.
         //
-        // Unit: [tn. sh.]
+        // Unit: tn. sh.
         //
         UNIT_SHORT_TON = 11;
 
         // Time of day.
         // Hour since midnight.
         //
-        // Unit: [min]
+        // Unit: min
         //
         UNIT_MINUTES = 12;
 
         // Day of the week.
         // Days since Monday. Monday = 0; Tuesday = 1; ...
         //
-        // Unit: []
-        //
         UNIT_DAY = 13;
 
         // Percentage.
         // Value.
         //
-        // Unit: [%]
+        // Unit: %
         //
         UNIT_PERCENTAGE = 14;
     }
@@ -145,7 +141,7 @@ message TrafficSign
     //
     optional Identifier id = 1;
 
-    // Main sign, e.g. speed limit 30 [km/h]
+    // Main sign, e.g. speed limit 30 km/h
     //
     optional MainSign main_sign = 2;
 
@@ -1860,7 +1856,7 @@ message TrafficSign
                 // </table>
                 //
                 // \note In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 //
                 TYPE_TRUCKS_PROHIBITED = 39;
 
@@ -2018,7 +2014,7 @@ message TrafficSign
                 //
                 // \note In the German StVO, tractors are defined as motorized
                 // vehicles that are not allowed to, or cannot, drive faster
-                // than 25 [km/h].
+                // than 25 km/h.
                 //
                 TYPE_TRACTORS_PROHIBITED = 163;
 
@@ -3785,7 +3781,7 @@ message TrafficSign
                 TYPE_SHOULDER_NOT_PASSABLE_MOTOR_VEHICLES = 220;
 
                 // Shoulder unsafe for vehicles with a permitted gross weight
-                // over 3.5 [t] and for tractors.
+                // over 3.5 t and for tractors.
                 // <table cellspacing="0" cellpadding="0">
                 // <tr>
                 // <td>
@@ -4435,7 +4431,7 @@ message TrafficSign
                 //
                 TYPE_HIGHWAY_PREANNOUNCEMENT_DIRECTIONS = 126;
 
-                // Pole indicating highways exit in ... [m].
+                // Pole indicating highways exit in ... m.
                 // <table cellspacing="0" cellpadding="0">
                 // <tr>
                 // <td>
@@ -4454,7 +4450,7 @@ message TrafficSign
                 // </table>
                 //
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit to specify the distance in [m]
+                // TrafficSignValue::value_unit to specify the distance in m
                 // or the displayed number of stripes (in that case, set \c
                 // TrafficSignValue::value_unit to \c
                 // TrafficSignValue::UNIT_NO_UNIT.).
@@ -6006,7 +6002,7 @@ message TrafficSign
                 // All green signals ("green wave") at certain speed.
                 // <br>
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [km/h]) to indicate the
+                // TrafficSignValue::value_unit (e.g. km/h) to indicate the
                 // speed.
                 // </td>
                 // </tr>
@@ -6292,7 +6288,7 @@ message TrafficSign
                 // - Use \c TrafficSignValue::value to include the distance
                 // indicated in the sign. Accompany this value with an
                 // indication of its unit of measure given by \c
-                // TrafficSignValue::value_unit (e.g. [m]),
+                // TrafficSignValue::value_unit (e.g. m),
                 // - Use \c TrafficSignValue::text to indicate the sign's
                 // specific text,
                 //
@@ -6325,7 +6321,7 @@ message TrafficSign
                 // "STOP" + distance
                 // </td>
                 // <td>
-                // Stop in e.g. ... [m]
+                // Stop in e.g. ... m
                 // </td>
                 // </tr>
                 // <tr>
@@ -6339,7 +6335,7 @@ message TrafficSign
                 // &rdquo;Rei&szlig;verschluss erst in&rdquo; + distance
                 // </td>
                 // <td>
-                // Zipper merge in e.g. ... [m]
+                // Zipper merge in e.g. ... m
                 // </td>
                 // </tr>
                 // <tr>
@@ -6353,7 +6349,7 @@ message TrafficSign
                 // "Ende Seitenstreifen in" + distance
                 // </td>
                 // <td>
-                // End of the side strip in e.g. ... [m]
+                // End of the side strip in e.g. ... m
                 // </td>
                 // </tr>
                 // <tr>
@@ -6367,7 +6363,7 @@ message TrafficSign
                 // "Ende in" + distance
                 // </td>
                 // <td>
-                // End in .. [m]
+                // End in .. m
                 // </td>
                 // </tr>
                 // <tr>
@@ -6387,7 +6383,7 @@ message TrafficSign
                 // still be used up to a certain point. To indicate the point,
                 // use one of the following alternatives:
                 // - A numerical value described by \c TrafficSignValue::value
-                // and \c TrafficSignValue::value_unit (e.g. [m]) to indicate
+                // and \c TrafficSignValue::value_unit (e.g. m) to indicate
                 // the point as a distance from the sign.
                 // - A text described by \c TrafficSignValue::text in order to
                 // describe the point's location verbally, e.g. "Baugebiet ...".
@@ -6404,7 +6400,7 @@ message TrafficSign
                 // - Use one or more \c TrafficSignValue messages to include
                 // the times indicated in the sign. Accompany each value with an
                 // indication of its unit of measure given by \c
-                // TrafficSignValue::value_unit, e.g. [h].
+                // TrafficSignValue::value_unit, e.g. h.
                 // - For each \c TrafficSignValue, \c TrafficSignValue::value
                 // indicates the time elapsed since midnight every day.
                 // - Use the \c TrafficSignValue::text member of the
@@ -6494,7 +6490,7 @@ message TrafficSign
                 // TrafficSignValue::value indicates the time elapsed since
                 // midnight of the corresponding day, and \c
                 // TrafficSignValue::value_unit indicates the unit this time is
-                // expressed in, e.g. in [min].
+                // expressed in, e.g. in min.
                 // </td>
                 // </tr>
                 // <tr>
@@ -6921,10 +6917,10 @@ message TrafficSign
                 // Trucks.
                 // \note
                 // - In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 // - This supplementary sign also denotes the trucks' tractor
                 // units and trailers.
-                // - Cars and buses with a total weight superior to 3.5 [t] are
+                // - Cars and buses with a total weight superior to 3.5 t are
                 // not denoted by this. sign.
                 // </td>
                 // </tr>
@@ -7068,7 +7064,7 @@ message TrafficSign
                 // Tractors.
                 // \note In the German StVO, tractors are defined as motorized
                 // vehicles that are not allowed to, or cannot, drive faster
-                // than 25 [km/h].
+                // than 25 km/h.
                 // </td>
                 // </tr>
                 // <tr>
@@ -7191,7 +7187,7 @@ message TrafficSign
                 // &rdquo;d&uuml;rfen &uuml;berholt werden&rdquo;.
                 // \note In the German StVO, tractors are defined as motorized
                 // vehicles that are not allowed to, or cannot, drive faster
-                // than 25 [km/h].
+                // than 25 km/h.
                 // </td>
                 // </tr>
                 // <tr>
@@ -7428,7 +7424,7 @@ message TrafficSign
                 // Only trucks with trailers and trucks with semi-trailers.
                 // \note
                 // - In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 // - This supplementary sign also denotes the trucks'
                 // tractor units and trailers.
                 // - This supplementary sign excludes passenger cars and
@@ -7465,7 +7461,7 @@ message TrafficSign
                 // <br>
                 // \note
                 // - In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 // - This supplementary sign also denotes the trucks' tractor
                 // units and trailers.
                 // </td>
@@ -7604,7 +7600,7 @@ message TrafficSign
                 // each \c TrafficSignValue, \c TrafficSignValue::value
                 // indicates the time elapsed since midnight every day, and \c
                 // TrafficSignValue::value_unit indicates the unit this time is
-                // expressed in, e.g. in [min].
+                // expressed in, e.g. in min.
                 // </td>
                 // </tr>
                 // <tr>
@@ -7930,10 +7926,10 @@ message TrafficSign
                 // Except trucks, their tractor unit and their trailers.
                 // \note
                 // - In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 // - This supplementary sign also denotes the trucks' tractor
                 // units and trailers.
-                // - Cars and buses with a total weight superior to 3.5 [t] are
+                // - Cars and buses with a total weight superior to 3.5 t are
                 // not exempted of a rule by this sign.
                 // </td>
                 // </tr>
@@ -7951,10 +7947,10 @@ message TrafficSign
                 // Except trucks with trailers.
                 // \note
                 // - In the German StVO, trucks are defined as motorized
-                // vehicles that are heavier than 3.5 [t].
+                // vehicles that are heavier than 3.5 t.
                 // - This supplementary sign also denotes the trucks' tractor
                 // units and trailers.
-                // - Cars and buses with a total weight superior to 3.5 [t] are
+                // - Cars and buses with a total weight superior to 3.5 t are
                 // not exempted of a rule by this sign.
                 // </td>
                 // </tr>
@@ -8014,7 +8010,7 @@ message TrafficSign
                 // Except tractors.
                 // \note In the German StVO, tractors are defined as motorized
                 // vehicles that are not allowed to, or cannot, drive faster
-                // than 25 [km/h].
+                // than 25 km/h.
                 // </td>
                 // </tr>
                 // <tr>
@@ -8045,7 +8041,7 @@ message TrafficSign
                 // Except campers with a maximum allowed mass.
                 // <br>
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [t]) to indicate the mass.
+                // TrafficSignValue::value_unit (e.g. t) to indicate the mass.
                 // </td>
                 // </tr>
                 // <tr>
@@ -8382,7 +8378,7 @@ message TrafficSign
                 // </table>
                 //
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [m]) to indicate the
+                // TrafficSignValue::value_unit (e.g. m) to indicate the
                 // distance.
                 //
                 TYPE_VALID_FOR_DISTANCE = 3;
@@ -8537,14 +8533,14 @@ message TrafficSign
                 // </table>
                 //
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [m]) to indicate the
+                // TrafficSignValue::value_unit (e.g. m) to indicate the
                 // distance.
                 //
                 // \note For OSI 4.0 compatibility use \c #TYPE_SPACE instead.
                 //
                 TYPE_VALID_IN_DISTANCE = 4;
 
-                // Stop in e.g. .. [m].
+                // Stop in e.g. .. m.
                 // <table cellspacing="0" cellpadding="0">
                 // <tr>
                 // <td>
@@ -8556,7 +8552,7 @@ message TrafficSign
                 // </table>
                 //
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [m]) to indicate the
+                // TrafficSignValue::value_unit (e.g. m) to indicate the
                 // distance.
                 //
                 // \note For OSI 4.0 compatibility use \c #TYPE_SPACE instead.
@@ -8729,7 +8725,7 @@ message TrafficSign
                 // TrafficSignValue, \c TrafficSignValue::value indicates
                 // the time elapsed since midnight each day, and \c
                 // TrafficSignValue::value_unit indicates the unit this time is
-                // expressed in, e.g. in [min].
+                // expressed in, e.g. in min.
                 // - If including start and end days of the week, include two
                 // additional \c TrafficSignValue messages. For these messages,
                 // use \c TrafficSignValue::value_unit as \c
@@ -8755,7 +8751,7 @@ message TrafficSign
                 // </td>
                 // <td>
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [min]) to indicate the
+                // TrafficSignValue::value_unit (e.g. min) to indicate the
                 // allowed duration of parking.
                 // </td>
                 // </tr>
@@ -8771,7 +8767,7 @@ message TrafficSign
                 // </td>
                 // <td>
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. [min]) to indicate the
+                // TrafficSignValue::value_unit (e.g. min) to indicate the
                 // allowed duration of parking. Set \c TrafficSignValue::text
                 // to &rdquo;in gekennzeichneten Fl&auml;chen&rdquo;.
                 // </td>
@@ -8794,7 +8790,7 @@ message TrafficSign
                 // </table>
                 //
                 // Use \c TrafficSignValue::value and \c
-                // TrafficSignValue::value_unit (e.g. in [t]) to indicate the
+                // TrafficSignValue::value_unit (e.g. in t) to indicate the
                 // weight.
                 //
                 TYPE_WEIGHT = 6;
@@ -9101,7 +9097,7 @@ message TrafficSign
                 //
                 // \note In the German StVO, tractors are defined as
                 // motorized vehicles that are not allowed to, or cannot,
-                // drive faster than 25 [km/h]
+                // drive faster than 25 km/h
                 //
                 ACTOR_TRACTORS = 37;
 
@@ -9117,7 +9113,7 @@ message TrafficSign
                 //
                 // \note
                 // In the German StVO, trucks are defined as
-                // motorized vehicles that are heavier than 3.5 [t]
+                // motorized vehicles that are heavier than 3.5 t
                 //
                 ACTOR_TRUCKS = 40;
 


### PR DESCRIPTION
#### Reference to a related issue in the repository
This PR solves #362 as unit-writing is now corrected.

#### Add a description
Corrects writing of units without brackets in whole docu.

#### Mention a member
@jdsika could you please double-check?

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.