### PR TITLE
Fix reference for left version of StVO 214

### DIFF
--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -1333,7 +1333,7 @@ message TrafficSign
                 // </tr>
                 // </table>
                 //
-                // Left: \c #TYPE_PRESCRIBED_LEFT_TURN_AND_RIGHT_TURN
+                // Left: \c #TYPE_PRESCRIBED_LEFT_TURN_AND_STRAIGHT
                 //
                 // As symbolic road marking \c
                 // RoadMarking::Classification::TYPE_SYMBOLIC_TRAFFIC_SIGN


### PR DESCRIPTION
Documentation bug probably due to 2017 renumbering of signs

This is purely cosmetic, but should be fixed to avoid confusion (that said, I'm not sure whether it would not be better to remove all references to "other" signs, since this is error-prone and probably not that helpful anyway).

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.