### PR TITLE
Added test for units

### DIFF
--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -122,7 +122,9 @@ message SensorViewConfiguration
     // that the simulation environment has to provide.
     // Viewing range: [- \c #field_of_view_horizontal/2,  \c
     // #field_of_view_horizontal/2] azimuth in the sensor frame as defined in \c
-    // Spherical3d. Unit: rad
+    // Spherical3d.
+    //
+    // Unit: rad
     optional double field_of_view_horizontal = 5;
 
     // Field of View in vertical orientation of the sensor.

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,28 @@
+import re
+import glob
+import unittest
+
+PROTO_FILES = glob.glob("*.proto")
+
+class TestUnits(unittest.TestCase):
+    """ Test class for units documentation. """
+
+    def test_no_brackets(self):
+        ''' Test to check if units have the right syntax. '''
+
+        NOT_VALID_BRACKETS = [r'\(', r'\)', r'\[', r'\]', r'\{', r'\}']
+        
+        for file in PROTO_FILES:
+            with open(file, "rt") as fin, self.subTest(file=file):
+                for i, line in enumerate(fin, start=1):
+                    found = re.search('Unit:', line, re.IGNORECASE)
+
+                    if found:
+                        comment_list = line.split()
+                        self.assertEqual(comment_list[0], '//', file + " in line " + str(i) + ": Unit must be on a separate line or have a space between //. (Example: '// Unit: m')")
+                        self.assertEqual(comment_list[1], 'Unit:', file + " in line " + str(i) + f": '{comment_list[1]}' do not match 'Unit:'. (Example: '// Unit: m')")
+                        self.assertGreaterEqual(len(comment_list), 3, file + " in line " + str(i) + ": No unit defined. (Example: '// Unit: m')")
+                        
+                        for unit in comment_list:
+                            for brackets in NOT_VALID_BRACKETS:
+                                self.assertNotRegex(unit, brackets, file + " in line " + str(i) + ": Invalid brackets around units.")


### PR DESCRIPTION
#### Reference to a related issue in the repository
The following [PR](https://github.com/OpenSimulationInterface/open-simulation-interface/pull/365) corrected the documentation of units according to the DIN norm in OSI. To complete the correction a test needs to be added which would have failed when the correction was not made.

#### Add a description
This PR adds a test for checking:
- Units defintion must be on a separate line (I made a correction in the osi_sensorviewconfiguration.proto file.)
- The syntax must be: '// Unit: m'
- First letter of Unit must always be uppercase
- Units must not be enclosed with any brackets

#### Mention a member
@jdsika @PhRosenberger pls review and let me know your thoughts and improvements.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.