### PR TITLE
Make handling of enums in rules check more robust

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -92,11 +92,10 @@ class TestRules(unittest.TestCase):
 
                     # Search for a closing brace.
                     matchClosingBrace = re.search("}", statement)
-                    if numMessage > 0 and matchClosingBrace is not None:
-                        numMessage -= 1
-
                     if isEnum is True and matchClosingBrace is not None:
                         isEnum = False
+                    elif numMessage > 0 and matchClosingBrace is not None:
+                        numMessage -= 1
 
                     if matchComment is not None:
                         if re.search(r"^[ ]\\\bendrules\b$", comment) is not None:


### PR DESCRIPTION
Earlier versions of this check erroneously treated the end of an enum
as the end of its enclosing message, leading to problems with nested
enums if they appeared not at the end of its enclosing messages.

Signed-off-by: Pierre R. Mai <pmai@pmsf.de>

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.