### PR TITLE
set default c11 compiler for apple machines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(open_simulation_interface)
 
+# set default compiler
+set(CMAKE_CXX_STANDARD 11)
+
 # Set a default build type if none was specified
 set(default_build_type "Release")
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")


### PR DESCRIPTION
#### Reference to a related issue in the repository
No open issue for this pull-request.

#### Add a description
Tell cmake which compiler to use on apple machines: Building the project out of the box on apple machines will cause Cmake to fail. Setting the correct default compiler will fix this issue. Extending CMakeLists.txt fixes the build-process and enables an 'out of the box' build without errors.

#### Mention a member
@pmai

#### Check the checklist
Crossed entries were considered as not required.
- ✅ My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- ✅ I have performed a self-review of my own code.
- ❌ I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- ✅ My changes generate no new warnings.
- ❌ I have added tests that prove my fix is effective or that my feature works.
- ✅ New and existing unit tests / travis ci pass locally with my changes.