### PR TITLE
Definiton of external references

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -221,19 +221,38 @@ message Identifier
 // This could be other OpenX standards, 3rd-party standards or user-defined objects.
 // simulation environments.
 //
+// \note The ExternalReference is an optional value and can be left empty.
+//
 message ExternalReference
 {
     // The source of the external references
     //
-    // Defines the original source of an object as an URI.
-    // The URI should be follow the syntax according to 
+    // Defines the original source of an object as uniquely identifiable reference.
+    // In case of using \c GroundTruth::map_reference or 
+    // \c GroundTruth::model_reference, the reference can be left empty.
+    // If not otherwise required, an URI is suggested and should follow the syntax according to 
     // \link https://tools.ietf.org/html/rfc3986 RFC 3986\endlink.
+    //
     //
     optional string reference = 1;
     
     // The type of the external references
     //
     // Must be used to describe the type of the original source.
+    //
+    // For OpenX/ASAM standards it is specified as follows,
+    // the PATCH-Value is optional:
+    // - OpenDRIVE 1.6
+    // - OpenDRIVE 1.6.0
+    // - OpenDRIVE 1.6.1
+    // - OpenSCENARIO 1.0
+    // - OpenSCENARIO 1.0.0
+    // - OpenSCENARIO 1.1
+    // - OpenSCENARIO 1.1.0
+    //
+    // For third-party standards and user-defined objects the 
+    // Reverse Domain Name Notation is suggested, to guarantee unique
+    // and interoperable identifications.
     //
     optional string type = 2;    
     
@@ -245,6 +264,19 @@ message ExternalReference
     // E.g. referencing a unique lane in OpenDRIVE 
     // (RoadId --> String, S-Value of LaneSection --> Double, LaneId --> Int)
     // 
+    // \note The detailed description of the identifiers and how they are 
+    //       used for referencing external objects are given in the individual
+    //       messages, where it is deployed.
+    //
+    // \see EnvironmentalConditions::source_reference
+    // \see Lane::source_reference
+    // \see LaneBoundary::source_reference
+    // \see StationaryObject::source_reference
+    // \see MovingObject::source_reference
+    // \see RoadMarking::source_reference
+    // \see TrafficLight::source_reference
+    // \see TrafficSign::source_reference
+    //
     repeated string identifier = 3;
 }
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -223,6 +223,20 @@ message Identifier
 //
 message ExternalReference
 {
+    // The source of the external references
+    //
+    // Defines the original source of an object as an URI.
+    // The URI should be follow the syntax according to 
+    // \link https://tools.ietf.org/html/rfc3986 RFC 3986\endlink.
+    //
+    optional string reference = 1;
+    
+    // The type of the external references
+    //
+    // Can be used to describe the original source, e.g. OpenDRIVE 1.6
+    //
+    optional string type = 2;    
+    
     // The external identifier reference value.
     //
     // For a common description of the external identifier, where a wide range
@@ -231,13 +245,7 @@ message ExternalReference
     // E.g. referencing a unique lane in OpenDRIVE 
     // (RoadId --> String, S-Value of LaneSection --> Double, LaneId --> Int)
     // 
-    repeated string value = 1;
-    
-    // The source of the references
-    //
-    // Can be used to describe the original source, e.g. OpenDRIVE 1.6
-    //
-    optional string source_reference = 2;
+    repeated string identifier = 3;
 }
 
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -215,52 +215,56 @@ message Identifier
     optional uint64 value = 1;
 }
 
-// \brief References to external objects
+// \brief References to external objects.
 //
 // The external reference is an optional recommendation to refer to objects defined outside of OSI.
 // This could be other OpenX standards, 3rd-party standards or user-defined objects.
 // simulation environments.
 //
-// \note The ExternalReference is an optional value and can be left empty.
+// \note ExternalReference is optional and can be left empty.
 //
 message ExternalReference
 {
-    // The source of the external references
+    // The source of the external references.
     //
     // Defines the original source of an object as uniquely identifiable reference.
     // In case of using \c GroundTruth::map_reference or 
     // \c GroundTruth::model_reference, the reference can be left empty.
-    // If not otherwise required, an URI is suggested and should follow the syntax according to 
+    // If not otherwise required, an URI is suggested. The syntax should follow 
     // \link https://tools.ietf.org/html/rfc3986 RFC 3986\endlink.
     //
     //
     optional string reference = 1;
     
-    // The type of the external references
+    // The type of the external references.
     //
-    // Must be used to describe the type of the original source.
+    // Mandatory value describing the type of the original source.
     //
     // For OpenX/ASAM standards it is specified as follows:
     // - net.asam.opendrive
     // - net.asam.openscenario
     //
-    // For third-party standards and user-defined objects the 
-    // Reverse Domain Name Notation, with lower case type field,
-    // is suggested, to guarantee unique and interoperable identifications.
+    // For third-party standards and user-defined objects, 
+    // reverse domain name notation with lower-case type field
+    // is recommended to guarantee unique and interoperable identification.
     //
     optional string type = 2;    
     
     // The external identifier reference value.
     //
-    // For a common description of the external identifier, where a wide range
-    // of identification types could be represented, the repeated string is chosen.
+    // The repeated string is chosen as a common description of the external
+    // identifier, because a variety of identificatier types could be
+    // involved .
     //
-    // E.g. referencing a unique lane in OpenDRIVE 
-    // (RoadId --> String, S-Value of LaneSection --> Double, LaneId --> Int)
+    // For example, referencing a unique lane in OpenDRIVE requires the
+    // following identifiers:
+    // * RoadId: String
+    // * S-Value of LaneSection: Double
+    // * LaneId: Int
     // 
     // \note The detailed description of the identifiers and how they are 
-    //       used for referencing external objects are given in the individual
-    //       messages, where it is deployed.
+    //       used for referencing external objects is given in the individual
+    //       messages where the external identifier is used.
     //
     // \see EnvironmentalConditions::source_reference
     // \see Lane::source_reference

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -219,7 +219,6 @@ message Identifier
 //
 // The external reference is an optional recommendation to refer to objects defined outside of OSI.
 // This could be other OpenX standards, 3rd-party standards or user-defined objects.
-// simulation environments.
 //
 // \note ExternalReference is optional and can be left empty.
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -240,19 +240,13 @@ message ExternalReference
     //
     // Must be used to describe the type of the original source.
     //
-    // For OpenX/ASAM standards it is specified as follows,
-    // the PATCH-Value is optional:
-    // - OpenDRIVE 1.6
-    // - OpenDRIVE 1.6.0
-    // - OpenDRIVE 1.6.1
-    // - OpenSCENARIO 1.0
-    // - OpenSCENARIO 1.0.0
-    // - OpenSCENARIO 1.1
-    // - OpenSCENARIO 1.1.0
+    // For OpenX/ASAM standards it is specified as follows:
+    // - net.asam.opendrive
+    // - net.asam.openscenario
     //
     // For third-party standards and user-defined objects the 
-    // Reverse Domain Name Notation is suggested, to guarantee unique
-    // and interoperable identifications.
+    // Reverse Domain Name Notation, with lower case type field,
+    // is suggested, to guarantee unique and interoperable identifications.
     //
     optional string type = 2;    
     

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -215,6 +215,31 @@ message Identifier
     optional uint64 value = 1;
 }
 
+// \brief References to external objects
+//
+// The external reference is used to identify objects defined in non-OSI
+// descriptions. This could be other OpenX-Standards as well as user defined
+// simulation environments.
+//
+message ExternalReference
+{
+    // The external identifier reference value.
+    //
+    // For a common description of the external identifier, where a wide range
+    // of identification types could be represented, the repeded string is chosen.
+    //
+    // E.g. referencing a unique lane in OpenDRIVE 
+    // (RoadId --> String, S-Value of LaneSection --> Double, LaneId --> Int)
+    // 
+    repeated string value = 1;
+    
+    // The source of the references
+    //
+    // Can be used to describe the original source, e.g. OpenDRIVE 1.6
+    //
+    optional string source_reference = 2;
+}
+
 //
 // \brief Specifies the mounting position of a sensor.
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -217,8 +217,8 @@ message Identifier
 
 // \brief References to external objects
 //
-// The external reference is used to identify objects defined in non-OSI
-// descriptions. This could be other OpenX-Standards as well as user defined
+// The external reference is an optional recommendation to refer to objects defined outside of OSI.
+// This could be other OpenX standards, 3rd-party standards or user-defined objects.
 // simulation environments.
 //
 message ExternalReference
@@ -233,14 +233,14 @@ message ExternalReference
     
     // The type of the external references
     //
-    // Can be used to describe the original source, e.g. OpenDRIVE 1.6
+    // Must be used to describe the type of the original source.
     //
     optional string type = 2;    
     
     // The external identifier reference value.
     //
     // For a common description of the external identifier, where a wide range
-    // of identification types could be represented, the repeded string is chosen.
+    // of identification types could be represented, the repeated string is chosen.
     //
     // E.g. referencing a unique lane in OpenDRIVE 
     // (RoadId --> String, S-Value of LaneSection --> Double, LaneId --> Int)
@@ -550,4 +550,3 @@ message WavelengthData
     //
     optional double samples_number = 3;
 }
-

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -85,6 +85,19 @@ message EnvironmentalConditions
     // Description of the fog.
     //
     optional Fog fog = 7;
+    
+    // External Reference to the Environmental Condition Sources
+    //
+    // \note For OpenDRIVE and OpenSECNARIO there is no no direct counterpart.
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       object is derived from only one origin source, like from one 
+    //       scernario file and and from the sensors.
+    //
+    repeated ExternalReference source_reference = 8;
 
     // Definition of discretized precipitation states according to [1].
     // (I = Intensity of precipitation in mm per hour mm/h)

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -88,16 +88,16 @@ message EnvironmentalConditions
     //
     optional Fog fog = 7;
     
-    // Optional external Reference to the Environmental Condition Sources
+    // Optional external reference to the environmental condition sources.
     //
     // \note For OpenDRIVE and OpenSECNARIO there is no direct counterpart.
     //
-    // \note For non-ASAM Standards, it is implementation-specific how
+    // \note For non-ASAM standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       object is derived from only one origin source, like from one 
-    //       scernario file and from the sensors.
+    // \note The value has to be repeated because one object may be derived
+    //       from more than one origin source, for example, from a scenario file
+    //       and from sensors.
     //
     repeated ExternalReference source_reference = 9;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -88,7 +88,7 @@ message EnvironmentalConditions
     //
     optional Fog fog = 7;
     
-    // External Reference to the Environmental Condition Sources
+    // Optional external Reference to the Environmental Condition Sources
     //
     // \note For OpenDRIVE and OpenSECNARIO there is no direct counterpart.
     //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 option optimize_for = SPEED;
 
+import "osi_common.proto";
+
 package osi3;
 
 //
@@ -97,7 +99,7 @@ message EnvironmentalConditions
     //       object is derived from only one origin source, like from one 
     //       scernario file and and from the sensors.
     //
-    repeated ExternalReference source_reference = 8;
+    repeated ExternalReference source_reference = 9;
 
     // Definition of discretized precipitation states according to [1].
     // (I = Intensity of precipitation in mm per hour mm/h)

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -90,14 +90,14 @@ message EnvironmentalConditions
     
     // External Reference to the Environmental Condition Sources
     //
-    // \note For OpenDRIVE and OpenSECNARIO there is no no direct counterpart.
+    // \note For OpenDRIVE and OpenSECNARIO there is no direct counterpart.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
     // \note The value has to be repeated, as it cannot guarantee, that one
     //       object is derived from only one origin source, like from one 
-    //       scernario file and and from the sensors.
+    //       scernario file and from the sensors.
     //
     repeated ExternalReference source_reference = 9;
 

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -56,10 +56,10 @@ message Lane
     // from one or more objects or external references. An example here is the 
     // reference to the lane defined in a OpenDRIVE map.
     //
-    // For OpenDRIVE 1.6 the items should be set as following:
+    // For OpenDRIVE the items should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
-    // * type = "OpenDRIVE 1.6"
+    // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road
     // * identifier[1] = s of t_road_lanes_laneSection
     // * identifier[2] = id of t_road_lanes_laneSection_left_lane,
@@ -752,7 +752,7 @@ message LaneBoundary
     
     // Optional external Reference to the Lane Boundary Source
     //
-    // \note For OpenDRIVE 1.6 there is no direct possibility to reference the
+    // \note For OpenDRIVE there is no direct possibility to reference the
     //       RoadMark, as there is no unique identifier in this sub-object.
     //
     // \note For non-ASAM Standards, it is implementation-specific how

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -762,7 +762,7 @@ message LaneBoundary
     //       object is derived from only one origin source, like from one 
     //       scernario file and and from the sensors.
     //
-    repeated ExternalReference source_reference = 3;
+    repeated ExternalReference source_reference = 4;
 
     //
     // \brief A single point of a lane boundary.

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -50,7 +50,7 @@ message Lane
     //
     optional Classification classification = 2;
 
-    // External Reference to the Lane Source
+    // Optional external Reference to the Lane Source
     //
     // The ExternalReference point to the source of the lane, if it is derived
     // from one or more objects or external references. An example here is the 
@@ -750,7 +750,7 @@ message LaneBoundary
     //
     optional Classification classification = 3;
     
-    // External Reference to the Lane Boundary Source
+    // Optional external Reference to the Lane Boundary Source
     //
     // \note For OpenDRIVE 1.6 there is no direct possibility to reference the
     //       RoadMark, as there is no unique identifier in this sub-object.

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -50,13 +50,13 @@ message Lane
     //
     optional Classification classification = 2;
 
-    // Optional external Reference to the Lane Source
+    // Optional external reference to the lane source.
     //
-    // The ExternalReference point to the source of the lane, if it is derived
-    // from one or more objects or external references. An example here is the 
-    // reference to the lane defined in a OpenDRIVE map.
+    // The external reference points to the source of the lane, if it is derived
+    // from one or more objects or external references.
     //
-    // For OpenDRIVE the items should be set as following:
+    // For example, to reference a lane defined in an OpenDRIVE map
+    // the items should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"
@@ -68,10 +68,9 @@ message Lane
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       Lane-Segment is derived from only one origin segment. It is also
-    //       possible, that multiple sources (map, sensor) should be added as
-    //       reference.
+    // \note The value has to be repeated, because one lane segment may be
+    //       derived from more than one origin segment. Multiple sources
+    //       may be added as reference as well, for example, a map and sensors.
     //
     repeated ExternalReference source_reference = 3;
 
@@ -750,17 +749,17 @@ message LaneBoundary
     //
     optional Classification classification = 3;
     
-    // Optional external Reference to the Lane Boundary Source
+    // Optional external reference to the lane boundary source.
     //
-    // \note For OpenDRIVE there is no direct possibility to reference the
+    // \note For OpenDRIVE, there is no direct possibility to reference the
     //       RoadMark, as there is no unique identifier in this sub-object.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       object is derived from only one origin source, like from one 
-    //       scernario file and and from the sensors.
+    // \note The value has to be repeated because one object may be derived
+    //       from more than one origin source, for example, from a scenario file
+    //       and from sensors.
     //
     repeated ExternalReference source_reference = 4;
 

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -50,6 +50,32 @@ message Lane
     //
     optional Classification classification = 2;
 
+    // External Reference to the Lane Source
+    //
+    // The ExternalReference point to the source of the lane, if it is derived
+    // from one or more objects or external references. An exaple here is the 
+    // reference to the lane defined in a OpenDRIVE map.
+    //
+    // For OpenDRIVE 1.6 the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definiton
+    //               in \c GroundTruth::map_reference
+    // * type = "OpenDRIVE 1.6"
+    // * identifier[0] = id of t_road
+    // * identifier[1] = s of t_road_lanes_laneSection
+    // * identifier[2] = id of t_road_lanes_laneSection_left_lane,
+    //                         t_road_lanes_laneSection_right_lane or
+    //                         t_road_lanes_laneSection_center_lane
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       Lane-Segment is derived from only one origin segment. It is also
+    //       possible, that multiple sources (map, sensor) should be added as
+    //       reference.
+    //
+    repeated ExternalReference source_reference = 3;
+
     //
     // \brief \c Classification of a lane.
     //

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -53,7 +53,7 @@ message Lane
     // External Reference to the Lane Source
     //
     // The ExternalReference point to the source of the lane, if it is derived
-    // from one or more objects or external references. An exaple here is the 
+    // from one or more objects or external references. An example here is the 
     // reference to the lane defined in a OpenDRIVE map.
     //
     // For OpenDRIVE 1.6 the items should be set as following:
@@ -749,6 +749,20 @@ message LaneBoundary
     // The classification of the lane boundary.
     //
     optional Classification classification = 3;
+    
+    // External Reference to the Lane Boundary Source
+    //
+    // \note For OpenDRIVE 1.6 there is no direct possibility to reference the
+    //       RoadMark, as there is no unique identifier in this sub-object.
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       object is derived from only one origin source, like from one 
+    //       scernario file and and from the sensors.
+    //
+    repeated ExternalReference source_reference = 3;
 
     //
     // \brief A single point of a lane boundary.

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -56,7 +56,7 @@ message Lane
     // from one or more objects or external references.
     //
     // For example, to reference a lane defined in an OpenDRIVE map
-    // the items should be set as following:
+    // the items should be set as follows:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -63,8 +63,7 @@ message Lane
     // * identifier[0] = id of t_road
     // * identifier[1] = s of t_road_lanes_laneSection
     // * identifier[2] = id of t_road_lanes_laneSection_left_lane,
-    //                         t_road_lanes_laneSection_right_lane or
-    //                         t_road_lanes_laneSection_center_lane
+    //                         t_road_lanes_laneSection_right_lane
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -392,7 +392,7 @@ message MovingObject
     //
     optional MovingObjectClassification moving_object_classification = 9;    
 
-    // External Reference to the MovingObject Source
+    // Optional external Reference to the MovingObject Source
     //
     // The ExternalReference point to the source of an moving object, if it
     // is derived from an external sources like OpenSCENARIO.

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -45,18 +45,18 @@ message StationaryObject
     // The ExternalReference point to the source of an stationary object, if it
     // is derived from an external sources like OpenDRIVE or OpenSCENARIO.
     //
-    // For OpenDRIVE 1.6 the objects should be set as following:
+    // For OpenDRIVE the objects should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
-    // * type = "OpenDRIVE 1.6"
+    // * type = "net.asam.opendrive"
     // * identifier[0] = "object" for t_road_objects_object and
     //                   "bridge" for t_road_objects_bridge
     // * identifier[1] = id of t_road_objects_object or t_road_objects_bridge
     //
-    // For OpenSCENARIO 1.0 the entities of the type MiscObject, which describes
+    // For OpenSCENARIO the entities of the type MiscObject, which describes
     // partly stationary objects should be set as following:
     // * reference = URI to the OpenSCENARIO File
-    // * type = "OpenSCENARIO 1.0"
+    // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("MiscObject")
     // * identifier[1] = name of MiscObject in Entity
     //
@@ -397,14 +397,14 @@ message MovingObject
     // The ExternalReference point to the source of an moving object, if it
     // is derived from an external sources like OpenSCENARIO.
     //
-    // For OpenSCENARIO 1.0 the entities of the type Vehicle or Pedestrian,
+    // For OpenSCENARIO the entities of the type Vehicle or Pedestrian,
     // which describes moving objecs should be set as following:
     // * reference = URI to the OpenSCENARIO File
-    // * type = "OpenSCENARIO 1.0"
+    // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("Vehicle" or "Pedestrian")
     // * identifier[1] = name of Vehicle/Pedestrian in Entity
     //
-    // \todo OpenSCENARIO 1.0 currently does not provide an animal type.
+    // \todo OpenSCENARIO currently does not provide an animal type.
     // 
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -45,7 +45,8 @@ message StationaryObject
     // The external reference points to the source of a stationary object, if it
     // is derived from an external sources like OpenDRIVE or OpenSCENARIO.
     //
-    // For OpenDRIVE, references to objects should be set as following:
+    // For example, to reference an object defined in an OpenDRIVE map
+    // the items should be set as follows:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"
@@ -53,8 +54,9 @@ message StationaryObject
     //                   "bridge" for t_road_objects_bridge
     // * identifier[1] = id of t_road_objects_object or t_road_objects_bridge
     //
-    // For OpenSCENARIO, references to entities of the type MiscObject, which
-    // describes partly stationary objects, should be set as following:
+    // For example, to reference OpenSCENARIO entities of the type MiscObject,
+    // which describe partly stationary objects, the items should be set as 
+    // follows:
     // * reference = URI to the OpenSCENARIO File
     // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("MiscObject")
@@ -397,8 +399,9 @@ message MovingObject
     // The external reference points to the source of an moving object, if it
     // is derived from an external sources like OpenSCENARIO.
     //
-    // For OpenSCENARIO, references to entities of the type Vehicle or
-    // Pedestrian, which describe moving objects, should be set as following:
+    // For example, to reference OpenSCENARIO entities of the type Vehicle or
+    // Pedestrian, which describe moving objects, the items should be set as
+    // follows:
     // * reference = URI to the OpenSCENARIO File
     // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("Vehicle" or "Pedestrian")

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -40,6 +40,39 @@ message StationaryObject
     //
     optional string model_reference = 4;
 
+    // External Reference to the StationaryObject Source
+    //
+    // The ExternalReference point to the source of an stationary object, if it
+    // is derived from an external sources like OpenDRIVE or OpenSCENARIO.
+    //
+    // For OpenDRIVE 1.6 the objects should be set as following:
+    // * reference = URI to map, can remain empty if identical with definiton
+    //               in \c GroundTruth::map_reference
+    // * type = "OpenDRIVE 1.6"
+    // * identifier[0] = "object" for t_road_objects_object and
+    //                   "bridge" for t_road_objects_bridge
+    // * identifier[1] = id of t_road_objects_object or t_road_objects_bridge
+    //
+    // For OpenSCENARIO 1.0 the entities of the type MiscObject, which describes
+    // partly stationary objecs should be set as following:
+    // * reference = URI to the OpenSCENARIO File
+    // * type = "OpenSCENARIO 1.0"
+    // * identifier[0] = Entity-Type ("MiscObject")
+    // * identifier[1] = name of MiscObject in Entity
+    //
+    // \note The following rule, described in OpenDRIVE, should also apply here:
+    // * Objects derived from OpenSCENARIO shall not be mixed with objects
+    //   described in OpenDRIVE.
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       object is derived from only one origin source, like from one 
+    //       scernario file and and from the sensors.
+    //
+    repeated ExternalReference source_reference = 5;
+
     //
     // \brief Classification data for a stationary object.
     //
@@ -358,6 +391,29 @@ message MovingObject
     // Specific information about the classification of the vehicle.
     //
     optional MovingObjectClassification moving_object_classification = 9;    
+
+    // External Reference to the MovingObject Source
+    //
+    // The ExternalReference point to the source of an moving object, if it
+    // is derived from an external sources like OpenSCENARIO.
+    //
+    // For OpenSCENARIO 1.0 the entities of the type Vehicle or Pedestrian,
+    // which describes moving objecs should be set as following:
+    // * reference = URI to the OpenSCENARIO File
+    // * type = "OpenSCENARIO 1.0"
+    // * identifier[0] = Entity-Type ("Vehicle" or "Pedestrian")
+    // * identifier[1] = name of Vehicle/Pedestrian in Entity
+    //
+    // \todo OpenSCENARIO 1.0 currently does not provide an animal type.
+    // 
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       object is derived from only one origin source, like from one map
+    //       and from the sensors.
+    //
+    repeated ExternalReference source_reference = 10;
 
     // Definition of object types.
     //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -40,12 +40,12 @@ message StationaryObject
     //
     optional string model_reference = 4;
 
-    // External Reference to the StationaryObject Source
+    // External reference to the stationary-object source.
     //
-    // The ExternalReference point to the source of an stationary object, if it
+    // The external reference points to the source of a stationary object, if it
     // is derived from an external sources like OpenDRIVE or OpenSCENARIO.
     //
-    // For OpenDRIVE the objects should be set as following:
+    // For OpenDRIVE, references to objects should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"
@@ -53,23 +53,23 @@ message StationaryObject
     //                   "bridge" for t_road_objects_bridge
     // * identifier[1] = id of t_road_objects_object or t_road_objects_bridge
     //
-    // For OpenSCENARIO the entities of the type MiscObject, which describes
-    // partly stationary objects should be set as following:
+    // For OpenSCENARIO, references to entities of the type MiscObject, which
+    // describes partly stationary objects, should be set as following:
     // * reference = URI to the OpenSCENARIO File
     // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("MiscObject")
     // * identifier[1] = name of MiscObject in Entity
     //
-    // \note The following rule, described in OpenDRIVE, should also apply here:
+    // \note The following rule, described in OpenDRIVE, also applies:
     // * Objects derived from OpenSCENARIO shall not be mixed with objects
     //   described in OpenDRIVE.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       object is derived from only one origin source, like from one 
-    //       scenario file and and from the sensors.
+    // \note The value has to be repeated because one object may be derived
+    //       from more than one origin source, for example, from a scenario file
+    //       and from sensors.
     //
     repeated ExternalReference source_reference = 5;
 
@@ -392,13 +392,13 @@ message MovingObject
     //
     optional MovingObjectClassification moving_object_classification = 9;    
 
-    // Optional external Reference to the MovingObject Source
+    // Optional external reference to the moving-object source
     //
-    // The ExternalReference point to the source of an moving object, if it
+    // The external reference points to the source of an moving object, if it
     // is derived from an external sources like OpenSCENARIO.
     //
-    // For OpenSCENARIO the entities of the type Vehicle or Pedestrian,
-    // which describes moving objecs should be set as following:
+    // For OpenSCENARIO, references to entities of the type Vehicle or
+    // Pedestrian, which describe moving objects, should be set as following:
     // * reference = URI to the OpenSCENARIO File
     // * type = "net.asam.openscenario"
     // * identifier[0] = Entity-Type ("Vehicle" or "Pedestrian")
@@ -409,9 +409,9 @@ message MovingObject
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       object is derived from only one origin source, like from one map
-    //       and from the sensors.
+    // \note The value has to be repeated because one object may be derived
+    //       from more than one origin source, for example, from a scenario file
+    //       and from sensors.
     //
     repeated ExternalReference source_reference = 10;
 

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -54,7 +54,7 @@ message StationaryObject
     // * identifier[1] = id of t_road_objects_object or t_road_objects_bridge
     //
     // For OpenSCENARIO 1.0 the entities of the type MiscObject, which describes
-    // partly stationary objecs should be set as following:
+    // partly stationary objects should be set as following:
     // * reference = URI to the OpenSCENARIO File
     // * type = "OpenSCENARIO 1.0"
     // * identifier[0] = Entity-Type ("MiscObject")
@@ -69,7 +69,7 @@ message StationaryObject
     //
     // \note The value has to be repeated, as it cannot guarantee, that one
     //       object is derived from only one origin source, like from one 
-    //       scernario file and and from the sensors.
+    //       scenario file and and from the sensors.
     //
     repeated ExternalReference source_reference = 5;
 

--- a/osi_occupant.proto
+++ b/osi_occupant.proto
@@ -23,6 +23,19 @@ message Occupant
     //
     optional Classification classification = 2;
 
+    // External Reference to the Occupant Source
+    //
+    // \note For OpenDRIVE and OpenSECNARIO there is no no direct counterpart.
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       object is derived from only one origin source, like from one 
+    //       scernario file and and from the sensors.
+    //
+    repeated ExternalReference source_reference = 3;
+
     //
     // \brief Information regarding the classification of the occupant.
     //

--- a/osi_occupant.proto
+++ b/osi_occupant.proto
@@ -23,16 +23,16 @@ message Occupant
     //
     optional Classification classification = 2;
 
-    // External Reference to the Occupant Source
+    // External reference to the occupant source.
     //
-    // \note For OpenDRIVE and OpenSCENARIO there is no no direct counterpart.
+    // \note For OpenDRIVE and OpenSCENARIO there is no direct counterpart.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       object is derived from only one origin source, like from one 
-    //       scernario file and and from the sensors.
+    // \note The value has to be repeated because one object may be derived
+    //       from more than one origin source, for example, from a scenario file
+    //       and from sensors.
     //
     repeated ExternalReference source_reference = 3;
 

--- a/osi_occupant.proto
+++ b/osi_occupant.proto
@@ -25,7 +25,7 @@ message Occupant
 
     // External Reference to the Occupant Source
     //
-    // \note For OpenDRIVE and OpenSECNARIO there is no no direct counterpart.
+    // \note For OpenDRIVE and OpenSCENARIO there is no no direct counterpart.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -61,7 +61,8 @@ message RoadMarking
     // is derived from one or more objects or external references. An example
     // here is the reference to the signal defined in a OpenDRIVE map.
     //
-    // For OpenDRIVE the items should be set as following:
+    // For example, to reference a signal defined in an OpenDRIVE map
+    // the items should be set as follows:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -61,13 +61,13 @@ message RoadMarking
     // is derived from one or more objects or external references. An example
     // here is the reference to the signal defined in a OpenDRIVE map.
     //
-    // For OpenDRIVE 1.6 the items should be set as following:
+    // For OpenDRIVE the items should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
-    // * type = "OpenDRIVE 1.6"
+    // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road_signals_signal
     //
-    // \note In OpenDRIVE 1.6 there is also the possibility to define surface
+    // \note In OpenDRIVE there is also the possibility to define surface
     //       markings as an object. In this case, the associated object is
     //       usually referenced within OpenDRIVE using the reference
     //       t_road_signals_signal_reference, which allows it to be

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -55,7 +55,7 @@ message RoadMarking
     //
     optional Classification classification = 3;
 
-    // External Reference to the Roadmarking Source
+    // Optional external Reference to the Roadmarking Source
     //
     // The ExternalReference point to the source of the surface marking, if it
     // is derived from one or more objects or external references. An example

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -55,6 +55,35 @@ message RoadMarking
     //
     optional Classification classification = 3;
 
+    // External Reference to the Roadmarking Source
+    //
+    // The ExternalReference point to the source of the surface marking, if it
+    // is derived from one or more objects or external references. An example
+    // here is the reference to the signal defined in a OpenDRIVE map.
+    //
+    // For OpenDRIVE 1.6 the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definiton
+    //               in \c GroundTruth::map_reference
+    // * type = "OpenDRIVE 1.6"
+    // * identifier[0] = id of t_road_signals_signal
+    //
+    // \note In OpenDRIVE 1.6 there is also the possibility to define surface
+    //       markings as an object. In this case, the associated object is
+    //       usually referenced within OpenDRIVE using the reference
+    //       t_road_signals_signal_reference, which allows it to be
+    //       identifiable.
+    //       An additional reference to the object is therefore not necessary.
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       Lane-Segment is derived from only one origin segment. It is also
+    //       possible, that multiple sources (map, sensor) should be added as
+    //       reference.
+    //
+    repeated ExternalReference source_reference = 4;
+
     //
     // \brief \c Classification data for a road surface marking.
     //

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -55,9 +55,9 @@ message RoadMarking
     //
     optional Classification classification = 3;
 
-    // Optional external Reference to the Roadmarking Source
+    // Optional external reference to the road-marking source.
     //
-    // The ExternalReference point to the source of the surface marking, if it
+    // The external reference points to the source of the surface marking, if it
     // is derived from one or more objects or external references. An example
     // here is the reference to the signal defined in a OpenDRIVE map.
     //
@@ -67,20 +67,17 @@ message RoadMarking
     // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road_signals_signal
     //
-    // \note In OpenDRIVE there is also the possibility to define surface
-    //       markings as an object. In this case, the associated object is
-    //       usually referenced within OpenDRIVE using the reference
-    //       t_road_signals_signal_reference, which allows it to be
-    //       identifiable.
+    // \note With OpenDRIVE, surface markings can also be defined as objects.
+    //       In this case, the associated object is usually referenced within
+    //       OpenDRIVE using the reference t_road_signals_signal_reference.
     //       An additional reference to the object is therefore not necessary.
     //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       Lane-Segment is derived from only one origin segment. It is also
-    //       possible, that multiple sources (map, sensor) should be added as
-    //       reference.
+    // \note The value has to be repeated, because one lane segment may be
+    //       derived from more than one origin segment. Multiple sources
+    //       may be added as reference as well, for example, a map and sensors.
     //
     repeated ExternalReference source_reference = 4;
 

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -48,10 +48,10 @@ message TrafficLight
     // derived from one or more objects or external references. An example here
     // is the reference to the signal defined in a OpenDRIVE map.
     //
-    // For OpenDRIVE 1.6 the items should be set as following:
+    // For OpenDRIVE the items should be set as following:
     // * reference = URI to map, can remain empty if identical with definiton
     //               in \c GroundTruth::map_reference
-    // * type = "OpenDRIVE 1.6"
+    // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road_signals_signal
     //
     // \note For non-ASAM Standards, it is implementation-specific how

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -48,7 +48,7 @@ message TrafficLight
     // is derived from one or more objects or external references.
     //
     // For example, to reference a signal defined in an OpenDRIVE map
-    // the items should be set as following:
+    // the items should be set as follows:
     // * reference = URI to map, can remain empty if identical with definition
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -42,6 +42,28 @@ message TrafficLight
     //
     optional string model_reference = 4;
 
+    // External Reference to the Traffic Light Source
+    //
+    // The ExternalReference point to the source of the traffic light, if it is
+    // derived from one or more objects or external references. An example here
+    // is the reference to the signal defined in a OpenDRIVE map.
+    //
+    // For OpenDRIVE 1.6 the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definiton
+    //               in \c GroundTruth::map_reference
+    // * type = "OpenDRIVE 1.6"
+    // * identifier[0] = id of t_road_signals_signal
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       Lane-Segment is derived from only one origin segment. It is also
+    //       possible, that multiple sources (map, sensor) should be added as
+    //       reference.
+    //
+    repeated ExternalReference source_reference = 5;
+
     //
     // \brief \c Classification data for a traffic light.
     //

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -42,14 +42,14 @@ message TrafficLight
     //
     optional string model_reference = 4;
 
-    // Optional external Reference to the Traffic Light Source
+    // Optional external reference to the traffic light source.
     //
-    // The ExternalReference point to the source of the traffic light, if it is
-    // derived from one or more objects or external references. An example here
-    // is the reference to the signal defined in a OpenDRIVE map.
+    // The external reference points to the source of the traffic light, if it 
+    // is derived from one or more objects or external references.
     //
-    // For OpenDRIVE the items should be set as following:
-    // * reference = URI to map, can remain empty if identical with definiton
+    // For example, to reference a signal defined in an OpenDRIVE map
+    // the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definition
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road_signals_signal
@@ -57,10 +57,9 @@ message TrafficLight
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       Lane-Segment is derived from only one origin segment. It is also
-    //       possible, that multiple sources (map, sensor) should be added as
-    //       reference.
+    // \note The value has to be repeated, because one lane segment may be
+    //       derived from more than one origin segment. Multiple sources
+    //       may be added as reference as well, for example, a map and sensors.
     //
     repeated ExternalReference source_reference = 5;
 

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -42,7 +42,7 @@ message TrafficLight
     //
     optional string model_reference = 4;
 
-    // External Reference to the Traffic Light Source
+    // Optional external Reference to the Traffic Light Source
     //
     // The ExternalReference point to the source of the traffic light, if it is
     // derived from one or more objects or external references. An example here

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -156,6 +156,33 @@ message TrafficSign
     //
     repeated SupplementarySign supplementary_sign = 3;
 
+
+    // External Reference to the Traffic Sign Source
+    //
+    // The ExternalReference point to the source of the traffic sign, if it is
+    // derived from one or more objects or external references. An example here
+    // is the reference to the signal defined in a OpenDRIVE map.
+    //
+    // For OpenDRIVE 1.6 the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definiton
+    //               in \c GroundTruth::map_reference
+    // * type = "OpenDRIVE 1.6"
+    // * identifier[0] = id of t_road_signals_signal
+    //
+    // \note For non-ASAM Standards, it is implementation-specific how
+    //       source_reference is resolved.
+    //
+    // \note If an individual identification of MainSign and SupplementarySign
+    //       is be necessary, this sould be defined via multiple individual
+    //       entries of this source_reference.
+    //
+    // \note The value has to be repeated, as it cannot guarantee, that one
+    //       Lane-Segment is derived from only one origin segment. It is also
+    //       possible, that multiple sources (map, sensor) should be added as
+    //       reference.
+    //
+    repeated ExternalReference source_reference = 4;
+
     //
     // \brief Main sign of the traffic sign.
     //

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -157,13 +157,13 @@ message TrafficSign
     repeated SupplementarySign supplementary_sign = 3;
 
 
-    // Optional external Reference to the Traffic Sign Source
+    // Optional external reference to the traffic sign source.
     //
-    // The ExternalReference point to the source of the traffic sign, if it is
-    // derived from one or more objects or external references. An example here
-    // is the reference to the signal defined in a OpenDRIVE map.
+    // The external reference point to the source of the traffic sign, if it is
+    // derived from one or more objects or external references.
     //
-    // For OpenDRIVE the items should be set as following:
+    // For example, to reference a signal defined in an OpenDRIVE map
+    // the items should be set as following:
     // * reference = URI to map, can remain empty if identical with definition
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"
@@ -173,13 +173,12 @@ message TrafficSign
     //       source_reference is resolved.
     //
     // \note If an individual identification of MainSign and SupplementarySign
-    //       is be necessary, this sould be defined via multiple individual
+    //       is necessary, this should be done via multiple individual
     //       entries of this source_reference.
     //
-    // \note The value has to be repeated, as it cannot guarantee, that one
-    //       Lane-Segment is derived from only one origin segment. It is also
-    //       possible, that multiple sources (map, sensor) should be added as
-    //       reference.
+    // \note The value has to be repeated, because one lane segment may be
+    //       derived from more than one origin segment. Multiple sources
+    //       may be added as reference as well, for example, a map and sensors.
     //
     repeated ExternalReference source_reference = 4;
 

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -157,7 +157,7 @@ message TrafficSign
     repeated SupplementarySign supplementary_sign = 3;
 
 
-    // External Reference to the Traffic Sign Source
+    // Optional external Reference to the Traffic Sign Source
     //
     // The ExternalReference point to the source of the traffic sign, if it is
     // derived from one or more objects or external references. An example here

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -163,7 +163,7 @@ message TrafficSign
     // derived from one or more objects or external references.
     //
     // For example, to reference a signal defined in an OpenDRIVE map
-    // the items should be set as following:
+    // the items should be set as follows:
     // * reference = URI to map, can remain empty if identical with definition
     //               in \c GroundTruth::map_reference
     // * type = "net.asam.opendrive"

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -163,10 +163,10 @@ message TrafficSign
     // derived from one or more objects or external references. An example here
     // is the reference to the signal defined in a OpenDRIVE map.
     //
-    // For OpenDRIVE 1.6 the items should be set as following:
-    // * reference = URI to map, can remain empty if identical with definiton
+    // For OpenDRIVE the items should be set as following:
+    // * reference = URI to map, can remain empty if identical with definition
     //               in \c GroundTruth::map_reference
-    // * type = "OpenDRIVE 1.6"
+    // * type = "net.asam.opendrive"
     // * identifier[0] = id of t_road_signals_signal
     //
     // \note For non-ASAM Standards, it is implementation-specific how


### PR DESCRIPTION
#### Description

OSI currently offers no options for an internal data management of the source of an object. Therefore an additional identifier is proposed to reference to external standards or external sources like models or physical sensors. For an exchange and a traceability, especially in the post processing of tests, it is important to identify the source of an object.

Currently, there is only a numeric identifier to describe the different object within OSI. As there should be an interoperability within other standards, especially the OpenX-Standards, but also third party simulations, an additional and more generic reference identifier is needed.

As the identification in different standards are more complex than only using a numeric id, a representation based on a list of strings is chosen. The background to this is the exemplary description of a Lane within other standards. OpenDRIVE 1.6 for example describes the outcome for an OSI-Lane bases on three different values and types:

* RoadId is defined as String
* S-Value of LaneSection is defined as Double
* LaneId is defined as Integer


#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.