### PR TITLE
Add global model reference to ground truth

### DIFF
--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -155,4 +155,20 @@ message GroundTruth
     // \note It is implementation-specific how map_reference is resolved.
     //
     optional string map_reference = 15;
+
+    // Opaque reference of an associated 3D model.
+    //
+    // The model covers the static parts of the environment that are not
+    // provided as individual models referenced from ground truth objects
+    // like moving or stationary objects.
+    //
+    // \note Origin and orientation of the model have to coincide with the
+    // inertial coordinate frame of the ground truth.
+    //
+    // \note It is implementation-specific how model_references are resolved to
+    // 3d models. It is also implementation-specific which exact parts this
+    // world model contains, e.g. whether it contains street geometries, or
+    // whether those are derived automatically from a map reference.
+    //
+    optional string model_reference = 16;
 }

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -166,9 +166,9 @@ message GroundTruth
     // inertial coordinate frame of the ground truth.
     //
     // \note It is implementation-specific how model_references are resolved to
-    // 3d models. It is also implementation-specific which exact parts this
-    // world model contains, e.g. whether it contains street geometries, or
-    // whether those are derived automatically from a map reference.
+    // 3d models. The parts the world model contains are also implementation-specific.
+    // For example, the world model can wether contain street geometries or
+    // derives street geometies automatically from a map reference.
     //
     optional string model_reference = 16;
 }


### PR DESCRIPTION
This PR represents a PR from the SETLevel4To5 project, adding an optional model_reference to the top-level ground truth, to allow the specification of a 3D model representing the environment: This model covers the static parts of the environment that are not provided as individual models referenced from ground truth objects like moving or stationary objects. It is implementation-specific which exact parts this world model contains, e.g. whether it contains street geometries, or whether those are derived automatically from a map reference, if one is provided.

Signed-off-by: Pierre R. Mai <pmai@pmsf.de>

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.