### PR TITLE
Move assigned_lane_id in osi_object.proto to VehicleClassification

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -190,7 +190,7 @@ message DetectedMovingObject
     //
     // Percentage value of the object width in the corresponding lane.
     //
-    // \note DEPRECATED: Use assigned_lane_percentage in VehicleClassification
+    // \note DEPRECATED: Use assigned_lane_percentage in MovingObjectClassification
     // instead.
     //
     // \rules
@@ -204,7 +204,7 @@ message DetectedMovingObject
     //
     // Percentage value of the object width in the corresponding lane.
     //
-    // \note DEPRECATED: Use assigned_lane_percentage in VehicleClassification
+    // \note DEPRECATED: Use assigned_lane_percentage in MovingObjectClassification
     // instead.
     //
     // \rules

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -315,6 +315,10 @@ message DetectedMovingObject
         // [1] Patton, K. T. & Thibodeau, G. A. (2015). <em>Anatomy & Physiology</em>. 9th Edition. Elsevier. Missouri, U.S.A. ISBN 978-0-323-34139-4. p. 1229.
         //
         optional Orientation3d upper_body_pose = 5;
+
+        // Specific information about the classification of a moving object.
+        //
+        optional MovingObject.MovingObjectClassification moving_object_classification = 6;        
     }
 
     // Definition of available reference points. Left/middle/right and

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -190,6 +190,9 @@ message DetectedMovingObject
     //
     // Percentage value of the object width in the corresponding lane.
     //
+    // \note DEPRECATED: Use assigned_lane_percentage in VehicleClassification
+    // instead.
+    //
     // \rules
     // is_greater_than_or_equal_to: 0
     // is_less_than_or_equal_to: 100
@@ -200,6 +203,9 @@ message DetectedMovingObject
     // Percentage side lane right.
     //
     // Percentage value of the object width in the corresponding lane.
+    //
+    // \note DEPRECATED: Use assigned_lane_percentage in VehicleClassification
+    // instead.
     //
     // \rules
     // is_greater_than_or_equal_to: 0

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -572,6 +572,15 @@ message MovingObject
         //
         optional Identifier trailer_id = 4;
 
+        // The IDs of the lanes that this object is assigned to.
+        //
+        // \note Might be multiple if the object is switching lanes or moving from
+        // one lane into another following lane.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated Identifier assigned_lane_id = 5;
+
         // Definition of vehicle types.
         //
         enum Type

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -308,7 +308,7 @@ message MovingObject
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    // \note DEPRECATED: Use assigned_lane_id in VehicleClassification
+    // \note DEPRECATED: Use assigned_lane_id in MovingObjectClassification
     // instead.
     //
     repeated Identifier assigned_lane_id = 4;
@@ -547,6 +547,31 @@ message MovingObject
     }
 
     //
+    // \brief Information for the classification of moving objects regarding
+    // \c MovingObject (host or other).
+    //
+    message MovingObjectClassification
+    {
+        // The IDs of the lanes that this object is assigned to.
+        //
+        // \note Might be multiple if the object is switching lanes or moving from
+        // one lane into another following lane.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated Identifier assigned_lane_id = 1;
+
+        // Percentage value of the object width in the corresponding lane.
+        //
+        // \note Might be multiple if the object is switching lanes or moving from
+        // one lane into another following lane.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated double assigned_lane_percentage = 2;        
+    }
+
+    //
     // \brief Information for the classification of vehicles regarding
     // \c MovingObject (host or other).
     //
@@ -574,24 +599,6 @@ message MovingObject
         // \endrules
         //
         optional Identifier trailer_id = 4;
-
-        // The IDs of the lanes that this object is assigned to.
-        //
-        // \note Might be multiple if the object is switching lanes or moving from
-        // one lane into another following lane.
-        //
-        // \note OSI uses singular instead of plural for repeated field names.
-        //
-        repeated Identifier assigned_lane_id = 5;
-
-        // Percentage value of the object width in the corresponding lane.
-        //
-        // \note Might be multiple if the object is switching lanes or moving from
-        // one lane into another following lane.
-        //
-        // \note OSI uses singular instead of plural for repeated field names.
-        //
-        repeated double assigned_lane_percentage = 6;
 
         // Definition of vehicle types.
         //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -308,6 +308,9 @@ message MovingObject
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
+    // \note DEPRECATED: Use assigned_lane_id in VehicleClassification
+    // instead.
+    //
     repeated Identifier assigned_lane_id = 4;
 
     // Specific information about the vehicle.
@@ -580,6 +583,15 @@ message MovingObject
         // \note OSI uses singular instead of plural for repeated field names.
         //
         repeated Identifier assigned_lane_id = 5;
+
+        // Percentage value of the object width in the corresponding lane.
+        //
+        // \note Might be multiple if the object is switching lanes or moving from
+        // one lane into another following lane.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated double assigned_lane_percentage = 6;
 
         // Definition of vehicle types.
         //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -355,6 +355,10 @@ message MovingObject
     //
     repeated StatePoint future_trajectory = 8;
 
+    // Specific information about the classification of the vehicle.
+    //
+    optional MovingObjectClassification moving_object_classification = 9;    
+
     // Definition of object types.
     //
     enum Type


### PR DESCRIPTION
#### Reference to a related issue in the repository
Add a reference to a related issue in the repository.

#### Add a description
Add the assigned lane id to the vehicle classification as it is the case with other entities (e.g. traffic signs)

**Some questions to ask**:
What is this change?
What does it fix?
Add the assigned lane id to the vehicle classification as it is the case with other entities (e.g. traffic signs)
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
It is a bug fix. Fields got altered, therefore minor version upgrade.

How has it been tested?
Documentation was build

Vehicle Classification without assigned lane id
![image](https://user-images.githubusercontent.com/50795453/72436420-a1f98200-37a0-11ea-8cfd-c3de20c73b2b.png)

Vehicle Classification with assigned lane id
![image](https://user-images.githubusercontent.com/50795453/72436196-28619400-37a0-11ea-99e9-70a5e2bacdae.png)


#### Mention a member
@jdsika @ThomasNaderBMW 

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.