### PR TITLE
Reserve fields above 10000 for extensions (#346)

### DIFF
--- a/doc/description.rst
+++ b/doc/description.rst
@@ -15,6 +15,10 @@ optional. For the purpose of providing a complete interface, all
 existing fields should be set, unless not setting a field carries a
 specific meaning as indicated in the accompanying comment.
 
+All field numbers of 10000 and upward are available for user-specific
+extensions (i.e. custom fields), i.e. no future evolution of OSI will
+use field numbers of 10000 or above itself.
+
 Compatibility
 -------------
 

--- a/doc/description.rst
+++ b/doc/description.rst
@@ -16,7 +16,7 @@ existing fields should be set, unless not setting a field carries a
 specific meaning as indicated in the accompanying comment.
 
 All field numbers of 10000 and upward are available for user-specific
-extensions (i.e. custom fields), i.e. no future evolution of OSI will
+extensions (i.e. custom fields), so no future evolution of OSI will
 use field numbers of 10000 or above itself.
 
 Compatibility


### PR DESCRIPTION
This resolves #346, by reserving all field numbers above 10000 for extensions. Since the extension mechanism of proto2 is not available in proto3, this is currently only fixed in the documentation, and will be taken into the conventions documentation prior to release.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.