### PR TITLE
Add flag to filter static content from SensorView

### DIFF
--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -190,6 +190,13 @@ message SensorViewConfiguration
     // Unit: s
     optional Timestamp simulation_start_time = 10;
 
+    // Omit Static Information
+    //
+    // This flag specifies whether ground truth information can
+    // omit static information or not.
+    //
+    optional bool omit_static_information = 11;
+
     // Generic Sensor View Configuration(s).
     //
     // \note OSI uses singular instead of plural for repeated field names.


### PR DESCRIPTION
This PR represents a PR from the SETLevel4To5 project to add a flag to the SensorViewConfiguration to indicate that no static content should be included in the SensorView ground truth information. It is purposefully left open what constitutes static information, to defer to ASAM discussions on this that transcend this PR. See OpenSimulationInterface/osi-sensor-model-packaging#56 for more details and the corresponding changes to packaging.

This PR is provided as a starting point for discussions in the relevant ASAM WPs.

Signed-off-by: Pierre R. Mai <pmai@pmsf.de>

- [X] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests / travis ci pass locally with my changes.