### PR TITLE
Extension of the Identifier message with an additional type

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -196,13 +196,8 @@ message Orientation3d
 // Has to be unique among all simulated items at any given time. For ground
 // truth, the identifier of an item (object, lane, sign, etc.) must remain
 // stable over its lifetime. \c Identifier values may be only be reused if the
-// available address space is exhausted and the specific values have not been in
-// use for several timesteps. Sensor specific tracking IDs have no restrictions
-// and should behave according to the sensor specifications.
-//
-// The value MAX(uint64) = 2^(64) -1 =
-// 0b1111111111111111111111111111111111111111111111111111111111111111 is
-// reserved and indicates an invalid ID or error.
+// available address space is exhausted and the specific values have not been
+// in use for several timesteps.
 //
 message Identifier
 {
@@ -213,6 +208,45 @@ message Identifier
     // \endrules
     //
     optional uint64 value = 1;
+    
+    // The type of the identifier value
+    //
+    optional TYPE type = 2;
+    
+    // \brief Classification of the identifier type
+    //
+    // The identifier can be used in different parts on the one hand as a
+    // definition for a new Object or as a reference.
+    //
+    // Additionally, in some cases it could be necessary to set an undefined
+    // identifier with the value TYPE_UNKNOWN. One of the main use cases are
+    // the description of dead-end roads in the LanePairing message. 
+    //
+    enum TYPE 
+    {
+        // The id is not valid or not defined
+        //
+        TYPE_UNKNOWN = 0;
+        
+        // Other must not be used
+        //
+        TYPE_OTHER = 1;
+        
+        // Represents an error
+        //
+        TYPE_ERROR = 2;
+        
+        // The identifier of an object
+        // 
+        // In this case the identifier value must be unique among all
+        // simulated objects
+        //
+        TYPE_IDENTIFIER = 3;
+        
+        // The identifier is a reference to an object
+        //
+        TYPE_REFERENCE = 4;
+    }
 }
 
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -213,7 +213,7 @@ message Identifier
     //
     optional TYPE type = 2;
     
-    // \brief Classification of the identifier type
+    // Classification of the identifier type
     //
     // The identifier can be used in different parts on the one hand as a
     // definition for a new Object or as a reference.


### PR DESCRIPTION
#### Description

The extension of the "message Identifier" allows the distinction between different types of the identifier value. Currently, during run-time, there is no possibility to represent a Identifier (which must be global unique) or a reference to a previous defined object.

Additionally, during discussed in the Harmonization Group, about Issue #156 that there should be a possibility to define identifiers, which are not set. In addition, the desire arose, that in LanePairing always both IDs should be initialized, which is solved with the new type value TYPE_UNKNOWN.

The usage MAX(uint64) is no longer required in the future, since it is mapped by the types TYPE_UNKNOWN and TYPE_ERROR. For reasons of backwards compatibility, it can be additionally set at TYPE_UNKNOWN oder TYPE_ERROR.

The Sensor specific tracking IDs, which are used by external sensor models, can be mapped by the "message ExternalIdentifier", Pull Request #465 and are more flexible for fulfilling the individual sensor specifications.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.
