### PR TITLE
Add new LogicalDetectionData message to SensorData

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(OSI_PROTO_FILES
     osi_roadmarking.proto
     osi_lane.proto
     osi_featuredata.proto
+    osi_logicaldetectiondata.proto
     osi_object.proto
     osi_occupant.proto
     osi_sensordata.proto

--- a/doc/osifiles.rst
+++ b/doc/osifiles.rst
@@ -56,6 +56,9 @@ OSI common provides the building blocks for the OSI field messages.
 `osi_featuredata.proto`_
 ---------------------------------
 
+`osi_logicaldetectiondata.proto`_
+---------------------------------
+
 `osi_object.proto`_
 ---------------------------------
 

--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -1,0 +1,228 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_version.proto";
+import "osi_common.proto";
+
+package osi3;
+
+//
+// \brief Processed data from one or multiple sensors as a list of logical detections. Logical detections are derived from sensor detections in a logical model through processing steps like fusion filtering, tracking etc.
+//
+// All information is given with respect to the reference frame of the logical/virtual sensor
+// \c SensorView::mounting_position (e.g. center of rear axle of the ego car) in Cartesian coordinates.
+//
+message LogicalDetectionData
+{
+    // The interface version used by the sender (i.e. the simulation
+    // environment).
+    //
+    optional InterfaceVersion version = 1;
+
+    // Header attributes of fused detections from multiple sensors and sensor types.
+    //
+    optional LogicalDetectionDataHeader header = 2;
+
+    // logical detections consisting of transformed (and potentially fused) detections from one or multiple sensors and sensor types.
+    // Logical detections are given with respect to the reference frame of the logical/virtual sensor
+    // \c SensorView::mounting_position (e.g. center of rear axle of the ego car)
+    //
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated LogicalDetection logical_detection = 3;
+}
+
+//
+// \brief The header attributes of the list of logical detections.
+//
+message LogicalDetectionDataHeader
+{
+    // Time stamp at which the transformation and optional fusion was finished in the global synchronized time.
+    //
+    // \note See \c SensorData::timestamp and
+    // \c SensorData::last_measurement_time for detailed discussions on the
+    // semantics of time-related fields.
+    //
+    optional Timestamp logical_detection_time = 1;
+
+    // Data Qualifier expresses to what extent the content of this event can be
+    // relied on.
+    //
+    optional DataQualifier data_qualifier = 2;
+
+    // The current number of valid detections in the logical detections list.
+    //
+    // \note This value has to be set if the list contains invalid logical detections.
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // \endrules
+    //
+    optional uint32 number_of_valid_logical_detections = 3;
+
+    // The IDs of the sensors that have been fused and result in the listed logical detections.
+    //
+    repeated Identifier sensor_id = 4;
+
+    // Data qualifier communicates the overall availability of the
+    // interface.
+    //
+    enum DataQualifier
+    {
+        // Unknown (must not be used in ground truth).
+        //
+        DATA_QUALIFIER_UNKNOWN = 0;
+
+        // Other (unspecified but known).
+        //
+        DATA_QUALIFIER_OTHER = 1;
+
+        // Data is available.
+        //
+        DATA_QUALIFIER_AVAILABLE = 2;
+
+        // Reduced data is available.
+        //
+        DATA_QUALIFIER_AVAILABLE_REDUCED = 3;
+
+        // Data is not available.
+        //
+        DATA_QUALIFIER_NOT_AVAILABLE = 4;
+
+        // Sensor is blind.
+        //
+        DATA_QUALIFIER_BLINDNESS = 5;
+
+        // Sensor temporary available.
+        //
+        DATA_QUALIFIER_TEMPORARY_AVAILABLE = 6;
+
+        // Sensor invalid.
+        //
+        DATA_QUALIFIER_INVALID = 7;
+    }
+}
+
+//
+// \brief A logical detection that could be based on multiple sensors and sensor types.
+//
+message LogicalDetection
+{
+    // Existence probability of the logical detection
+    //
+    // \note Use as confidence measure where a low value means less confidence
+    // and a high value indicates strong confidence.
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // is_less_than_or_equal_to: 1
+    // \endrules
+    //
+    optional double existence_probability = 1;
+
+    // ID of the detected object this logical detection is associated to.
+    //
+    // \note ID = MAX(uint64) indicates no reference to an object.
+    //
+    // \rules
+    // refers_to: DetectedObject
+    // \endrules
+    //
+    optional Identifier object_id = 2;
+
+    // Measured position of the logical detection given in cartesian coordinates in the
+    // host vehicle coordinate system.
+    //
+    // Unit: m
+    //
+    optional Vector3d position = 3;
+
+    // Root mean squared error of the measured position of the logical detection.
+    //
+    optional Vector3d position_rmse = 4;
+
+    // Velocity of the logical detection given in cartesian coordinates in the
+    // host vehicle coordinate system.
+    //
+    // Unit: m/s
+    //
+    optional Vector3d velocity = 5;
+
+    // Root mean squared error of the logical detection's velocity.
+    //
+    // Unit: m/s
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // \endrules
+    //
+    optional Vector3d velocity_rmse = 6;
+
+    // Intensity or equivalent value of the logical detection's echo.
+    //
+    // Unit: %
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // is_less_than_or_equal_to: 100
+    // \endrules
+    //
+    optional double intensity = 7;
+
+    // The signal to noise ratio (SNR) of the logical detection.
+    //
+    // Unit: dB
+    //
+    optional double snr = 8;
+
+    // Describes the possibility whether more than one object may have led to
+    // this logical detection.
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // is_less_than_or_equal_to: 1
+    // \endrules
+    //
+    optional double point_target_probability = 9;
+
+    // The IDs of the sensors that have been fused to the single logical detection.
+    //
+    // \note one logical detection can originate from multiple sensors.
+    //
+    repeated Identifier sensor_id = 10;
+
+    // Basic classification of the logical detection.
+    //
+    optional LogicalDetectionClassification classification = 11;
+}
+
+// Definition of basic logical detection classifications.
+//
+enum LogicalDetectionClassification
+{
+    // Logical detection is unknown (must not be used in ground truth).
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_UNKNOWN = 0;
+
+    // Other (unspecified but known) logical detection.
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_OTHER = 1;
+
+    // Invalid logical detection, not to be used for object tracking, of unspecified
+    // type (none of the other types applies).
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_INVALID = 2;
+
+    // Clutter (noise, spray, rain, fog etc.).
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_CLUTTER = 3;
+
+    // Over-drivable (ground etc.).
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_OVERDRIVABLE = 4;
+
+    // Under-drivable (sign gantry etc.).
+    //
+    LOGICAL_DETECTION_CLASSIFICATION_UNDERDRIVABLE = 5;
+}

--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -8,7 +8,8 @@ import "osi_common.proto";
 package osi3;
 
 //
-// \brief Processed data from one or multiple sensors as a list of logical detections. Logical detections are derived from sensor detections in a logical model through processing steps like fusion filtering, tracking etc.
+// \brief Processed data from one or multiple sensors as a list of logical detections.
+// Logical detections are derived from sensor detections in a logical model through processing steps like fusion filtering, tracking etc.
 //
 // All information is given with respect to the reference frame of the logical/virtual sensor
 // \c SensorView::mounting_position (e.g. center of rear axle of the ego car) in Cartesian coordinates.
@@ -34,7 +35,7 @@ message LogicalDetectionData
 }
 
 //
-// \brief The header attributes of the list of logical detections.
+// \brief The header attributes of each sensor's logical detections list.
 //
 message LogicalDetectionDataHeader
 {
@@ -61,7 +62,8 @@ message LogicalDetectionDataHeader
     //
     optional uint32 number_of_valid_logical_detections = 3;
 
-    // The IDs of the sensors that have been fused and result in the listed logical detections.
+    // The ID(s) of the sensor(s) that produced the detections for transformation
+    // and - in case of multiple sensors - fusion into logical detections.
     //
     repeated Identifier sensor_id = 4;
 
@@ -186,9 +188,10 @@ message LogicalDetection
     //
     optional double point_target_probability = 9;
 
-    // The IDs of the sensors that have been fused to the single logical detection.
+    // The ID(s) of the sensor(s) that produced the detection(s) for transformation
+    // and - in case of multiple sensors - fusion into the single logical detection.
     //
-    // \note one logical detection can originate from multiple sensors.
+    // \note One logical detection can originate from multiple sensors.
     //
     repeated Identifier sensor_id = 10;
 

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -12,6 +12,7 @@ import "osi_detectedobject.proto";
 import "osi_detectedoccupant.proto";
 import "osi_sensorview.proto";
 import "osi_featuredata.proto";
+import "osi_logicaldetectiondata.proto";
 
 package osi3;
 
@@ -92,7 +93,7 @@ message DetectedEntityHeader
 //
 // Sensor fusion models can consolidate multiple \c SensorData interfaces into
 // one consolidated \c SensorData interface.  This can happen either in
-// seperate logical models, consuming and producing \c SensorData interfaces,
+// separate logical models, consuming and producing \c SensorData interfaces,
 // or it can happen as part of a combined sensor/logical model, that consumes
 // \c SensorView interfaces and directly produces one consolidated \c SensorData
 // output.
@@ -297,4 +298,19 @@ message SensorData
     // object hypothesis and tracking.
     //
     optional FeatureData feature_data = 26;
+
+    // Logical detection data interface.
+    //
+    // Logical detection data are provided by a transformation
+    // (and optional sensor fusion)
+    // performed by a sensor model or a logical Model
+    // that fuses multiple sensors and/or sensor types
+    // into a single reference frame
+    // of the so called logical/virtual sensor.
+    // Therefore, all information is given with respect to
+    // the reference frame of the logical/virtual sensor
+    // \c SensorView::mounting_position (e.g. center of rear axle of the ego car)
+    // in cartesian coordinates.
+    //
+    optional LogicalDetectionData logical_detection_data = 27;
 }

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -303,7 +303,7 @@ message SensorData
     //
     // Logical detection data are provided by a transformation
     // (and optional sensor fusion)
-    // performed by a sensor model or a logical Model
+    // performed by a sensor model or a logical model
     // that fuses multiple sensors and/or sensor types
     // into a single reference frame
     // of the so called logical/virtual sensor.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ class GenerateProtobufCommand(build_py):
         'osi_trafficcommand.proto',
         'osi_roadmarking.proto',
         'osi_featuredata.proto',
+        'osi_logicaldetectiondata.proto',
         'osi_object.proto',
         'osi_occupant.proto',
         'osi_lane.proto',


### PR DESCRIPTION
LogicalDetectionData provides feature data in the virtual cartesian
sensor coordinate system and is therefore suitable for fusion at the
feature data level, whereas FeatureData is not.

Signed-off-by: Pierre R. Mai <pmai@pmsf.de>

This PR coming from the SETLevel4To5 project is partly related to #367, and tackles the issue that the current `FeatureData` interface is strictly limited to one physical detector/sensor, since the coordinate system is spherical. This makes it more or less impossible to transport fusioned data, which must necessarily reside in one common coordinate system. The naming also tries to align with DIS 23150 (further alignment might also recommend renaming of `FeatureData`, which is however not included in this PR so as to remain backward compatible for now).

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.