### PR TITLE
Fix image reference for StVO 222 and 222-10

### DIFF
--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -1441,10 +1441,10 @@ message TrafficSign
                 // <table cellspacing="0" cellpadding="0">
                 // <tr>
                 // <td>
-                // \image html 222.png
+                // \image html 222-10.png
                 // </td>
                 // <td>
-                // StVO 222
+                // StVO 222-10
                 // </td>
                 // </tr>
                 // </table>
@@ -1457,10 +1457,10 @@ message TrafficSign
                 // <table cellspacing="0" cellpadding="0">
                 // <tr>
                 // <td>
-                // \image html 222-10.png
+                // \image html 222.png
                 // </td>
                 // <td>
-                // StVO 222-10
+                // StVO 222
                 // </td>
                 // </tr>
                 // </table>


### PR DESCRIPTION
Documentation bug probably due to 2017 renumbering of signs

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.