### PR TITLE
Two fields added in SensorViewConfiguration for Radar and Lidar.

### DIFF
--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -451,6 +451,22 @@ message RadarSensorViewConfiguration
         // Unit: dB
         optional double response = 3;
     }
+
+
+    // Ray tracing data.
+    //
+    // The maximum length in m of each ray to terminate the ray when reached
+    // and give an intensity of the reflection to 0.
+    //
+    repeated uint32 max_range_per_ray = 12;
+
+    // Ray tracing data.
+    //
+    // The maximum length in m of each path of multiple rays caused by
+    // multi-path propagation in one pixel.
+    // When reached, propagation is terminated.
+    //
+    repeated uint32 max_range_per_pixel = 13;
 }
 
 //
@@ -595,6 +611,21 @@ message LidarSensorViewConfiguration
     // timestamp. Length is num_of_pixels
     //
     repeated uint32 timings = 12;
+
+    // Ray tracing data.
+    //
+    // The maximum length in m of each ray to terminate the ray when reached
+    // and give an intensity of the reflection to 0.
+    //
+    repeated uint32 max_range_per_ray = 13;
+
+    // Ray tracing data.
+    //
+    // The maximum length in m of each path of multiple rays caused by
+    // multi-path propagation in one pixel.
+    // When reached, propagation is terminated.
+    //
+    repeated uint32 max_range_per_pixel = 14;
 }
 
 //


### PR DESCRIPTION
#### Reference to a related issue in the repository
Solves #389.

#### Description
This PR is an extension of OSI with two fields added in `SensorViewConfiguration` for Radar and Lidar to properly configure a ray tracer. One is `max_range_per_ray` in m that terminates a ray if nothing is hit, the other is `max_range_per_pixel` in m that is applied to the sum of the lengths of all rays on one path that terminates the ray propagation in case of multi-path-propagation.

#### Mention a member
@pmai, Please check this extension.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.