### PR TITLE
Extension of traffic lights and signs regarding model references

### DIFF
--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -35,6 +35,13 @@ message TrafficLight
     //
     optional Classification classification = 3;
 
+    // Opaque reference of an associated 3D model of the traffic light.
+    //
+    // \note It is implementation-specific how model_references are resolved to
+    // 3d models.
+    //
+    optional string model_reference = 4;
+
     //
     // \brief \c Classification data for a traffic light.
     //

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -181,6 +181,13 @@ message TrafficSign
         //
         optional Classification classification = 2;
 
+        // Opaque reference of an associated 3D model of the traffic sign.
+        //
+        // \note It is implementation-specific how model_references are resolved to
+        // 3d models.
+        //
+        optional string model_reference = 3;
+
         //
         // \brief \c Classification data for a traffic sign.
         //
@@ -5458,6 +5465,13 @@ message TrafficSign
         // The classification of the supplementary traffic sign.
         //
         optional Classification classification = 2;
+
+        // Opaque reference of an associated 3D model of the supplementary traffic sign.
+        //
+        // \note It is implementation-specific how model_references are resolved to
+        // 3d models.
+        //
+        optional string model_reference = 3;
 
         //
         // \brief \c Classification data for a supplementary traffic sign.


### PR DESCRIPTION
#### Reference to a related issue in the repository
No related issue.

#### Add a description
Beside the model_references in stationary and moving object, it can be helpful to have a reference packed within traffic lights and traffic signs (main sign + supplementary sign).
The model_reference can be used e.g. to tell which 3D-model should be visualized.

**Some questions to ask**:

- What is this change?
Added three model_references

- What does it fix? Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
It's a new feature the helps to use osi for visualization. 
How has it been tested?
It works, testing was company internally.

#### Mention a member
@pmai , @engelben 
This would be a PR for the planned CCB.

#### Check the checklist

- [ ] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.