### PR TITLE
Introduction of Traffic Participants and releated Top-Level Messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(OSI_PROTO_FILES
     osi_hostvehicledata.proto
     osi_trafficsign.proto
     osi_trafficlight.proto
+    osi_trafficupdate.proto
     osi_roadmarking.proto
     osi_lane.proto
     osi_featuredata.proto

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(OSI_PROTO_FILES
     osi_trafficsign.proto
     osi_trafficlight.proto
     osi_trafficupdate.proto
+    osi_trafficcommand.proto
     osi_roadmarking.proto
     osi_lane.proto
     osi_featuredata.proto

--- a/doc/osifiles.rst
+++ b/doc/osifiles.rst
@@ -38,6 +38,9 @@ OSI common provides the building blocks for the OSI field messages.
 `osi_hostvehicledata.proto`_
 ---------------------------------
 
+`osi_trafficcommand.proto`_
+---------------------------------
+
 `osi_trafficupdate.proto`_
 ---------------------------------
 

--- a/doc/osifiles.rst
+++ b/doc/osifiles.rst
@@ -38,6 +38,9 @@ OSI common provides the building blocks for the OSI field messages.
 `osi_hostvehicledata.proto`_
 ---------------------------------
 
+`osi_trafficupdate.proto`_
+---------------------------------
+
 `osi_trafficsign.proto`_
 ---------------------------------
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -191,20 +191,6 @@ message Orientation3d
 }
 
 //
-// \brief Specifies the Position and Orientation of an object.
-//
-message Position6d
-{
-    // Offset position relative to the specified reference coordinate system.
-    //
-    optional Vector3d position = 1;
-
-    // Orientation offset relative to the specified reference coordinate system.
-    //
-    optional Orientation3d orientation = 2;
-}
-
-//
 // \brief A common identifier (ID), represented as an integer.
 //
 // Has to be unique among all simulated items at any given time. For ground

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -191,6 +191,20 @@ message Orientation3d
 }
 
 //
+// \brief Specifies the Position and Orientation of an object.
+//
+message Position6d
+{
+    // Offset position relative to the specified reference coordinate system.
+    //
+    optional Vector3d position = 1;
+
+    // Orientation offset relative to the specified reference coordinate system.
+    //
+    optional Orientation3d orientation = 2;
+}
+
+//
 // \brief A common identifier (ID), represented as an integer.
 //
 // Has to be unique among all simulated items at any given time. For ground

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -90,11 +90,11 @@ message TrafficAction
     // A SpeedAction
     //
     optional SpeedAction speed_action = 5;    
-	
+
     // An AbortActionsAction
     //
     optional AbortActionsAction abort_actions_action = 6; 
-	
+
     // An EndActionsAction
     //
     optional EndActionsAction end_actions_action = 7; 
@@ -475,7 +475,7 @@ message AbortActionsAction
     // The Action Header
     //
     optional ActionHeader action_header = 1;
-	
+
     // Actions which must be aborted immediately.
     // 
     // These fields hold the action ids of the actions that must be 
@@ -497,11 +497,11 @@ message EndActionsAction
     // The Action Header
     //
     optional ActionHeader action_header = 1;
-	
+
     // Actions which are regarded as successfully executed.
     // 
     // These fields hold the action ids of the actions that are regarded 
-    // as successfully executed and shall be terminated gracefully.	
+    // as successfully executed and shall be terminated gracefully.
     //
     repeated Identifier target_action_id = 2; 
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -80,6 +80,10 @@ message TrafficAction
     // A LaneChangeAction
     //
     optional LaneChangeAction lane_change_action = 4; 
+
+    // A SpeedAction
+    //
+    optional SpeedAction speed_action = 5;    
 }
 
 //
@@ -361,4 +365,80 @@ message LaneChangeAction
         //
         DYNAMICS_SHAPE_STEP = 4;
     }
+}
+
+//
+// \brief Speed Action.
+//
+// This action assigns a targeted speed to a traffic participant. To avoid 
+// contradictory constraints, it shall not be sent if the traffic participant
+// is under impact of a FollowTrajectoryAction. Yet, it may be sent if the 
+// traffic particpiant is under impact of a FollowPathAction, 
+// AcquireGlobalPositionAction or LaneChangeAction.
+// Furthermore, the action can be constrained by specifying the dynamics 
+// shape or even the duration and the distance of the acceleration / 
+// deceleration process.
+//
+// \note This action is aligned with SpeedAction of OpenSCENARIO 1.0
+// defining the targeted speed and optionally the parametrization of the 
+// speed transition.
+//
+
+message SpeedAction
+{
+    // The Action Header
+    //
+    optional ActionHeader action_header = 1;
+    
+    // Targeted absolute speed.
+    //
+    optional double absolute_target_speed = 2;
+    
+    // Specified transition shape of the speed change. This is optional: 
+    // If no dynamics shape is given, the transition is 
+    // open to the traffic participant model.
+    //
+    optional DynamicsShape dynamics_shape = 3;
+    
+    // Specified duration of the speed change. This is optional: 
+    // If no duration is given, the duration of the transition is 
+    // open to the traffic participant model.
+    //
+    // Unit: s
+    //
+    optional double duration = 4; 
+    
+    // Specified distance of the speed change. This is optional: 
+    // If no distance is given, the distance travelled while changing
+    // speed is open to the traffic participant model.
+    //
+    // Unit: m
+    //
+    optional double distance = 5;
+    
+    // Definition of speed change dynamic shapes.
+    //
+    enum DynamicsShape
+    {
+        // Shape is unspecified.
+        //
+        DYNAMICS_SHAPE_UNSPECIFIED = 0;
+
+        // Shape is linear.
+        //
+        DYNAMICS_SHAPE_LINEAR = 1;
+
+        // Shape is cubic.
+        //
+        DYNAMICS_SHAPE_CUBIC = 2;
+
+        // Shape is sinusoidal.
+        //
+        DYNAMICS_SHAPE_SINUSOIDAL = 3;
+
+        // Shape is a step function.
+        //
+        DYNAMICS_SHAPE_STEP = 4;
+    }
+
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -65,13 +65,13 @@ message TrafficCommand
 //
 message TrafficAction
 {
-    // A TrajectoryAction
+    // A FollowTrajectoryAction
     //
-    optional TrajectoryAction trajectory_action = 1;
+    optional FollowTrajectoryAction follow_trajectory_action = 1;
 
-    // A PathAction
+    // A FollowPathAction
     //
-    optional PathAction path_action = 2;
+    optional FollowPathAction follow_path_action = 2;
 
     // An AcquireGlobalPositionAction
     //
@@ -128,20 +128,28 @@ message ActionHeader
 }
 
 //
-// \brief The TrajectoryAction. It provides an interface to describe the motion
-// in space as a function of time.
+// \brief Follow Trajectory Action.
 //
-// \note The StatePoint requires the timestamp to be set.
+// Controls a traffic participant to follow a trajectory using vertices
+// with timings. It specifies the motion in space as a function of time.
 //
-// \note The StatePoint requires the pose (xyz/rpy) to be set.
+// \note The StatePoint messages in trajectory_point require the timestamp
+// to be specified.
 //
-message TrajectoryAction
+// \note This action is aligned with the FollowTrajectoryAction of
+// OpenSCENARIO 1.0 using a 4/7D trajectory with shape Polyline.
+//
+message FollowTrajectoryAction
 {
     // The Action Header
     //
     optional ActionHeader action_header = 1;
 
-    // A list of TrajectoryPoints
+    // A list of trajectory StatePoints
+    //
+    // The timestamp fields for all trajectory points are required to be
+    // set, as are the position fields. The orientation fields can be set
+    // depending on the constrain_orientation field being true.
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
@@ -151,27 +159,60 @@ message TrajectoryAction
     // by the trajectory points
     //
     // This boolean flag defines whether orientation values supplied in 
-    // the trajectory points shall be used to constrain the orientation
-    // of the traffic participant or not.
+    // the trajectory points (if any) shall be used to constrain the
+    // orientation of the traffic participant or not.
     //
     optional bool constrain_orientation = 3;
+
+    // Specify the following mode that should be employed in executing
+    // the trajectory.
+    //
+    optional FollowingMode following_mode = 4;
+
+    // Definition of Following Mode.
+    //
+    enum FollowingMode
+    {
+        // Following mode position forces the traffic participant to
+        // follow the trajectory explicitly, disregarding any internal
+        // constraints, like e.g. steering dynamics.
+        //
+        FOLLOWING_MODE_POSITION = 0;
+
+        // Following mode follow allows the traffic participant to
+        // treat the trajectory as a target, to be achieved as closely
+        // as possible while retaining any internal constraints,
+        // like e.g. steering dynamics.
+        //
+        FOLLOWING_MODE_FOLLOW = 1;
+    }
 }
 
 //
-// \brief The PathAction. It provides an interface to describe a path.
+// \brief Follow Path Action.
 //
-// \note The StatePoint requires the position to be set. The orientation can be
-// set optional.
+// Controls a traffic participant to follow a trajectory using vertices
+// with timings. It specifies the motion in space independent of time.
 //
-// \note All other StatePoint values are ignored.
+// \note The StatePoint messages in path_point only require the position
+// field to be specified. The orientation can be set optionally. Any
+// timestamp StatePoint values are ignored.
 //
-message PathAction
+// \note This action is aligned with the FollowTrajectoryAction of
+// OpenSCENARIO 1.0 using a 3/6D trajectory with shape Polyline.
+//
+message FollowPathAction
 {
     // The Action Header
     //
     optional ActionHeader action_header = 1;
 
-    // A list of PathPoints
+    // A list of path StatePoints
+    //
+    // The position fields for all path points  required to be set.
+    // The timestamp field are not required to be set and are ignored.
+    // The orientation fields can be set depending on the constrain_orientation
+    // field being true.
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
@@ -185,11 +226,44 @@ message PathAction
     // of the traffic participant or not.
     //
     optional bool constrain_orientation = 3;
+
+    // Specify the following mode that should be employed in executing
+    // the path.
+    //
+    optional FollowingMode following_mode = 4;
+
+    // Definition of Following Mode.
+    //
+    enum FollowingMode
+    {
+        // Following mode position forces the traffic participant to
+        // follow the path explicitly, disregarding any internal
+        // constraints, like e.g. steering dynamics.
+        //
+        FOLLOWING_MODE_POSITION = 0;
+
+        // Following mode follow allows the traffic participant to
+        // treat the path as a target, to be achieved as closely
+        // as possible while retaining any internal constraints,
+        // like e.g. steering dynamics.
+        //
+        FOLLOWING_MODE_FOLLOW = 1;
+    }
 }
 
 //
-// \brief Acquire Global Position Action. It provides an interface to describe
-// a target pose.
+// \brief Acquire Global Position Action.
+//
+// This action assigns a route to an traffic participant. The route
+// assigned will be the shortest route (along roads or satisfying any
+// other constraints a traffic participant is operating under) between
+// the traffic participant's current position and the position specified.
+//
+// As with all routing actions, the exact way this route is achieved is
+// under the control of the traffic participant model.
+//
+// \note This action is aligned with the AcquirePositionAction of
+// OpenSCENARIO 1.0 using a WorldPosition position argument.
 //
 message AcquireGlobalPositionAction
 {
@@ -208,6 +282,9 @@ message AcquireGlobalPositionAction
 
     // Orientation in the global coordinate system.
     //
+    // This is optional, if no orientation is given, the end orientation
+    // is under control of the traffic participant.
+    //
     optional Orientation3d orientation = 3;
 }
 
@@ -219,23 +296,23 @@ message LaneChangeAction
     // The Action Header
     //
     optional ActionHeader action_header = 1;
-	
+    
     // Targeted lane relative to the current lane.
     //
     // Convention: +1 means to the right, -1 means to the left.
     //
     optional int32 relative_target_lane = 2;
-	
+    
     // Specified shape of the lane change action.
     //
     optional DynamicsShape dynamics_shape = 3;
-	
+    
     // Duration of the lane change.
     //
     // Unit: s
     //
     optional double duration = 4; 
-	
+    
     // Distance of the lane change.
     //
     // Unit: m
@@ -265,5 +342,5 @@ message LaneChangeAction
         // Shape is a step function.
         //
         DYNAMICS_SHAPE_STEP = 4;
-    }	
+    }
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -87,7 +87,8 @@ message TrafficAction
 //
 // \note The StatePoint definition does not define mandatory fields.
 // The context defines how and what fields are used.
-// For example: Path only used xyz of the StatePoint, trajectory also timestamp...
+// For example: FollowPathAction does not use timestamp in contrast to
+// FollowTrajectoryAction. 
 //
 message StatePoint
 {
@@ -254,7 +255,7 @@ message FollowPathAction
 //
 // \brief Acquire Global Position Action.
 //
-// This action assigns a route to an traffic participant. The route
+// This action assigns a route to a traffic participant. The route
 // assigned will be the shortest route (along roads or satisfying any
 // other constraints a traffic participant is operating under) between
 // the traffic participant's current position and the position specified.
@@ -291,6 +292,17 @@ message AcquireGlobalPositionAction
 //
 // \brief Lane Change Action.
 //
+// This action assigns a lane change to a traffic participant. The fields 
+// of this message enable different levels of constraint for the traffic 
+// participant depending on the use case. In case the constraints are 
+// supposed to be small, the dynamics shape or even the duration and 
+// the distance for the lane change can be omitted.
+//
+// \note This action is aligned with LaneChangeAction of OpenSCENARIO 1.0
+// defining the targeted lane and optionally the parametrization of the 
+// lane change.
+//
+
 message LaneChangeAction
 {
     // The Action Header
@@ -303,17 +315,23 @@ message LaneChangeAction
     //
     optional int32 relative_target_lane = 2;
     
-    // Specified shape of the lane change action.
+    // Specified shape of the lane change action. This is optional: 
+    // If no dynamics shape is given, the shape of the lane change is 
+    // open to the traffic participant model.
     //
     optional DynamicsShape dynamics_shape = 3;
     
-    // Duration of the lane change.
+    // Duration of the lane change. This is optional: 
+    // If no duration is given, the duration of the lane change is 
+    // open to the traffic participant model.
     //
     // Unit: s
     //
     optional double duration = 4; 
     
-    // Distance of the lane change.
+    // Distance of the lane change. This is optional: 
+    // If no distance is given, the distance of the lane change is 
+    // open to the traffic participant model.
     //
     // Unit: m
     //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -8,11 +8,11 @@ import "osi_common.proto";
 package osi3;
 
 //
-// \brief The traffic command message is provided by the scenario
-// engine to traffic participant models to provide control commands
-// to them based on the scenario.
+// \brief The scenario engine provides control commands in the traffic command  
+// message to traffic participant models. The control commands are based on 
+// the scenario.
 //
-// \note This interface is currently just a placeholder, and will be
+// \note This interface is currently just a placeholder and will be
 // changed in experimental ways to support basic scenario execution.
 // In the future this interface shall be aligned with the level of
 // atomic actions as described in OpenSCENARIO 1.0 or later.
@@ -30,8 +30,8 @@ message TrafficCommand
     //
     // \note For traffic command data the timestamp coincides both with
     // the notional simulation time the data applies to and the time it was sent
-    // (there is no inherent latency for traffic command data, as opposed
-    // to sensor data).
+    // There is no inherent latency for traffic command data, as opposed
+    // to sensor data.
     //
     optional Timestamp timestamp = 2;
 
@@ -39,11 +39,11 @@ message TrafficCommand
     //
     optional Identifier traffic_participant_id = 3;
 
-    // Commanded Traffic Action(s) if any
+    // Commanded traffic action(s) if any
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    // \note If more than one action is being supplied in one command message
+    // \note If more than one action is supplied in one command message
     // all actions are executed in parallel.
     //
     repeated TrafficAction action = 4;
@@ -51,22 +51,22 @@ message TrafficCommand
 }
 
 //
-// \brief Atomic Traffic Actions to be performed
+// \brief Atomic traffic actions to be performed
 //
-// The actual commands being transmitted are the atomic traffic actions
-// described by this message.
+// The transmitted commands are the atomic traffic actions described by 
+// this message.
 //
-// \note This message is notionally a multiple choice selection, i.e. only 
+// \note This message is notionally a multiple choice selection, that is, only 
 // certain combinations of atomic traffic actions shall be transmitted within 
-// certain time intervals (e.g. for plausibity reasons). The restrictions 
+// certain time intervals, for example, for plausibity reasons. The restrictions 
 // regarding that are not part of this message, yet are seen as a task of the 
-// scenario description (e.g. OpenSCENARIO). 
+// scenario description, for example, OpenSCENARIO. 
 //
-// \note All TrafficActions are expected to be sent only once, to indicate
-// that they must start immediately. This is also true, if their execution 
-// is expected to take simulation time. To inform the traffic participant 
+// \note All traffic actions are sent only once just before they are about 
+// to start. This is also true, if their execution is expected to 
+// take simulation time. To inform the traffic participant 
 // model that certain actions must or shall be terminated, there are 
-// explicit Actions nested inside this message (AbortActionsAction, 
+// explicit actions nested inside this message (AbortActionsAction, 
 // EndActionsAction), which hold a reference to the respective actions.
 //
 message TrafficAction
@@ -131,7 +131,7 @@ message StatePoint
 }
 
 //
-// \brief The ActionHeader
+// \brief The action header
 //
 //
 message ActionHeader
@@ -147,27 +147,27 @@ message ActionHeader
 }
 
 //
-// \brief Follow Trajectory Action.
+// \brief Follow trajectory action.
 //
 // Controls a traffic participant to follow a trajectory using vertices
 // with timings. It specifies the motion in space as a function of time.
 //
-// \note The StatePoint messages in trajectory_point require the timestamp
-// to be specified.
+// \note The StatePoint messages in trajectory_point requires a  
+// specified timestamp.
 //
 // \note This action is aligned with the FollowTrajectoryAction of
 // OpenSCENARIO 1.0 using a 4/7D trajectory with shape Polyline.
 //
 message FollowTrajectoryAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
 
     // A list of trajectory StatePoints
     //
-    // The timestamp fields for all trajectory points are required to be
-    // set, as are the position fields. The orientation fields can be set
+    // Set the timestamp fields and position fields for all 
+    // trajectory points. The orientation fields can be set
     // depending on the constrain_orientation field being true.
     //
     // \note OSI uses singular instead of plural for repeated field names.
@@ -175,7 +175,7 @@ message FollowTrajectoryAction
     repeated StatePoint trajectory_point = 2;
 
     // Constrain the orientation of the traffic participant as specified
-    // by the trajectory points
+    // by the trajectory points.
     //
     // This boolean flag defines whether orientation values supplied in 
     // the trajectory points (if any) shall be used to constrain the
@@ -188,33 +188,33 @@ message FollowTrajectoryAction
     //
     optional FollowingMode following_mode = 4;
 
-    // Definition of Following Mode.
+    // Definition of following mode.
     //
     enum FollowingMode
     {
         // Following mode position forces the traffic participant to
         // follow the trajectory explicitly, disregarding any internal
-        // constraints, like e.g. steering dynamics.
+        // constraints, for example, steering dynamics.
         //
         FOLLOWING_MODE_POSITION = 0;
 
         // Following mode follow allows the traffic participant to
         // treat the trajectory as a target, to be achieved as closely
         // as possible while retaining any internal constraints,
-        // like e.g. steering dynamics.
+        // for example, steering dynamics.
         //
         FOLLOWING_MODE_FOLLOW = 1;
     }
 }
 
 //
-// \brief Follow Path Action.
+// \brief Follow path action.
 //
 // Controls a traffic participant to follow a trajectory using vertices
 // with timings. It specifies the motion in space independent of time.
 //
-// \note The StatePoint messages in path_point only require the position
-// field to be specified. The orientation can be set optionally. Any
+// \note The StatePoint messages in path_point only requires a specified 
+// position field. The orientation can be set optionally. Any
 // timestamp StatePoint values are ignored.
 //
 // \note This action is aligned with the FollowTrajectoryAction of
@@ -222,14 +222,14 @@ message FollowTrajectoryAction
 //
 message FollowPathAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
 
     // A list of path StatePoints
     //
-    // The position fields for all path points  required to be set.
-    // The timestamp field are not required to be set and are ignored.
+    // Set the position fields for all path points.
+    // The timestamp field are not required and ignored.
     // The orientation fields can be set depending on the constrain_orientation
     // field being true.
     //
@@ -238,7 +238,7 @@ message FollowPathAction
     repeated StatePoint path_point = 2;
 
     // Constrain the orientation of the traffic participant as specified
-    // by the path points
+    // by the path points.
     //
     // This boolean flag defines whether orientation values supplied in 
     // the path points shall be used to constrain the orientation
@@ -251,27 +251,27 @@ message FollowPathAction
     //
     optional FollowingMode following_mode = 4;
 
-    // Definition of Following Mode.
+    // Definition of following mode.
     //
     enum FollowingMode
     {
         // Following mode position forces the traffic participant to
         // follow the path explicitly, disregarding any internal
-        // constraints, like e.g. steering dynamics.
+        // constraints, for example, steering dynamics.
         //
         FOLLOWING_MODE_POSITION = 0;
 
         // Following mode follow allows the traffic participant to
         // treat the path as a target, to be achieved as closely
         // as possible while retaining any internal constraints,
-        // like e.g. steering dynamics.
+        // for example, steering dynamics.
         //
         FOLLOWING_MODE_FOLLOW = 1;
     }
 }
 
 //
-// \brief Acquire Global Position Action.
+// \brief Acquire global position action.
 //
 // This action assigns a route to a traffic participant. The route
 // assigned will be the shortest route (along roads or satisfying any
@@ -286,7 +286,7 @@ message FollowPathAction
 //
 message AcquireGlobalPositionAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
 
@@ -301,14 +301,14 @@ message AcquireGlobalPositionAction
 
     // Orientation in the global coordinate system.
     //
-    // This is optional, if no orientation is given, the end orientation
+    // This is optional. If no orientation is given, the end orientation
     // is under control of the traffic participant.
     //
     optional Orientation3d orientation = 3;
 }
 
 //
-// \brief Lane Change Action.
+// \brief Lane change action.
 //
 // This action assigns a lane change to a traffic participant. The fields 
 // of this message enable different levels of constraint for the traffic 
@@ -323,7 +323,7 @@ message AcquireGlobalPositionAction
 
 message LaneChangeAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
     
@@ -341,7 +341,7 @@ message LaneChangeAction
     
     // Duration of the lane change.
     // 
-    // A value of 0.0 (the default value) will impose no constraint
+    // A value of 0.0 (the default value) imposes no constraint
     // on the duration, unless the dynamics shape is a step function,
     // where an immediate step is effected.
     //
@@ -351,7 +351,7 @@ message LaneChangeAction
     
     // Distance of the lane change.
     // 
-    // A value of 0.0 (the default value) will impose no constraint
+    // A value of 0.0 (the default value) imposes no constraint
     // on the distance, unless the dynamics shape is a step function,
     // where an immediate step is effected.
     //
@@ -386,7 +386,7 @@ message LaneChangeAction
 }
 
 //
-// \brief Speed Action.
+// \brief Speed action.
 //
 // This action assigns a targeted speed to a traffic participant. 
 // The action can be constrained by specifying the dynamics 
@@ -400,7 +400,7 @@ message LaneChangeAction
 
 message SpeedAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
     
@@ -416,7 +416,7 @@ message SpeedAction
     
     // Duration of the speed change.
     // 
-    // A value of 0.0 (the default value) will impose no constraint
+    // A value of 0.0 (the default value) imposes no constraint
     // on the duration, unless the dynamics shape is a step function,
     // where an immediate step is effected.
     //
@@ -426,7 +426,7 @@ message SpeedAction
     
     // Distance of the speed change.
     // 
-    // A value of 0.0 (the default value) will impose no constraint
+    // A value of 0.0 (the default value) imposes no constraint
     // on the distance, unless the dynamics shape is a step function,
     // where an immediate step is effected.
     //
@@ -462,17 +462,17 @@ message SpeedAction
 }
 
 //
-// \brief AbortActionsAction.
+// \brief Abort actions action
 //
-// This action tells a TrafficParticipant that it should abort the
-// execution of other actions (referenced within this action) immediately.
+// This action tells a traffic participant that it should immediately 
+// abort the execution of other actions referenced within this action.
 // In contrast to the EndActionsAction this action forces a hard 
 // termination of the referenced actions.
 //
 
 message AbortActionsAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
 
@@ -484,9 +484,9 @@ message AbortActionsAction
     repeated Identifier target_action_id = 2; 
 }
 
-// \brief EndActionsAction.
+// \brief End actions action.
 //
-// This action tells a TrafficParticipant that the exection of the 
+// This action tells a traffic participant that the exection of the 
 // referenced actions is regarded as successfully performed. The 
 // termination of the referenced actions is allowed to be performed 
 // gracefully. 
@@ -494,7 +494,7 @@ message AbortActionsAction
 
 message EndActionsAction
 {
-    // The Action Header
+    // The action header
     //
     optional ActionHeader action_header = 1;
 

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -84,17 +84,17 @@ message TrafficAction
     //
     optional SpeedAction speed_action = 5;    
 	
-	// A LongitudinalDistanceAction (TODO: to be implemented)
-	//
-	optional LongitudinalDistanceAction longitudinal_distance_action = 6;
+    // A LongitudinalDistanceAction (TODO: to be implemented)
+    //
+    optional LongitudinalDistanceAction longitudinal_distance_action = 6;
 	
-	// LaneOffsetAction (TODO: to be implemented)
-	//
-	optional LaneOffsetAction lane_offset_action = 7;
+    // LaneOffsetAction (TODO: to be implemented)
+    //
+    optional LaneOffsetAction lane_offset_action = 7;
 	
-	// LateralDistanceAction (TODO: to be implemented)
-	// 
-	optional LateralDistanceAction lateral_distance_action = 8; 
+    // LateralDistanceAction (TODO: to be implemented)
+    // 
+    optional LateralDistanceAction lateral_distance_action = 8; 
 }
 
 //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -67,6 +67,10 @@ message TrafficAction
         // A PathAction
         //
         PathAction path_action = 2;
+
+        // An AcquireGlobalPositionAction
+        //
+        AcquireGlobalPositionAction acquire_global_position_action = 3;
     }
 }
 
@@ -181,19 +185,24 @@ message PathAction
 
 
 //
-// \brief Acquire Global Position Action
-//
-// \note This is not discussed in SL425 UAP 2.1.5 and is not part of this
-// proposal. This is temporary for the MS1.
-//
-// \note Remark: The Position6d is a redefinition of a Position + Orientation.
-// Neither the redefinition nore the naming "position" for a pose makes sense.
+// \brief Acquire Global Position Action. It provides an interface to describe
+// a target pose.
 //
 // \note Remark: Maybe better to avoid an other redefinition and use a
-// TrajectoryAction with only trajectorypoint.
+// PathAction with only one path_point.
 //
-message AcquireGlobalPositionAction {
-    // Position and orientation relative to the global coordinate system.
+message AcquireGlobalPositionAction
+{
+    // The action_header
     //
-    optional Position6d position = 1;
+    //
+    optional ActionHeader action_header = 1;
+
+    // Offset position relative to the global coordinate system.
+    //
+    optional Vector3d position = 2;
+
+    // Orientation offset relative to the global coordinate system.
+    //
+    optional Orientation3d orientation = 3;
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -95,7 +95,7 @@ message StatePoint
     //
     // \note Zero time point does not need to coincide with the UNIX epoch.
     //
-    optional Timestamp time_stamp = 1;
+    optional Timestamp timestamp = 1;
 
     // Position in the global coordinate system.
     //
@@ -133,9 +133,6 @@ message ActionHeader
     // \note Zero time point does not need to coincide with the UNIX epoch.
     //
     optional Timestamp start_time = 2;
-  
-    // This boolean describes if the Orientation values in StatePoint shall be set or not: 1 = yes, 0 = no.
-    optional bool Orientation_constrain = 3;
 }
 
 //
@@ -157,8 +154,16 @@ message TrajectoryAction
     // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated StatePoint trajectory_point = 2;
-}
 
+    // Constrain the orientation of the traffic participant as specified
+    // by the trajectory points
+    //
+    // This boolean flag defines whether orientation values supplied in 
+    // the trajectory points shall be used to constrain the orientation
+    // of the traffic participant or not.
+    //
+    optional bool constrain_orientation = 3;
+}
 
 //
 // \brief The PathAction. It provides an interface to describe a path.
@@ -179,6 +184,15 @@ message PathAction
     // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated StatePoint path_point = 2;
+
+    // Constrain the orientation of the traffic participant as specified
+    // by the path points
+    //
+    // This boolean flag defines whether orientation values supplied in 
+    // the path points shall be used to constrain the orientation
+    // of the traffic participant or not.
+    //
+    optional bool constrain_orientation = 3;
 }
 
 //
@@ -214,8 +228,8 @@ message LaneChangeAction
     // Targeted lane relative to the current lane.
     //
     // Convention: +1 means to the right, -1 means to the left.
-    //     
-    optional int32 RelativeTargetLane = 2; 
+    //
+    optional int32 relative_target_lane = 2;
 	
     // Specified shape of the lane change action.
     //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -125,14 +125,6 @@ message ActionHeader
     // messages exchanged with one traffic participant.
     //
     optional Identifier action_id = 1;
-
-    // The start_time can be used to set a starttime of execution
-    //
-    // \note Is optional. If not set, execution must start directly.
-    //
-    // \note Zero time point does not need to coincide with the UNIX epoch.
-    //
-    optional Timestamp start_time = 2;
 }
 
 //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -43,8 +43,8 @@ message TrafficCommand
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    // \note The current SL425 discussion status: We assume all actions are
-    // executed in parallel.
+    // \note If more than one action is being supplied in one command message
+    // all actions are executed in parallel.
     //
     repeated TrafficAction action = 4;
 
@@ -53,14 +53,19 @@ message TrafficCommand
 //
 // \brief Atomic Traffic Actions to be performed
 //
-// \note  This message allows "inheritance", as all TrafficActions can be treated
-// the same, even they have different implementation.
+// The actual commands being transmitted are the atomic traffic actions
+// described by this message.
+//
+// \note This message is notionally a choice selection, i.e. only one
+// of the multiple optional fields in it must be set at any time.
+// It is not defined as a one of field, since this is not currently
+// used in OSI message definitions for portability reasons.  From
+// an API point of view this results in the same generated interface,
+// but without the better enforcement of the restriction on the wire.
 //
 message TrafficAction
 {
-    // Only one of the TrafficActions is supposed to be chosen. Pending, if the proto-keyword "One of" can be used.
-	
-    // A TrafficAction
+    // A TrajectoryAction
     //
     optional TrajectoryAction trajectory_action = 1;
 
@@ -77,18 +82,12 @@ message TrafficAction
     optional LaneChangeAction lane_change_action = 4; 
 }
 
-
-
 //
 // \brief The StatePoint definition
 //
 // \note The StatePoint definition does not define mandatory fields.
 // The context defines how and what fields are used.
 // For example: Path only used xyz of the StatePoint, trajectory also timestamp...
-//
-// A StatePoint contains a BaseMoving (full state with xyz/rpy and the derivatives
-// linear /angular velocity and acceleration).
-// Furthermore it contains a time stamp.
 //
 message StatePoint
 {
@@ -98,8 +97,8 @@ message StatePoint
     //
     optional Timestamp time_stamp = 1;
 
-
-    // Offset position relative to the global coordinate system in [m].
+    // Position in the global coordinate system.
+    //
     // The position refers to the center (x,y,z) of the bounding box.
     //
     // \note Remark: The definition of the reference point follows the
@@ -107,7 +106,7 @@ message StatePoint
     //
     optional Vector3d position = 2;
 
-    // Orientation offset relative to the global coordinate system in [rad].
+    // Orientation in the global coordinate system.
     //
     optional Orientation3d orientation = 3;
 }
@@ -118,29 +117,26 @@ message StatePoint
 //
 message ActionHeader
 {
-  // The unique id of the command
-  //
-  // \note This field is mandatory.
-  //
-  // \note SL425 discussion: In what context must the id be unique? Global, for
-  // all TrafficCommands or only in TrafficCommand context?
-  //
-  optional Identifier action_id = 1;
+    // The unique id of the action
+    //
+    // \note This field is mandatory.
+    //
+    // \note This id must be unique within all traffic command
+    // messages exchanged with one traffic participant.
+    //
+    optional Identifier action_id = 1;
 
-  // The start_time can be used to set a starttime of execution
-  //
-  // \note Is optional. If not set, execution must start directly.
-  //
-  // \note Zero time point does not need to coincide with the UNIX epoch.
-  //
-  optional Timestamp start_time = 2;
+    // The start_time can be used to set a starttime of execution
+    //
+    // \note Is optional. If not set, execution must start directly.
+    //
+    // \note Zero time point does not need to coincide with the UNIX epoch.
+    //
+    optional Timestamp start_time = 2;
   
-  // This boolean describes if the Orientation values in StatePoint shall be set or not: 1 = yes, 0 = no.
-  optional bool Orientation_constrain = 3;
-
+    // This boolean describes if the Orientation values in StatePoint shall be set or not: 1 = yes, 0 = no.
+    optional bool Orientation_constrain = 3;
 }
-
-
 
 //
 // \brief The TrajectoryAction. It provides an interface to describe the motion
@@ -150,15 +146,9 @@ message ActionHeader
 //
 // \note The StatePoint requires the pose (xyz/rpy) to be set.
 //
-// \note The velocity and acceleration can be set. If not set, the model must
-// calculate it itself.
-//
-// \note SL425 discussion: We define it to be set in the world frame atm.
-//
 message TrajectoryAction
 {
-    // The action_header
-    //
+    // The Action Header
     //
     optional ActionHeader action_header = 1;
 
@@ -178,12 +168,9 @@ message TrajectoryAction
 //
 // \note All other StatePoint values are ignored.
 //
-// \note SL425 discussion: We define it to be set in the world frame atm.
-//
 message PathAction
 {
-    // The action_header
-    //
+    // The Action Header
     //
     optional ActionHeader action_header = 1;
 
@@ -194,23 +181,18 @@ message PathAction
     repeated StatePoint path_point = 2;
 }
 
-
-
 //
 // \brief Acquire Global Position Action. It provides an interface to describe
 // a target pose.
 //
-// \note Remark: Maybe better to avoid an other redefinition and use a
-// PathAction with only one path_point.
-//
 message AcquireGlobalPositionAction
 {
-    // The action_header
-    //
+    // The Action Header
     //
     optional ActionHeader action_header = 1;
 
-    // Offset position relative to the global coordinate system in [m].
+    // Position in the global coordinate system.
+    //
     // The position refers to the center (x,y,z) of the bounding box.
     //
     // \note Remark: The definition of the reference point follows the
@@ -218,36 +200,61 @@ message AcquireGlobalPositionAction
     //
     optional Vector3d position = 2;
 
-    // Orientation offset relative to the global coordinate system in [rad].
+    // Orientation in the global coordinate system.
     //
     optional Orientation3d orientation = 3;
 }
 
 message LaneChangeAction
 {
-    // The action_header
-    //
+    // The Action Header
     //
     optional ActionHeader action_header = 1;
 	
-    // Required field for this Action. Targeted Lane relative to the current lane. Convention: +1 means to the right, -1 means to the left. 
+    // Targeted lane relative to the current lane.
+    //
+    // Convention: +1 means to the right, -1 means to the left.
+    //     
     optional int32 RelativeTargetLane = 2; 
 	
-    // Enum definition
+    // Specified shape of the lane change action.
+    //
     optional DynamicsShape dynamics_shape = 3;
 	
-    // duration of the lane change, in seconds
+    // Duration of the lane change.
+    //
+    // Unit: s
+    //
     optional double duration = 4; 
 	
-    // distance of the lane change, in meters
+    // Distance of the lane change.
+    //
+    // Unit: m
+    //
     optional double distance = 5;
-	
+    
+    // Definition of LaneChange dynamic shapes.
+    //
     enum DynamicsShape
     {
-        UNDEFINED = 1; 
-        LINEAR = 2;
-        CUBIC = 3;
-        SINUSOIDAL = 4;
-        STEP = 5;
+        // Shape is unspecified.
+        //
+        DYNAMICS_SHAPE_UNSPECIFIED = 0;
+
+        // Shape is linear.
+        //
+        DYNAMICS_SHAPE_LINEAR = 2;
+
+        // Shape is cubic.
+        //
+        DYNAMICS_SHAPE_CUBIC = 3;
+
+        // Shape is sinusoidal.
+        //
+        DYNAMICS_SHAPE_SINUSOIDAL = 4;
+
+        // Shape is a step function.
+        //
+        DYNAMICS_SHAPE_STEP = 5;
     }	
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -76,7 +76,7 @@ message TrafficAction
     // An AcquireGlobalPositionAction
     //
     optional AcquireGlobalPositionAction acquire_global_position_action = 3;
-	
+
     // A LaneChangeAction
     //
     optional LaneChangeAction lane_change_action = 4; 
@@ -211,6 +211,9 @@ message AcquireGlobalPositionAction
     optional Orientation3d orientation = 3;
 }
 
+//
+// \brief Lane Change Action.
+//
 message LaneChangeAction
 {
     // The Action Header
@@ -249,18 +252,18 @@ message LaneChangeAction
 
         // Shape is linear.
         //
-        DYNAMICS_SHAPE_LINEAR = 2;
+        DYNAMICS_SHAPE_LINEAR = 1;
 
         // Shape is cubic.
         //
-        DYNAMICS_SHAPE_CUBIC = 3;
+        DYNAMICS_SHAPE_CUBIC = 2;
 
         // Shape is sinusoidal.
         //
-        DYNAMICS_SHAPE_SINUSOIDAL = 4;
+        DYNAMICS_SHAPE_SINUSOIDAL = 3;
 
         // Shape is a step function.
         //
-        DYNAMICS_SHAPE_STEP = 5;
+        DYNAMICS_SHAPE_STEP = 4;
     }	
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -58,7 +58,7 @@ message TrafficCommand
 //
 message TrafficAction
 {
-	// Only one of the TrafficActions is supposed to be chosen. Pending, if the proto-keyword "One of" can be used.
+    // Only one of the TrafficActions is supposed to be chosen. Pending, if the proto-keyword "One of" can be used.
 	
     // A TrafficAction
     //
@@ -72,8 +72,8 @@ message TrafficAction
     //
     optional AcquireGlobalPositionAction acquire_global_position_action = 3;
 	
-	// A LaneChangeAction
-	//
+    // A LaneChangeAction
+    //
     optional LaneChangeAction lane_change_action = 4; 
 }
 
@@ -99,11 +99,17 @@ message StatePoint
     optional Timestamp time_stamp = 1;
 
 
-    // BaseMoving to describe a state
+    // Offset position relative to the global coordinate system in [m].
+    // The position refers to the center (x,y,z) of the bounding box.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
+    // \note Remark: The definition of the reference point follows the
+    // specification of the \c BaseMoving message.
     //
-    optional BaseMoving state = 2;
+    optional Vector3d position = 2;
+
+    // Orientation offset relative to the global coordinate system in [rad].
+    //
+    optional Orientation3d orientation = 3;
 }
 
 //
@@ -201,11 +207,15 @@ message AcquireGlobalPositionAction
     //
     optional ActionHeader action_header = 1;
 
-    // Offset position relative to the global coordinate system.
+    // Offset position relative to the global coordinate system in [m].
+    // The position refers to the center (x,y,z) of the bounding box.
+    //
+    // \note Remark: The definition of the reference point follows the
+    // specification of the \c BaseMoving message.
     //
     optional Vector3d position = 2;
 
-    // Orientation offset relative to the global coordinate system.
+    // Orientation offset relative to the global coordinate system in [rad].
     //
     optional Orientation3d orientation = 3;
 }
@@ -217,16 +227,16 @@ message LaneChangeAction
     //
     optional ActionHeader action_header = 1;
 	
-	// Required field for this Action. Targeted Lane relative to the current lane. Convention: +1 means to the right, -1 means to the left. 
+    // Required field for this Action. Targeted Lane relative to the current lane. Convention: +1 means to the right, -1 means to the left. 
     optional int32 RelativeTargetLane = 2; 
 	
-	// Enum definition
+    // Enum definition
     optional DynamicsShape dynamics_shape = 3;
 	
-	// in seconds
+    // in seconds
     optional double LC_duration = 4; 
 	
-	// in meters
+    // in meters
     optional double LC_distance = 5;
 	
     enum DynamicsShape

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -4,7 +4,6 @@ option optimize_for = SPEED;
 
 import "osi_version.proto";
 import "osi_common.proto";
-import "osi_object.proto";
 
 package osi3;
 
@@ -53,5 +52,20 @@ message TrafficCommand
 //
 message TrafficAction
 {
+    // Action to be taken
+    //
+    // \note This could in the future be a oneof field, rather than multiple
+    // optional fields, only one of which should be set at any time.  From
+    // an API point of view this is the same, but with better enforcement
+    // on the wire.
+    optional AcquireGlobalPositionAction acquire_global_position_action = 1;
+}
 
+//
+// \brief Acquire Global Position Action
+//
+message AcquireGlobalPositionAction {
+    // Position and orientation relative to the global coordinate system.
+    //
+    optional Position6d position = 1;
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -25,8 +25,8 @@ message TrafficCommand
 
     // The data timestamp of the simulation environment. Zero time is arbitrary
     // but must be identical for all messages. Zero time does not need to
-    // coincide with the UNIX epoch. Recommended is the starting time point of
-    // the simulation.
+    // coincide with the UNIX epoch. It is recommended to use zero timestamp as 
+    // the starting time point of the simulation.
     //
     // \note For traffic command data the timestamp coincides both with
     // the notional simulation time the data applies to and the time it was sent

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -62,6 +62,13 @@ message TrafficCommand
 // regarding that are not part of this message, yet are seen as a task of the 
 // scenario description (e.g. OpenSCENARIO). 
 //
+// \note All TrafficActions are expected to be sent only once, to indicate
+// that they must start immediately. This is also true, if their execution 
+// is expected to take simulation time. To inform the traffic participant 
+// model that certain actions must or shall be terminated, there are 
+// explicit Actions nested inside this message (AbortActionsAction, 
+// EndActionsAction), which hold a reference to the respective actions.
+//
 message TrafficAction
 {
     // A FollowTrajectoryAction
@@ -83,6 +90,14 @@ message TrafficAction
     // A SpeedAction
     //
     optional SpeedAction speed_action = 5;    
+	
+    // An AbortActionsAction
+    //
+    optional AbortActionsAction abort_actions_action = 6; 
+	
+    // An EndActionsAction
+    //
+    optional EndActionsAction end_actions_action = 7; 
 }
 
 //
@@ -444,4 +459,49 @@ message SpeedAction
         DYNAMICS_SHAPE_STEP = 4;
     }
 
+}
+
+//
+// \brief AbortActionsAction.
+//
+// This action tells a TrafficParticipant that it should abort the
+// execution of other actions (referenced within this action) immediately.
+// In contrast to the EndActionsAction this action forces a hard 
+// termination of the referenced actions.
+//
+
+message AbortActionsAction
+{
+    // The Action Header
+    //
+    optional ActionHeader action_header = 1;
+	
+    // Actions which must be aborted immediately.
+    // 
+    // These fields hold the action ids of the actions that must be 
+    // aborted immediately. 
+    //
+    repeated Identifier target_action_id = 2; 
+}
+
+// \brief EndActionsAction.
+//
+// This action tells a TrafficParticipant that the exection of the 
+// referenced actions is regarded as successfully performed. The 
+// termination of the referenced actions is allowed to be performed 
+// gracefully. 
+//
+
+message EndActionsAction
+{
+    // The Action Header
+    //
+    optional ActionHeader action_header = 1;
+	
+    // Actions which are regarded as successfully executed.
+    // 
+    // These fields hold the action ids of the actions that are regarded 
+    // as successfully executed and shall be terminated gracefully.	
+    //
+    repeated Identifier target_action_id = 2; 
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -83,18 +83,6 @@ message TrafficAction
     // A SpeedAction
     //
     optional SpeedAction speed_action = 5;    
-	
-    // A LongitudinalDistanceAction (TODO: to be implemented)
-    //
-    optional LongitudinalDistanceAction longitudinal_distance_action = 6;
-	
-    // LaneOffsetAction (TODO: to be implemented)
-    //
-    optional LaneOffsetAction lane_offset_action = 7;
-	
-    // LateralDistanceAction (TODO: to be implemented)
-    // 
-    optional LateralDistanceAction lateral_distance_action = 8; 
 }
 
 //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -83,6 +83,18 @@ message TrafficAction
     // A SpeedAction
     //
     optional SpeedAction speed_action = 5;    
+	
+	// A LongitudinalDistanceAction (TODO: to be implemented)
+	//
+	optional LongitudinalDistanceAction longitudinal_distance_action = 6;
+	
+	// LaneOffsetAction (TODO: to be implemented)
+	//
+	optional LaneOffsetAction lane_offset_action = 7;
+	
+	// LateralDistanceAction (TODO: to be implemented)
+	// 
+	optional LateralDistanceAction lateral_distance_action = 8; 
 }
 
 //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -1,0 +1,57 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_version.proto";
+import "osi_common.proto";
+import "osi_object.proto";
+
+package osi3;
+
+//
+// \brief The traffic command message is provided by the scenario
+// engine to traffic participant models to provide control commands
+// to them based on the scenario.
+//
+// \note This interface is currently just a placeholder, and will be
+// changed in experimental ways to support basic scenario execution.
+// In the future this interface shall be aligned with the level of
+// atomic actions as described in OpenSCENARIO 1.0 or later.
+//
+message TrafficCommand
+{
+    // The interface version used by the sender (scenario engine).
+    //
+    optional InterfaceVersion version = 1;
+
+    // The data timestamp of the simulation environment. Zero time is arbitrary
+    // but must be identical for all messages. Zero time does not need to
+    // coincide with the UNIX epoch. Recommended is the starting time point of
+    // the simulation.
+    //
+    // \note For traffic command data the timestamp coincides both with
+    // the notional simulation time the data applies to and the time it was sent
+    // (there is no inherent latency for traffic command data, as opposed
+    // to sensor data).
+    //
+    optional Timestamp timestamp = 2;
+
+    // The ID of this traffic participant.
+    //
+    optional Identifier traffic_participant_id = 3;
+
+    // Commanded Traffic Action(s) if any
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated TrafficAction action = 4;
+
+}
+
+//
+// \brief Atomic Traffic Actions to be performed
+//
+message TrafficAction
+{
+
+}

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -43,6 +43,9 @@ message TrafficCommand
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
+    // \note The current SL425 discussion status: We assume all actions are
+    // executed in parallel.
+    //
     repeated TrafficAction action = 4;
 
 }
@@ -50,19 +53,144 @@ message TrafficCommand
 //
 // \brief Atomic Traffic Actions to be performed
 //
+// \note  This message allows "inheritance", as all TrafficActions can be treated
+// the same, even they have different implementation.
+//
 message TrafficAction
 {
-    // Action to be taken
+    oneof Action {
+
+        // A TrafficAction
+        //
+        TrajectoryAction trajectory_action = 1;
+
+        // A PathAction
+        //
+        PathAction path_action = 2;
+    }
+}
+
+
+
+//
+// \brief The StatePoint definition
+//
+// \note The StatePoint definition does not define mandatory fields.
+// The context defines how and what fields are used.
+// For example: Path only used xyz of the StatePoint, trajectory also timestamp...
+//
+// A StatePoint contains a BaseMoving (full state with xyz/rpy and the derivatives
+// linear /angular velocity and acceleration).
+// Furthermore it contains a time stamp.
+//
+message StatePoint
+{
+    // The timestamp of a StatePoint
     //
-    // \note This could in the future be a oneof field, rather than multiple
-    // optional fields, only one of which should be set at any time.  From
-    // an API point of view this is the same, but with better enforcement
-    // on the wire.
-    optional AcquireGlobalPositionAction acquire_global_position_action = 1;
+    // \note Zero time point does not need to coincide with the UNIX epoch.
+    //
+    optional Timestamp time_stamp = 1;
+
+
+    // BaseMoving to describe a state
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    optional BaseMoving state = 2;
 }
 
 //
+// \brief The ActionHeader
+//
+//
+message ActionHeader
+{
+  // The unique id of the command
+  //
+  // \note This field is mandatory.
+  //
+  // \note SL425 discussion: In what context must the id be unique? Global, for
+  // all TrafficCommands or only in TrafficCommand context?
+  //
+  optional Identifier action_id = 1;
+
+  // The start_time can be used to set a starttime of execution
+  //
+  // \note Is optional. If not set, execution must start directly.
+  //
+  // \note Zero time point does not need to coincide with the UNIX epoch.
+  //
+  optional Timestamp start_time = 2;
+
+}
+
+
+
+//
+// \brief The TrajectoryAction. It provides an interface to describe the motion
+// in space as a function of time.
+//
+// \note The StatePoint requires the timestamp to be set.
+//
+// \note The StatePoint requires the pose (xyz/rpy) to be set.
+//
+// \note The velocity and acceleration can be set. If not set, the model must
+// calculate it itself.
+//
+// \note SL425 discussion: We define it to be set in the world frame atm.
+//
+message TrajectoryAction
+{
+    // The action_header
+    //
+    //
+    optional ActionHeader action_header = 1;
+
+    // A list of TrajectoryPoints
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated StatePoint trajectory_point = 2;
+}
+
+
+//
+// \brief The PathAction. It provides an interface to describe a path.
+//
+// \note The StatePoint requires the position to be set. The orientation can be
+// set optional.
+//
+// \note All other StatePoint values are ignored.
+//
+// \note SL425 discussion: We define it to be set in the world frame atm.
+//
+message PathAction
+{
+    // The action_header
+    //
+    //
+    optional ActionHeader action_header = 1;
+
+    // A list of PathPoints
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated StatePoint path_point = 2;
+}
+
+
+
+//
 // \brief Acquire Global Position Action
+//
+// \note This is not discussed in SL425 UAP 2.1.5 and is not part of this
+// proposal. This is temporary for the MS1.
+//
+// \note Remark: The Position6d is a redefinition of a Position + Orientation.
+// Neither the redefinition nore the naming "position" for a pose makes sense.
+//
+// \note Remark: Maybe better to avoid an other redefinition and use a
+// TrajectoryAction with only trajectorypoint.
 //
 message AcquireGlobalPositionAction {
     // Position and orientation relative to the global coordinate system.

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -134,6 +134,9 @@ message ActionHeader
   // \note Zero time point does not need to coincide with the UNIX epoch.
   //
   optional Timestamp start_time = 2;
+  
+  // This boolean describes if the Orientation values in StatePoint shall be set or not: 1 = yes, 0 = no.
+  optional bool Orientation_constrain = 3;
 
 }
 
@@ -233,11 +236,11 @@ message LaneChangeAction
     // Enum definition
     optional DynamicsShape dynamics_shape = 3;
 	
-    // in seconds
-    optional double LC_duration = 4; 
+    // duration of the lane change, in seconds
+    optional double duration = 4; 
 	
-    // in meters
-    optional double LC_distance = 5;
+    // distance of the lane change, in meters
+    optional double distance = 5;
 	
     enum DynamicsShape
     {

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -56,12 +56,11 @@ message TrafficCommand
 // The actual commands being transmitted are the atomic traffic actions
 // described by this message.
 //
-// \note This message is notionally a choice selection, i.e. only one
-// of the multiple optional fields in it must be set at any time.
-// It is not defined as a one of field, since this is not currently
-// used in OSI message definitions for portability reasons.  From
-// an API point of view this results in the same generated interface,
-// but without the better enforcement of the restriction on the wire.
+// \note This message is notionally a multiple choice selection, i.e. only 
+// certain combinations of atomic traffic actions shall be transmitted within 
+// certain time intervals (e.g. for plausibity reasons). The restrictions 
+// regarding that are not part of this message, yet are seen as a task of the 
+// scenario description (e.g. OpenSCENARIO). 
 //
 message TrafficAction
 {
@@ -319,23 +318,27 @@ message LaneChangeAction
     //
     optional int32 relative_target_lane = 2;
     
-    // Specified shape of the lane change action. This is optional: 
-    // If no dynamics shape is given, the shape of the lane change is 
-    // open to the traffic participant model.
+    // Specified shape of the lane change action. 
+    // If the shape is unspecified (enum value 0), the shape of the 
+    // lane change is open to the traffic participant model. 
     //
     optional DynamicsShape dynamics_shape = 3;
     
-    // Duration of the lane change. This is optional: 
-    // If no duration is given, the duration of the lane change is 
-    // open to the traffic participant model.
+    // Duration of the lane change.
+    // 
+    // A value of 0.0 (the default value) will impose no constraint
+    // on the duration, unless the dynamics shape is a step function,
+    // where an immediate step is effected.
     //
     // Unit: s
     //
     optional double duration = 4; 
     
-    // Distance of the lane change. This is optional: 
-    // If no distance is given, the distance of the lane change is 
-    // open to the traffic participant model.
+    // Distance of the lane change.
+    // 
+    // A value of 0.0 (the default value) will impose no constraint
+    // on the distance, unless the dynamics shape is a step function,
+    // where an immediate step is effected.
     //
     // Unit: m
     //
@@ -370,12 +373,8 @@ message LaneChangeAction
 //
 // \brief Speed Action.
 //
-// This action assigns a targeted speed to a traffic participant. To avoid 
-// contradictory constraints, it shall not be sent if the traffic participant
-// is under impact of a FollowTrajectoryAction. Yet, it may be sent if the 
-// traffic particpiant is under impact of a FollowPathAction, 
-// AcquireGlobalPositionAction or LaneChangeAction.
-// Furthermore, the action can be constrained by specifying the dynamics 
+// This action assigns a targeted speed to a traffic participant. 
+// The action can be constrained by specifying the dynamics 
 // shape or even the duration and the distance of the acceleration / 
 // deceleration process.
 //
@@ -394,23 +393,27 @@ message SpeedAction
     //
     optional double absolute_target_speed = 2;
     
-    // Specified transition shape of the speed change. This is optional: 
-    // If no dynamics shape is given, the transition is 
-    // open to the traffic participant model.
+    // Specified transition shape of the speed change action. 
+    // If the shape is unspecified (enum value 0), the shape of the 
+    // speed change is open to the traffic participant model. 
     //
     optional DynamicsShape dynamics_shape = 3;
     
-    // Specified duration of the speed change. This is optional: 
-    // If no duration is given, the duration of the transition is 
-    // open to the traffic participant model.
+    // Duration of the speed change.
+    // 
+    // A value of 0.0 (the default value) will impose no constraint
+    // on the duration, unless the dynamics shape is a step function,
+    // where an immediate step is effected.
     //
     // Unit: s
     //
     optional double duration = 4; 
     
-    // Specified distance of the speed change. This is optional: 
-    // If no distance is given, the distance travelled while changing
-    // speed is open to the traffic participant model.
+    // Distance of the speed change.
+    // 
+    // A value of 0.0 (the default value) will impose no constraint
+    // on the distance, unless the dynamics shape is a step function,
+    // where an immediate step is effected.
     //
     // Unit: m
     //

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -58,20 +58,23 @@ message TrafficCommand
 //
 message TrafficAction
 {
-    oneof Action {
+	// Only one of the TrafficActions is supposed to be chosen. Pending, if the proto-keyword "One of" can be used.
+	
+    // A TrafficAction
+    //
+    optional TrajectoryAction trajectory_action = 1;
 
-        // A TrafficAction
-        //
-        TrajectoryAction trajectory_action = 1;
+    // A PathAction
+    //
+    optional PathAction path_action = 2;
 
-        // A PathAction
-        //
-        PathAction path_action = 2;
-
-        // An AcquireGlobalPositionAction
-        //
-        AcquireGlobalPositionAction acquire_global_position_action = 3;
-    }
+    // An AcquireGlobalPositionAction
+    //
+    optional AcquireGlobalPositionAction acquire_global_position_action = 3;
+	
+	// A LaneChangeAction
+	//
+    optional LaneChangeAction lane_change_action = 4; 
 }
 
 
@@ -205,4 +208,33 @@ message AcquireGlobalPositionAction
     // Orientation offset relative to the global coordinate system.
     //
     optional Orientation3d orientation = 3;
+}
+
+message LaneChangeAction
+{
+    // The action_header
+    //
+    //
+    optional ActionHeader action_header = 1;
+	
+	// Required field for this Action. Targeted Lane relative to the current lane. Convention: +1 means to the right, -1 means to the left. 
+    optional int32 RelativeTargetLane = 2; 
+	
+	// Enum definition
+    optional DynamicsShape dynamics_shape = 3;
+	
+	// in seconds
+    optional double LC_duration = 4; 
+	
+	// in meters
+    optional double LC_distance = 5;
+	
+    enum DynamicsShape
+    {
+        UNDEFINED = 1; 
+        LINEAR = 2;
+        CUBIC = 3;
+        SINUSOIDAL = 4;
+        STEP = 5;
+    }	
 }

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -1,0 +1,51 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_version.proto";
+import "osi_common.proto";
+import "osi_object.proto";
+
+package osi3;
+
+//
+// \brief The traffic update message is provided by traffic
+// participant models to provide updates to their position and
+// state back to the simulation environment.
+//
+// \note Note that for reasons of convenience and consistency, the
+// updated information is provided as a MovingObject.  Certain fields
+// of this sub-message need not be set and will be ignored by the
+// simulation environment, because they are in fact static information.
+// Instead of creating a seperate message type for only the non-static
+// information, re-use of the existing message was considered more
+// appropriate.
+//
+message TrafficUpdate
+{
+    // The interface version used by the sender (traffic participant model).
+    //
+    optional InterfaceVersion version = 1;
+
+    // The data timestamp of the simulation environment. Zero time is arbitrary
+    // but must be identical for all messages. Zero time does not need to
+    // coincide with the UNIX epoch. Recommended is the starting time point of
+    // the simulation.
+    //
+    // \note For moving object update data the timestamp coincides both with
+    // the notional simulation time the data applies to and the time it was sent
+    // (there is no inherent latency for moving object update data, as opposed
+    // to sensor data).
+    //
+    optional Timestamp timestamp = 2;
+
+    // Updated Moving Object
+    //
+    // \note Only the id, base member (without dimension and base_polygon),
+    // and the vehicle_classification.light_state members are considered in
+    // updates, all other members can be left undefined, and will be
+    // ignored by the receiver of this message.
+    //
+    optional MovingObject update = 3;
+
+}

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -40,7 +40,7 @@ message TrafficUpdate
 
     // Updated moving object
     //
-    // \note Only the following member are considered in updates: id, base member 
+    // \note Only the following members are considered in updates: id, base member 
     // without dimension and base_polygon and the vehicle_classification.light_state.
     // All other members can be left undefined and will be
     // ignored by the receiver of this message.

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -13,13 +13,12 @@ package osi3;
 // participant models to provide updates to their position and
 // state back to the simulation environment.
 //
-// \note Note that for reasons of convenience and consistency, the
+// \note For reasons of convenience and consistency, the
 // updated information is provided as a MovingObject.  Certain fields
-// of this sub-message need not be set and will be ignored by the
-// simulation environment, because they are in fact static information.
+// of this sub-message are not required to be set and will be ignored by the
+// simulation environment, because they are static information.
 // Instead of creating a seperate message type for only the non-static
-// information, re-use of the existing message was considered more
-// appropriate.
+// information, re-use existing message.
 //
 message TrafficUpdate
 {
@@ -33,17 +32,17 @@ message TrafficUpdate
     // the simulation.
     //
     // \note For moving object update data the timestamp coincides both with
-    // the notional simulation time the data applies to and the time it was sent
-    // (there is no inherent latency for moving object update data, as opposed
-    // to sensor data).
+    // the notional simulation time the data applies to and the time it was sent.
+    // There is no inherent latency for moving object update data, as opposed
+    // to sensor data.
     //
     optional Timestamp timestamp = 2;
 
-    // Updated Moving Object
+    // Updated moving object
     //
-    // \note Only the id, base member (without dimension and base_polygon),
+    // \note Only the id, base member without dimension and base_polygon
     // and the vehicle_classification.light_state members are considered in
-    // updates, all other members can be left undefined, and will be
+    // updates. All other members can be left undefined and will be
     // ignored by the receiver of this message.
     //
     optional MovingObject update = 3;

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -40,9 +40,9 @@ message TrafficUpdate
 
     // Updated moving object
     //
-    // \note Only the id, base member without dimension and base_polygon
-    // and the vehicle_classification.light_state members are considered in
-    // updates. All other members can be left undefined and will be
+    // \note Only the following member are considered in updates: id, base member 
+    // without dimension and base_polygon and the vehicle_classification.light_state.
+    // All other members can be left undefined and will be
     // ignored by the receiver of this message.
     //
     optional MovingObject update = 3;

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ class GenerateProtobufCommand(build_py):
         'osi_hostvehicledata.proto',
         'osi_trafficsign.proto',
         'osi_trafficlight.proto',
+        'osi_trafficupdate.proto',
         'osi_roadmarking.proto',
         'osi_featuredata.proto',
         'osi_object.proto',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ class GenerateProtobufCommand(build_py):
         'osi_trafficsign.proto',
         'osi_trafficlight.proto',
         'osi_trafficupdate.proto',
+        'osi_trafficcommand.proto',
         'osi_roadmarking.proto',
         'osi_featuredata.proto',
         'osi_object.proto',


### PR DESCRIPTION
The basis of this PR is the consolidated traffic participant feature branch from the SETLevel4To5 project, which provides for traffic participant modeling through the newly introduced TrafficUpdate and TrafficCommand top-level messages. Note that this initial contribution has already been enhanced inside the ASAM project as well.

This draft PR is created in order to highlight this proposal and allow coordinated further work on it inside the relevant ASAM WPs.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.