### PR TITLE
Moved different action definitions into message trafficAction.

### DIFF
--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -39,9 +39,7 @@ message TrafficCommand
     //
     optional Identifier traffic_participant_id = 3;
 
-    // Commanded traffic action(s) if any
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
+    // Commanded traffic action(s) if any.
     //
     // \note If more than one action is supplied in one command message
     // all actions are executed in parallel.
@@ -50,7 +48,7 @@ message TrafficCommand
 }
 
 //
-// \brief Atomic traffic actions to be performed
+// \brief Atomic traffic actions to be performed.
 //
 // The transmitted commands are the atomic traffic actions described by 
 // this message.
@@ -70,675 +68,663 @@ message TrafficCommand
 //
 message TrafficAction
 {
-    // A FollowTrajectoryAction
+    // A FollowTrajectoryAction.
     //
     optional FollowTrajectoryAction follow_trajectory_action = 1;
 
-    // A FollowPathAction
+    // A FollowPathAction.
     //
     optional FollowPathAction follow_path_action = 2;
 
-    // An AcquireGlobalPositionAction
+    // An AcquireGlobalPositionAction.
     //
     optional AcquireGlobalPositionAction acquire_global_position_action = 3;
 
-    // A LaneChangeAction
+    // A LaneChangeAction.
     //
     optional LaneChangeAction lane_change_action = 4; 
 
-    // A SpeedAction
+    // A SpeedAction.
     //
     optional SpeedAction speed_action = 5;    
 
-    // An AbortActionsAction
+    // An AbortActionsAction.
     //
     optional AbortActionsAction abort_actions_action = 6; 
 
-    // An EndActionsAction
+    // An EndActionsAction.
     //
     optional EndActionsAction end_actions_action = 7; 
-    
-    // A CustomAction
+
+    // A CustomAction.
     //
     optional CustomAction custom_action = 8;
 
-    // A LongitudinalDistanceAction
+    // A LongitudinalDistanceAction.
     //
     optional LongitudinalDistanceAction longitudinal_distance_action = 9;
 
-    // A LaneOffsetAction
+    // A LaneOffsetAction.
     //
     optional LaneOffsetAction lane_offset_action = 10;
 
-    // A LateralDistanceAction
+    // A LateralDistanceAction.
     //
     optional LateralDistanceAction lateral_distance_action = 11;
 
-    // A TeleportAction
+    // A TeleportAction.
     //
-    optional TeleportAction teleport_action = 12; 
-}
+    optional TeleportAction teleport_action = 12;
 
-//
-// \brief The action header
-//
-//
-message ActionHeader
-{
-    // The unique id of the action
     //
-    // \note This field is mandatory.
+    // \brief The action header
     //
-    // \note This id must be unique within all traffic command
-    // messages exchanged with one traffic participant.
     //
-    optional Identifier action_id = 1;
-}
-
-//
-// \brief Follow trajectory action.
-//
-// Controls a traffic participant to follow a trajectory using vertices
-// with timings. It specifies the motion in space as a function of time.
-//
-// \note The StatePoint messages in trajectory_point requires a  
-// specified timestamp.
-//
-// \note This action is aligned with the FollowTrajectoryAction of
-// OpenSCENARIO 1.0 using a 4/7D trajectory with shape Polyline.
-//
-message FollowTrajectoryAction
-{
-    // The action header
-    //
-    optional ActionHeader action_header = 1;
-
-    // A list of trajectory StatePoints
-    //
-    // Set the timestamp fields and position fields for all 
-    // trajectory points. The orientation fields can be set
-    // depending on the constrain_orientation field being true.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
-    repeated StatePoint trajectory_point = 2;
-
-    // Constrain the orientation of the traffic participant as specified
-    // by the trajectory points.
-    //
-    // This boolean flag defines whether orientation values supplied in 
-    // the trajectory points (if any) shall be used to constrain the
-    // orientation of the traffic participant or not.
-    //
-    optional bool constrain_orientation = 3;
-
-    // Specify the following mode that should be employed in executing
-    // the trajectory.
-    //
-    optional FollowingMode following_mode = 4;
-
-    // Definition of following mode.
-    //
-    enum FollowingMode
+    message ActionHeader
     {
-        // Following mode position forces the traffic participant to
-        // follow the trajectory explicitly, disregarding any internal
-        // constraints, for example, steering dynamics.
+        // The unique id of the action.
         //
-        FOLLOWING_MODE_POSITION = 0;
-
-        // Following mode follow allows the traffic participant to
-        // treat the trajectory as a target, to be achieved as closely
-        // as possible while retaining any internal constraints,
-        // for example, steering dynamics.
+        // \note This field is mandatory.
         //
-        FOLLOWING_MODE_FOLLOW = 1;
-    }
-}
-
-//
-// \brief Follow path action.
-//
-// Controls a traffic participant to follow a path using vertices. It 
-// specifies the motion in space independent of time.
-//
-// \note The StatePoint messages in path_point only requires a specified 
-// position field. The orientation can be set optionally. Any
-// timestamp StatePoint values are ignored.
-//
-// \note This action is aligned with the FollowTrajectoryAction of
-// OpenSCENARIO 1.0 using a 3/6D trajectory with shape Polyline.
-//
-message FollowPathAction
-{
-    // The action header
-    //
-    optional ActionHeader action_header = 1;
-
-    // A list of path StatePoints
-    //
-    // Set the position fields for all path points.
-    // The timestamp field are not required and ignored.
-    // The orientation fields can be set depending on the constrain_orientation
-    // field being true.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
-    repeated StatePoint path_point = 2;
-
-    // Constrain the orientation of the traffic participant as specified
-    // by the path points.
-    //
-    // This boolean flag defines whether orientation values supplied in 
-    // the path points shall be used to constrain the orientation
-    // of the traffic participant or not.
-    //
-    optional bool constrain_orientation = 3;
-
-    // Specify the following mode that should be employed in executing
-    // the path.
-    //
-    optional FollowingMode following_mode = 4;
-
-    // Definition of following mode.
-    //
-    enum FollowingMode
-    {
-        // Following mode position forces the traffic participant to
-        // follow the path explicitly, disregarding any internal
-        // constraints, for example, steering dynamics.
+        // \note This id must be unique within all traffic command
+        // messages exchanged with one traffic participant.
         //
-        FOLLOWING_MODE_POSITION = 0;
-
-        // Following mode follow allows the traffic participant to
-        // treat the path as a target, to be achieved as closely
-        // as possible while retaining any internal constraints,
-        // for example, steering dynamics.
-        //
-        FOLLOWING_MODE_FOLLOW = 1;
-    }
-}
-
-//
-// \brief Acquire global position action.
-//
-// This action assigns a route to a traffic participant. The route
-// assigned will be the shortest route (along roads or satisfying any
-// other constraints a traffic participant is operating under) between
-// the traffic participant's current position and the position specified.
-//
-// As with all routing actions, the exact way this route is achieved is
-// under the control of the traffic participant model.
-//
-// \note This action is aligned with the AcquirePositionAction of
-// OpenSCENARIO 1.0 using a WorldPosition position argument.
-//
-message AcquireGlobalPositionAction
-{
-    // The action header
-    //
-    optional ActionHeader action_header = 1;
-
-    // Position in the global coordinate system.
-    //
-    // The position refers to the center (x,y,z) of the bounding box.
-    //
-    // \note Remark: The definition of the reference point follows the
-    // specification of the \c BaseMoving message.
-    //
-    optional Vector3d position = 2;
-
-    // Orientation in the global coordinate system.
-    //
-    // This is optional. If no orientation is given, the end orientation
-    // is under control of the traffic participant.
-    //
-    optional Orientation3d orientation = 3;
-}
-
-//
-// \brief Lane change action.
-//
-// This action assigns a lane change to a traffic participant. The fields 
-// of this message enable different levels of constraint for the traffic 
-// participant depending on the use case. In case the constraints are 
-// supposed to be small, the dynamics shape or even the duration and 
-// the distance for the lane change can be omitted.
-//
-// \note This action is aligned with LaneChangeAction of OpenSCENARIO 1.0
-// defining the targeted lane and optionally the parametrization of the 
-// lane change.
-//
-
-message LaneChangeAction
-{
-    // The action header
-    //
-    optional ActionHeader action_header = 1;
-    
-    // Targeted lane relative to the current lane.
-    //
-    // Convention: +1 means to the right, -1 means to the left.
-    //
-    optional int32 relative_target_lane = 2;
-    
-    // Specified shape of the lane change action. 
-    // If the shape is unspecified (enum value 0), the shape of the 
-    // lane change is open to the traffic participant model. 
-    //
-    optional DynamicsShape dynamics_shape = 3;
-    
-    // Duration of the lane change.
-    // 
-    // A value of 0.0 (the default value) imposes no constraint
-    // on the duration, unless the dynamics shape is a step function,
-    // where an immediate step is effected.
-    //
-    // Unit: s
-    //
-    optional double duration = 4; 
-    
-    // Distance of the lane change.
-    // 
-    // A value of 0.0 (the default value) imposes no constraint
-    // on the distance, unless the dynamics shape is a step function,
-    // where an immediate step is effected.
-    //
-    // Unit: m
-    //
-    optional double distance = 5;
-    
-    // Definition of LaneChange dynamic shapes.
-    //
-    enum DynamicsShape
-    {
-        // Shape is unspecified.
-        //
-        DYNAMICS_SHAPE_UNSPECIFIED = 0;
-
-        // Shape is linear.
-        //
-        DYNAMICS_SHAPE_LINEAR = 1;
-
-        // Shape is cubic.
-        //
-        DYNAMICS_SHAPE_CUBIC = 2;
-
-        // Shape is sinusoidal.
-        //
-        DYNAMICS_SHAPE_SINUSOIDAL = 3;
-
-        // Shape is a step function.
-        //
-        DYNAMICS_SHAPE_STEP = 4;
-    }
-}
-
-//
-// \brief Speed action.
-//
-// This action assigns a targeted speed to a traffic participant. 
-// The action can be constrained by specifying the dynamics 
-// shape or even the duration and the distance of the acceleration / 
-// deceleration process.
-//
-// \note This action is aligned with SpeedAction of OpenSCENARIO 1.0
-// defining the targeted speed and optionally the parametrization of the 
-// speed transition.
-//
-
-message SpeedAction
-{
-    // The action header
-    //
-    optional ActionHeader action_header = 1;
-    
-    // Targeted absolute speed.
-    //
-    optional double absolute_target_speed = 2;
-    
-    // Specified transition shape of the speed change action. 
-    // If the shape is unspecified (enum value 0), the shape of the 
-    // speed change is open to the traffic participant model. 
-    //
-    optional DynamicsShape dynamics_shape = 3;
-    
-    // Duration of the speed change.
-    // 
-    // A value of 0.0 (the default value) imposes no constraint
-    // on the duration, unless the dynamics shape is a step function,
-    // where an immediate step is effected.
-    //
-    // Unit: s
-    //
-    optional double duration = 4; 
-    
-    // Distance of the speed change.
-    // 
-    // A value of 0.0 (the default value) imposes no constraint
-    // on the distance, unless the dynamics shape is a step function,
-    // where an immediate step is effected.
-    //
-    // Unit: m
-    //
-    optional double distance = 5;
-    
-    // Definition of speed change dynamic shapes.
-    //
-    enum DynamicsShape
-    {
-        // Shape is unspecified.
-        //
-        DYNAMICS_SHAPE_UNSPECIFIED = 0;
-
-        // Shape is linear.
-        //
-        DYNAMICS_SHAPE_LINEAR = 1;
-
-        // Shape is cubic.
-        //
-        DYNAMICS_SHAPE_CUBIC = 2;
-
-        // Shape is sinusoidal.
-        //
-        DYNAMICS_SHAPE_SINUSOIDAL = 3;
-
-        // Shape is a step function.
-        //
-        DYNAMICS_SHAPE_STEP = 4;
+        optional Identifier action_id = 1;
     }
 
-}
-
-// \brief Longitudinal Distance Action
-//
-// The action tells the (host) traffic participant to reach a certain longitudinal distance  
-// relative to a target traffic participant. The longitudinal distance is defined as the distance
-// along the centerline of the lane, on which the (host) traffic participant is currently located. 
-// The interpolation strategy between centerline points for calculating 
-// that distance along the centerline is open to the traffic participant modeller.  
-//
-// \note This action is aligned with LongitudinalDistanceAction of OpenSCENARIO 1.0
-// defining the reference traffic participant and the distance.
-//
-// \note Limitation: This concept currently only works for lanes with a centerline, i.e. for lanes 
-// of TYPE_DRIVING, not for lanes of TYPE_NONDRIVING or TYPE_INTERSECTION.
-//
-
-message LongitudinalDistanceAction 
-{
-    // Action Header of the message
     //
-    optional ActionHeader action_header = 1;
-
-    // Unique Id of the reference traffic participant to which the distance is defined.
+    // \brief Follow trajectory action.
     //
-    optional Identifier target_traffic_participant_id = 2;
-
-    // The distance to reach along the lane
+    // Controls a traffic participant to follow a trajectory using vertices
+    // with timings. It specifies the motion in space as a function of time.
     //
-    // Unit: m
+    // \note The StatePoint messages in trajectory_point requires a  
+    // specified timestamp.
     //
-    optional double distance = 3;
-
-    // Determine the measurement of longitudinal distance between the traffic
-    // participant receiving this action and the reference traffic
-    // participant. 
-    // True: Longitudinal distance is measured using the distance between closest bounding box points.
-    // False: Longitudinal distance is mesasured using the distance between the center of each object's bounding box.
+    // \note This action is aligned with the FollowTrajectoryAction of
+    // OpenSCENARIO 1.0 using a 4/7D trajectory with shape Polyline.
     //
-    optional bool freespace = 4;
-
-    // Define wheather the traffic participant should only reach the distance once 
-    // or if it should also follow if after having reached it.
-    // True: the traffic participant shall approach the reference participant
-    // and follow with the distance specified until the action is aborted/ended.
-    // False: the action ends as soon as the traffic participant has reached
-    // the specified distance. 
-    //
-    optional bool follow = 5;
-
-    // Parameter that assings either unlimited dynamics (if omitted) 
-    // or limited maxAcceleration/maxDeceleration/maxSpeed to the action.
-    //
-    optional DynamicConstraints dynamic_constraints = 6;
-}
-
-
-// \brief Lateral Distance Action 
-//
-// The action tells the (host) traffic participant to reach a certain lateral distance relative to 
-// a target traffic participant. The lateral distance is defined along an imaginative perpendicular line
-// with respect to the centerline of the current (host) traffic participant's lane. 
-// The interpolation strategy between centerline points for calculating that distance along the imaginative 
-// perpendicular line is open to the traffic participant modeller.  
-//
-// \note This action is aligned with LateralDistanceAction of OpenSCENARIO 1.0
-// defining the reference traffic participant and the distance.
-//
-// \note Limitation: This concept currently only works for lanes with a centerline, i.e. for lanes 
-// of TYPE_DRIVING, not for lanes of TYPE_NONDRIVING or TYPE_INTERSECTION.
-//
-
-message LateralDistanceAction
-{
-    // Action Header of the message
-    //
-    optional ActionHeader action_header = 1;
-
-    // Id of the reference entity the lateral distance shall be kept to.
-    //
-    optional Identifier target_traffic_participant_id = 2;
-
-    // Lateral distance value. 
-    //
-    // Unit: m
-    //
-    optional double distance = 3;
-
-    // Determine the measurement of lateral distance between the traffic
-    // participant receiving this action and the reference traffic
-    // participant. 
-    // True: Lateral distance is measured using the distance between closest bounding box points.
-    // False: Lateral distance is mesasured using the distance between the center of each object's bounding box.
-    //
-    optional bool freespace = 4;
-
-    // Define wheather the traffic participant should only reach the distance once 
-    // or if it should also follow if after having reached it.
-    // True: the traffic particpant shall approach the reference participant
-    // and follow with the distance specified until the action is aborted/ended.
-    // False: the action ends as soon as the traffic participant has reached
-    // the specified distance. 
-    //
-    optional bool follow = 5;
-
-    // Parameter that assings either unlimited dynamics (if omitted) 
-    // or limited maxAcceleration/maxDeceleration/maxSpeed to the action.
-    //
-    optional DynamicConstraints dynamic_constraints = 6;
-}
-
-// \brief Lane Offset Action
-//
-// This action assigns a targeted lane offset to a traffic participant. 
-// The action can be constrained by specifying the dynamics shape of the
-// lateral transition profile. 
-//
-// \note This action is aligned with LaneOffsetAction of OpenSCENARIO 1.0.
-//
-
-message LaneOffsetAction
-{
-    // The Action Header
-    //
-    optional ActionHeader action_header = 1;
-    
-    // Targeted lane offset in meters relative to the centerline of the
-    // current traffic participant's lane. Positive values mean left of the centerline, 
-    // negative values mean right of the centerline. 
-    //
-    // Unit: m
-    //
-    optional double target_lane_offset = 2;
-    
-    // Specified transition shape of reaching the lane offset. 
-    // If the shape is unspecified (enum value 0), the shape of the 
-    // transition is open to the traffic participant model. 
-    //
-    optional DynamicsShape dynamics_shape = 3;
-    
-    // Definition of dynamic shape of the transition.
-    //
-    enum DynamicsShape
+    message FollowTrajectoryAction
     {
-        // Shape is unspecified.
+        // The action header.
         //
-        DYNAMICS_SHAPE_UNSPECIFIED = 0;
+        optional ActionHeader action_header = 1;
 
-        // Shape is linear.
+        // A list of trajectory StatePoints.
         //
-        DYNAMICS_SHAPE_LINEAR = 1;
+        // Set the timestamp fields and position fields for all 
+        // trajectory points. The orientation fields can be set
+        // depending on the constrain_orientation field being true.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated StatePoint trajectory_point = 2;
 
-        // Shape is cubic.
+        // Constrain the orientation of the traffic participant as specified
+        // by the trajectory points.
         //
-        DYNAMICS_SHAPE_CUBIC = 2;
+        // This boolean flag defines whether orientation values supplied in 
+        // the trajectory points (if any) shall be used to constrain the
+        // orientation of the traffic participant or not.
+        //
+        optional bool constrain_orientation = 3;
 
-        // Shape is sinusoidal.
+        // Specify the following mode that should be employed in executing
+        // the trajectory.
         //
-        DYNAMICS_SHAPE_SINUSOIDAL = 3;
+        optional FollowingMode following_mode = 4;
 
-        // Shape is a step function.
+        // Definition of following mode.
         //
-        DYNAMICS_SHAPE_STEP = 4;
+        enum FollowingMode
+        {
+            // Following mode position forces the traffic participant to
+            // follow the trajectory explicitly, disregarding any internal
+            // constraints, for example, steering dynamics.
+            //
+            FOLLOWING_MODE_POSITION = 0;
+
+            // Following mode follow allows the traffic participant to
+            // treat the trajectory as a target, to be achieved as closely
+            // as possible while retaining any internal constraints,
+            // for example, steering dynamics.
+            //
+            FOLLOWING_MODE_FOLLOW = 1;
+        }
     }
 
-}
-    
+    //
+    // \brief Follow path action.
+    //
+    // Controls a traffic participant to follow a path using vertices. It 
+    // specifies the motion in space independent of time.
+    //
+    // \note The StatePoint messages in path_point only requires a specified 
+    // position field. The orientation can be set optionally. Any
+    // timestamp StatePoint values are ignored.
+    //
+    // \note This action is aligned with the FollowTrajectoryAction of
+    // OpenSCENARIO 1.0 using a 3/6D trajectory with shape Polyline.
+    //
+    message FollowPathAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
 
-// \brief Teleport Action
-//
-// This Action allows to immediately place a traffic participant to 
-// another position. 
-//
-// \note This action is aligned with the TeleportAction of
-// OpenSCENARIO 1.0 using a WorldPosition position argument.
-//
+        // A list of path StatePoints
+        //
+        // Set the position fields for all path points.
+        // The timestamp field are not required and ignored.
+        // The orientation fields can be set depending on the constrain_orientation
+        // field being true.
+        //
+        // \note OSI uses singular instead of plural for repeated field names.
+        //
+        repeated StatePoint path_point = 2;
 
-message TeleportAction
-{
-    // The Action Header
-    //
-    optional ActionHeader action_header = 1;
+        // Constrain the orientation of the traffic participant as specified
+        // by the path points.
+        //
+        // This boolean flag defines whether orientation values supplied in 
+        // the path points shall be used to constrain the orientation
+        // of the traffic participant or not.
+        //
+        optional bool constrain_orientation = 3;
 
-    // Position in the global coordinate system.
-    //
-    // The position refers to the center (x,y,z) of the bounding box.
-    //
-    // \note Remark: The definition of the reference point follows the
-    // specification of the \c BaseMoving message.
-    //
-    optional Vector3d position = 2;
+        // Specify the following mode that should be employed in executing
+        // the path.
+        //
+        optional FollowingMode following_mode = 4;
 
-    // Orientation in the global coordinate system.
-    //
-    // This is optional, if no orientation is given, the end orientation
-    // is under control of the traffic participant.
-    //
-    optional Orientation3d orientation = 3;
-}
+        // Definition of following mode.
+        //
+        enum FollowingMode
+        {
+            // Following mode position forces the traffic participant to
+            // follow the path explicitly, disregarding any internal
+            // constraints, for example, steering dynamics.
+            //
+            FOLLOWING_MODE_POSITION = 0;
 
-// \brief AbortActionsAction.
-//
-// This action tells a traffic participant that it should immediately 
-// abort the execution of other actions referenced within this action.
-// In contrast to the EndActionsAction this action forces a hard 
-// termination of the referenced actions.
-//
+            // Following mode follow allows the traffic participant to
+            // treat the path as a target, to be achieved as closely
+            // as possible while retaining any internal constraints,
+            // for example, steering dynamics.
+            //
+            FOLLOWING_MODE_FOLLOW = 1;
+        }
+    }
 
-message AbortActionsAction
-{
-    // The action header
     //
-    optional ActionHeader action_header = 1;
+    // \brief Acquire global position action.
+    //
+    // This action assigns a route to a traffic participant. The route
+    // assigned will be the shortest route (along roads or satisfying any
+    // other constraints a traffic participant is operating under) between
+    // the traffic participant's current position and the position specified.
+    //
+    // As with all routing actions, the exact way this route is achieved is
+    // under the control of the traffic participant model.
+    //
+    // \note This action is aligned with the AcquirePositionAction of
+    // OpenSCENARIO 1.0 using a WorldPosition position argument.
+    //
+    message AcquireGlobalPositionAction
+    {
+        // The action header.
+        //
+        optional ActionHeader action_header = 1;
 
-    // Actions which must be aborted immediately.
-    // 
-    // These fields hold the action ids of the actions that must be 
-    // aborted immediately. 
-    //
-    repeated Identifier target_action_id = 2; 
-}
+        // Position in the global coordinate system.
+        //
+        // The position refers to the center (x,y,z) of the bounding box.
+        //
+        // \note Remark: The definition of the reference point follows the
+        // specification of the \c BaseMoving message.
+        //
+        optional Vector3d position = 2;
 
-// \brief End actions action.
-//
-// This action tells a traffic participant that the exection of the 
-// referenced actions is regarded as successfully performed. The 
-// termination of the referenced actions is allowed to be performed 
-// gracefully. 
-//
+        // Orientation in the global coordinate system.
+        //
+        // This is optional. If no orientation is given, the end orientation
+        // is under control of the traffic participant.
+        //
+        optional Orientation3d orientation = 3;
+    }
 
-message EndActionsAction
-{
-    // The action header
     //
-    optional ActionHeader action_header = 1;
+    // \brief Lane change action.
+    //
+    // This action assigns a lane change to a traffic participant. The fields 
+    // of this message enable different levels of constraint for the traffic 
+    // participant depending on the use case. In case the constraints are 
+    // supposed to be small, the dynamics shape or even the duration and 
+    // the distance for the lane change can be omitted.
+    //
+    // \note This action is aligned with LaneChangeAction of OpenSCENARIO 1.0
+    // defining the targeted lane and optionally the parametrization of the 
+    // lane change.
+    //
+    message LaneChangeAction
+    {
+        // The action header.
+        //
+        optional ActionHeader action_header = 1;
 
-    // Actions which are regarded as successfully executed.
-    // 
-    // These fields hold the action ids of the actions that are regarded 
-    // as successfully executed and shall be terminated gracefully.
-    //
-    repeated Identifier target_action_id = 2; 
-}
+        // Targeted lane relative to the current lane.
+        //
+        // Convention: +1 means to the right, -1 means to the left.
+        //
+        optional int32 relative_target_lane = 2;
 
-// \brief DynamicConstraints
-//
-// This message is used in Longitudinal and Lateral Distance Actions as
-// constraints on the TrafficParticipant not allowing them to exceed/drop below
-// certain speeds/acceleration levels.
-//
+        // Specified shape of the lane change action. 
+        // If the shape is unspecified (enum value 0), the shape of the 
+        // lane change is open to the traffic participant model. 
+        //
+        optional DynamicsShape dynamics_shape = 3;
 
-message DynamicConstraints
-{
-    // Maximum acceleration the distance contoller is allowed to use for keeping distance. 
-    //
-    // Unit: m/s^2
-    //
-    optional double max_acceleration = 1;
+        // Duration of the lane change.
+        // 
+        // A value of 0.0 (the default value) imposes no constraint
+        // on the duration, unless the dynamics shape is a step function,
+        // where an immediate step is effected.
+        //
+        // Unit: s
+        //
+        optional double duration = 4; 
 
-    // Maximum deceleration the distance contoller is allowed to use for keeping distance. 
-    //
-    // Unit: m/s^2
-    //
-    optional double max_deceleration = 2;
+        // Distance of the lane change.
+        // 
+        // A value of 0.0 (the default value) imposes no constraint
+        // on the distance, unless the dynamics shape is a step function,
+        // where an immediate step is effected.
+        //
+        // Unit: m
+        //
+        optional double distance = 5;
 
-    // Maximum speed the distance contoller is allowed to use for keeping distance. 
-    //
-    // Unit: m/s
-    //
-    optional double max_speed = 3;
-}
+        // Definition of LaneChange dynamic shapes.
+        //
+        enum DynamicsShape
+        {
+            // Shape is unspecified.
+            //
+            DYNAMICS_SHAPE_UNSPECIFIED = 0;
 
-//
-// \brief Custom Action.
-//
-// This action assigns a custom command to a traffic participant.
-// The syntax and semantics of this action is implementation defined.
-// It is entirely up to each individual traffic participant which
-// custom commands it supports, if any, and how they must be phrased.
-//
-// \note This action is aligned with CustomCommandAction of OpenSCENARIO 1.0
-// providing a customizable user defined action.
-//
+            // Shape is linear.
+            //
+            DYNAMICS_SHAPE_LINEAR = 1;
 
-message CustomAction
-{
-    // The Action Header
-    //
-    optional ActionHeader action_header = 1;
+            // Shape is cubic.
+            //
+            DYNAMICS_SHAPE_CUBIC = 2;
 
-    // The custom command given to the traffic participant.
+            // Shape is sinusoidal.
+            //
+            DYNAMICS_SHAPE_SINUSOIDAL = 3;
+
+            // Shape is a step function.
+            //
+            DYNAMICS_SHAPE_STEP = 4;
+        }
+    }
+
     //
-    optional string command = 2;
+    // \brief Speed action.
+    //
+    // This action assigns a targeted speed to a traffic participant. 
+    // The action can be constrained by specifying the dynamics 
+    // shape or even the duration and the distance of the acceleration / 
+    // deceleration process.
+    //
+    // \note This action is aligned with SpeedAction of OpenSCENARIO 1.0
+    // defining the targeted speed and optionally the parametrization of the 
+    // speed transition.
+    //
+    message SpeedAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Targeted absolute speed.
+        //
+        optional double absolute_target_speed = 2;
+
+        // Specified transition shape of the speed change action. 
+        // If the shape is unspecified (enum value 0), the shape of the 
+        // speed change is open to the traffic participant model. 
+        //
+        optional DynamicsShape dynamics_shape = 3;
+
+        // Duration of the speed change.
+        // 
+        // A value of 0.0 (the default value) imposes no constraint
+        // on the duration, unless the dynamics shape is a step function,
+        // where an immediate step is effected.
+        //
+        // Unit: s
+        //
+        optional double duration = 4; 
+
+        // Distance of the speed change.
+        // 
+        // A value of 0.0 (the default value) imposes no constraint
+        // on the distance, unless the dynamics shape is a step function,
+        // where an immediate step is effected.
+        //
+        // Unit: m
+        //
+        optional double distance = 5;
+
+        // Definition of speed change dynamic shapes.
+        //
+        enum DynamicsShape
+        {
+            // Shape is unspecified.
+            //
+            DYNAMICS_SHAPE_UNSPECIFIED = 0;
+
+            // Shape is linear.
+            //
+            DYNAMICS_SHAPE_LINEAR = 1;
+
+            // Shape is cubic.
+            //
+            DYNAMICS_SHAPE_CUBIC = 2;
+
+            // Shape is sinusoidal.
+            //
+            DYNAMICS_SHAPE_SINUSOIDAL = 3;
+
+            // Shape is a step function.
+            //
+            DYNAMICS_SHAPE_STEP = 4;
+        }
+
+    }
+
+    // \brief Longitudinal Distance Action
+    //
+    // The action tells the (host) traffic participant to reach a certain longitudinal distance  
+    // relative to a target traffic participant. The longitudinal distance is defined as the distance
+    // along the centerline of the lane, on which the (host) traffic participant is currently located. 
+    // The interpolation strategy between centerline points for calculating 
+    // that distance along the centerline is open to the traffic participant modeller.  
+    //
+    // \note This action is aligned with LongitudinalDistanceAction of OpenSCENARIO 1.0
+    // defining the reference traffic participant and the distance.
+    //
+    // \note Limitation: This concept currently only works for lanes with a centerline, i.e. for lanes 
+    // of TYPE_DRIVING, not for lanes of TYPE_NONDRIVING or TYPE_INTERSECTION.
+    //
+    message LongitudinalDistanceAction 
+    {
+        // Action Header of the message
+        //
+        optional ActionHeader action_header = 1;
+
+        // Unique Id of the reference traffic participant to which the distance is defined.
+        //
+        optional Identifier target_traffic_participant_id = 2;
+
+        // The distance to reach along the lane
+        //
+        // Unit: m
+        //
+        optional double distance = 3;
+
+        // Determine the measurement of longitudinal distance between the traffic
+        // participant receiving this action and the reference traffic
+        // participant. 
+        // True: Longitudinal distance is measured using the distance between closest bounding box points.
+        // False: Longitudinal distance is mesasured using the distance between the center of each object's bounding box.
+        //
+        optional bool freespace = 4;
+
+        // Define wheather the traffic participant should only reach the distance once 
+        // or if it should also follow if after having reached it.
+        // True: the traffic participant shall approach the reference participant
+        // and follow with the distance specified until the action is aborted/ended.
+        // False: the action ends as soon as the traffic participant has reached
+        // the specified distance. 
+        //
+        optional bool follow = 5;
+
+        // Parameter that assings either unlimited dynamics (if omitted) 
+        // or limited maxAcceleration/maxDeceleration/maxSpeed to the action.
+        //
+        optional DynamicConstraints dynamic_constraints = 6;
+    }
+
+    // \brief Lateral Distance Action 
+    //
+    // The action tells the (host) traffic participant to reach a certain lateral distance relative to 
+    // a target traffic participant. The lateral distance is defined along an imaginative perpendicular line
+    // with respect to the centerline of the current (host) traffic participant's lane. 
+    // The interpolation strategy between centerline points for calculating that distance along the imaginative 
+    // perpendicular line is open to the traffic participant modeller.  
+    //
+    // \note This action is aligned with LateralDistanceAction of OpenSCENARIO 1.0
+    // defining the reference traffic participant and the distance.
+    //
+    // \note Limitation: This concept currently only works for lanes with a centerline, i.e. for lanes 
+    // of TYPE_DRIVING, not for lanes of TYPE_NONDRIVING or TYPE_INTERSECTION.
+    //
+    message LateralDistanceAction
+    {
+        // Action Header of the message
+        //
+        optional ActionHeader action_header = 1;
+
+        // Id of the reference entity the lateral distance shall be kept to.
+        //
+        optional Identifier target_traffic_participant_id = 2;
+
+        // Lateral distance value. 
+        //
+        // Unit: m
+        //
+        optional double distance = 3;
+
+        // Determine the measurement of lateral distance between the traffic
+        // participant receiving this action and the reference traffic
+        // participant. 
+        // True: Lateral distance is measured using the distance between closest bounding box points.
+        // False: Lateral distance is mesasured using the distance between the center of each object's bounding box.
+        //
+        optional bool freespace = 4;
+
+        // Define wheather the traffic participant should only reach the distance once 
+        // or if it should also follow if after having reached it.
+        // True: the traffic particpant shall approach the reference participant
+        // and follow with the distance specified until the action is aborted/ended.
+        // False: the action ends as soon as the traffic participant has reached
+        // the specified distance. 
+        //
+        optional bool follow = 5;
+
+        // Parameter that assings either unlimited dynamics (if omitted) 
+        // or limited maxAcceleration/maxDeceleration/maxSpeed to the action.
+        //
+        optional DynamicConstraints dynamic_constraints = 6;
+    }
+
+    // \brief Lane Offset Action
+    //
+    // This action assigns a targeted lane offset to a traffic participant. 
+    // The action can be constrained by specifying the dynamics shape of the
+    // lateral transition profile. 
+    //
+    // \note This action is aligned with LaneOffsetAction of OpenSCENARIO 1.0.
+    //
+    message LaneOffsetAction
+    {
+        // The Action Header
+        //
+        optional ActionHeader action_header = 1;
+        
+        // Targeted lane offset in meters relative to the centerline of the
+        // current traffic participant's lane. Positive values mean left of the centerline, 
+        // negative values mean right of the centerline. 
+        //
+        // Unit: m
+        //
+        optional double target_lane_offset = 2;
+        
+        // Specified transition shape of reaching the lane offset. 
+        // If the shape is unspecified (enum value 0), the shape of the 
+        // transition is open to the traffic participant model. 
+        //
+        optional DynamicsShape dynamics_shape = 3;
+        
+        // Definition of dynamic shape of the transition.
+        //
+        enum DynamicsShape
+        {
+            // Shape is unspecified.
+            //
+            DYNAMICS_SHAPE_UNSPECIFIED = 0;
+
+            // Shape is linear.
+            //
+            DYNAMICS_SHAPE_LINEAR = 1;
+
+            // Shape is cubic.
+            //
+            DYNAMICS_SHAPE_CUBIC = 2;
+
+            // Shape is sinusoidal.
+            //
+            DYNAMICS_SHAPE_SINUSOIDAL = 3;
+
+            // Shape is a step function.
+            //
+            DYNAMICS_SHAPE_STEP = 4;
+        }
+
+    }
+
+    // \brief Teleport Action
+    //
+    // This Action allows to immediately place a traffic participant to 
+    // another position. 
+    //
+    // \note This action is aligned with the TeleportAction of
+    // OpenSCENARIO 1.0 using a WorldPosition position argument.
+    //
+    message TeleportAction
+    {
+        // The Action Header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Position in the global coordinate system.
+        //
+        // The position refers to the center (x,y,z) of the bounding box.
+        //
+        // \note Remark: The definition of the reference point follows the
+        // specification of the \c BaseMoving message.
+        //
+        optional Vector3d position = 2;
+
+        // Orientation in the global coordinate system.
+        //
+        // This is optional, if no orientation is given, the end orientation
+        // is under control of the traffic participant.
+        //
+        optional Orientation3d orientation = 3;
+    }
+
+    // \brief AbortActionsAction.
+    //
+    // This action tells a traffic participant that it should immediately 
+    // abort the execution of other actions referenced within this action.
+    // In contrast to the EndActionsAction this action forces a hard 
+    // termination of the referenced actions.
+    //
+    message AbortActionsAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Actions which must be aborted immediately.
+        // 
+        // These fields hold the action ids of the actions that must be 
+        // aborted immediately. 
+        //
+        repeated Identifier target_action_id = 2; 
+    }
+
+    // \brief End actions action.
+    //
+    // This action tells a traffic participant that the exection of the 
+    // referenced actions is regarded as successfully performed. The 
+    // termination of the referenced actions is allowed to be performed 
+    // gracefully. 
+    //
+    message EndActionsAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Actions which are regarded as successfully executed.
+        // 
+        // These fields hold the action ids of the actions that are regarded 
+        // as successfully executed and shall be terminated gracefully.
+        //
+        repeated Identifier target_action_id = 2; 
+    }
+
+    // \brief DynamicConstraints
+    //
+    // This message is used in Longitudinal and Lateral Distance Actions as
+    // constraints on the TrafficParticipant not allowing them to exceed/drop below
+    // certain speeds/acceleration levels.
+    //
+    message DynamicConstraints
+    {
+        // Maximum acceleration the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s^2
+        //
+        optional double max_acceleration = 1;
+
+        // Maximum deceleration the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s^2
+        //
+        optional double max_deceleration = 2;
+
+        // Maximum speed the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s
+        //
+        optional double max_speed = 3;
+    }
+
+    //
+    // \brief Custom Action.
+    //
+    // This action assigns a custom command to a traffic participant.
+    // The syntax and semantics of this action is implementation defined.
+    // It is entirely up to each individual traffic participant which
+    // custom commands it supports, if any, and how they must be phrased.
+    //
+    // \note This action is aligned with CustomCommandAction of OpenSCENARIO 1.0
+    // providing a customizable user defined action.
+    //
+    message CustomAction
+    {
+        // The Action Header.
+        //
+        optional ActionHeader action_header = 1;
+
+        // The custom command given to the traffic participant.
+        //
+        optional string command = 2;
+    }
 }

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -119,7 +119,6 @@ message TrafficAction
     //
     // \brief The action header
     //
-    //
     message ActionHeader
     {
         // The unique id of the action.
@@ -130,6 +129,77 @@ message TrafficAction
         // messages exchanged with one traffic participant.
         //
         optional Identifier action_id = 1;
+    }
+
+    // Definition of following mode.
+    //
+    enum FollowingMode
+    {
+        // Following mode position forces the traffic participant to
+        // follow a path/trajectory explicitly, disregarding any internal
+        // constraints, for example, steering dynamics.
+        //
+        FOLLOWING_MODE_POSITION = 0;
+
+        // Following mode follow allows the traffic participant to
+        // treat a path/trajectory as a target, to be achieved as closely
+        // as possible while retaining any internal constraints,
+        // for example, steering dynamics.
+        //
+        FOLLOWING_MODE_FOLLOW = 1;
+    }    
+
+    // Definition of dynamic shapes.
+    //
+    enum DynamicsShape
+    {
+        // Shape is unspecified.
+        //
+        DYNAMICS_SHAPE_UNSPECIFIED = 0;
+
+        // Shape is linear.
+        //
+        DYNAMICS_SHAPE_LINEAR = 1;
+
+        // Shape is cubic.
+        //
+        DYNAMICS_SHAPE_CUBIC = 2;
+
+        // Shape is sinusoidal.
+        //
+        DYNAMICS_SHAPE_SINUSOIDAL = 3;
+
+        // Shape is a step function.
+        //
+        DYNAMICS_SHAPE_STEP = 4;
+    }
+
+
+    // \brief DynamicConstraints
+    //
+    // This message is used in Longitudinal and Lateral Distance Actions as
+    // constraints on the TrafficParticipant not allowing them to exceed/drop below
+    // certain speeds/acceleration levels.
+    //
+    message DynamicConstraints
+    {
+        // Maximum acceleration the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s^2
+        //
+        optional double max_acceleration = 1;
+
+        // Maximum deceleration the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s^2
+        //
+        optional double max_deceleration = 2;
+
+        // Maximum speed the distance contoller is allowed to use for keeping distance. 
+        //
+        // Unit: m/s
+        //
+        optional double max_speed = 3;
     }
 
     //
@@ -173,24 +243,6 @@ message TrafficAction
         // the trajectory.
         //
         optional FollowingMode following_mode = 4;
-
-        // Definition of following mode.
-        //
-        enum FollowingMode
-        {
-            // Following mode position forces the traffic participant to
-            // follow the trajectory explicitly, disregarding any internal
-            // constraints, for example, steering dynamics.
-            //
-            FOLLOWING_MODE_POSITION = 0;
-
-            // Following mode follow allows the traffic participant to
-            // treat the trajectory as a target, to be achieved as closely
-            // as possible while retaining any internal constraints,
-            // for example, steering dynamics.
-            //
-            FOLLOWING_MODE_FOLLOW = 1;
-        }
     }
 
     //
@@ -236,24 +288,6 @@ message TrafficAction
         // the path.
         //
         optional FollowingMode following_mode = 4;
-
-        // Definition of following mode.
-        //
-        enum FollowingMode
-        {
-            // Following mode position forces the traffic participant to
-            // follow the path explicitly, disregarding any internal
-            // constraints, for example, steering dynamics.
-            //
-            FOLLOWING_MODE_POSITION = 0;
-
-            // Following mode follow allows the traffic participant to
-            // treat the path as a target, to be achieved as closely
-            // as possible while retaining any internal constraints,
-            // for example, steering dynamics.
-            //
-            FOLLOWING_MODE_FOLLOW = 1;
-        }
     }
 
     //
@@ -343,31 +377,6 @@ message TrafficAction
         // Unit: m
         //
         optional double distance = 5;
-
-        // Definition of LaneChange dynamic shapes.
-        //
-        enum DynamicsShape
-        {
-            // Shape is unspecified.
-            //
-            DYNAMICS_SHAPE_UNSPECIFIED = 0;
-
-            // Shape is linear.
-            //
-            DYNAMICS_SHAPE_LINEAR = 1;
-
-            // Shape is cubic.
-            //
-            DYNAMICS_SHAPE_CUBIC = 2;
-
-            // Shape is sinusoidal.
-            //
-            DYNAMICS_SHAPE_SINUSOIDAL = 3;
-
-            // Shape is a step function.
-            //
-            DYNAMICS_SHAPE_STEP = 4;
-        }
     }
 
     //
@@ -417,33 +426,71 @@ message TrafficAction
         // Unit: m
         //
         optional double distance = 5;
-
-        // Definition of speed change dynamic shapes.
-        //
-        enum DynamicsShape
-        {
-            // Shape is unspecified.
-            //
-            DYNAMICS_SHAPE_UNSPECIFIED = 0;
-
-            // Shape is linear.
-            //
-            DYNAMICS_SHAPE_LINEAR = 1;
-
-            // Shape is cubic.
-            //
-            DYNAMICS_SHAPE_CUBIC = 2;
-
-            // Shape is sinusoidal.
-            //
-            DYNAMICS_SHAPE_SINUSOIDAL = 3;
-
-            // Shape is a step function.
-            //
-            DYNAMICS_SHAPE_STEP = 4;
-        }
-
     }
+
+    // \brief AbortActionsAction.
+    //
+    // This action tells a traffic participant that it should immediately 
+    // abort the execution of other actions referenced within this action.
+    // In contrast to the EndActionsAction this action forces a hard 
+    // termination of the referenced actions.
+    //
+    message AbortActionsAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Actions which must be aborted immediately.
+        // 
+        // These fields hold the action ids of the actions that must be 
+        // aborted immediately. 
+        //
+        repeated Identifier target_action_id = 2; 
+    }
+
+    // \brief End actions action.
+    //
+    // This action tells a traffic participant that the exection of the 
+    // referenced actions is regarded as successfully performed. The 
+    // termination of the referenced actions is allowed to be performed 
+    // gracefully. 
+    //
+    message EndActionsAction
+    {
+        // The action header
+        //
+        optional ActionHeader action_header = 1;
+
+        // Actions which are regarded as successfully executed.
+        // 
+        // These fields hold the action ids of the actions that are regarded 
+        // as successfully executed and shall be terminated gracefully.
+        //
+        repeated Identifier target_action_id = 2; 
+    }    
+
+    //
+    // \brief Custom Action.
+    //
+    // This action assigns a custom command to a traffic participant.
+    // The syntax and semantics of this action is implementation defined.
+    // It is entirely up to each individual traffic participant which
+    // custom commands it supports, if any, and how they must be phrased.
+    //
+    // \note This action is aligned with CustomCommandAction of OpenSCENARIO 1.0
+    // providing a customizable user defined action.
+    //
+    message CustomAction
+    {
+        // The Action Header.
+        //
+        optional ActionHeader action_header = 1;
+
+        // The custom command given to the traffic participant.
+        //
+        optional string command = 2;
+    }    
 
     // \brief Longitudinal Distance Action
     //
@@ -484,11 +531,11 @@ message TrafficAction
         optional bool freespace = 4;
 
         // Define wheather the traffic participant should only reach the distance once 
-        // or if it should also follow if after having reached it.
+        // or if it should also keep the distance after having reached it.
         // True: the traffic participant shall approach the reference participant
-        // and follow with the distance specified until the action is aborted/ended.
+        // and follow with the distance specified until the action is aborted (communicate with AbortActionsAction).
         // False: the action ends as soon as the traffic participant has reached
-        // the specified distance. 
+        // the specified distance (communicate with EndActionsAction).
         //
         optional bool follow = 5;
 
@@ -537,11 +584,11 @@ message TrafficAction
         optional bool freespace = 4;
 
         // Define wheather the traffic participant should only reach the distance once 
-        // or if it should also follow if after having reached it.
-        // True: the traffic particpant shall approach the reference participant
-        // and follow with the distance specified until the action is aborted/ended.
+        // or if it should also keep the distance after having reached it.
+        // True: the traffic participant shall approach the reference participant
+        // and follow with the distance specified until the action is aborted (communicate with AbortActionsAction).
         // False: the action ends as soon as the traffic participant has reached
-        // the specified distance. 
+        // the specified distance (communicate with EndActionsAction).
         //
         optional bool follow = 5;
 
@@ -578,32 +625,6 @@ message TrafficAction
         // transition is open to the traffic participant model. 
         //
         optional DynamicsShape dynamics_shape = 3;
-        
-        // Definition of dynamic shape of the transition.
-        //
-        enum DynamicsShape
-        {
-            // Shape is unspecified.
-            //
-            DYNAMICS_SHAPE_UNSPECIFIED = 0;
-
-            // Shape is linear.
-            //
-            DYNAMICS_SHAPE_LINEAR = 1;
-
-            // Shape is cubic.
-            //
-            DYNAMICS_SHAPE_CUBIC = 2;
-
-            // Shape is sinusoidal.
-            //
-            DYNAMICS_SHAPE_SINUSOIDAL = 3;
-
-            // Shape is a step function.
-            //
-            DYNAMICS_SHAPE_STEP = 4;
-        }
-
     }
 
     // \brief Teleport Action
@@ -635,96 +656,5 @@ message TrafficAction
         // is under control of the traffic participant.
         //
         optional Orientation3d orientation = 3;
-    }
-
-    // \brief AbortActionsAction.
-    //
-    // This action tells a traffic participant that it should immediately 
-    // abort the execution of other actions referenced within this action.
-    // In contrast to the EndActionsAction this action forces a hard 
-    // termination of the referenced actions.
-    //
-    message AbortActionsAction
-    {
-        // The action header
-        //
-        optional ActionHeader action_header = 1;
-
-        // Actions which must be aborted immediately.
-        // 
-        // These fields hold the action ids of the actions that must be 
-        // aborted immediately. 
-        //
-        repeated Identifier target_action_id = 2; 
-    }
-
-    // \brief End actions action.
-    //
-    // This action tells a traffic participant that the exection of the 
-    // referenced actions is regarded as successfully performed. The 
-    // termination of the referenced actions is allowed to be performed 
-    // gracefully. 
-    //
-    message EndActionsAction
-    {
-        // The action header
-        //
-        optional ActionHeader action_header = 1;
-
-        // Actions which are regarded as successfully executed.
-        // 
-        // These fields hold the action ids of the actions that are regarded 
-        // as successfully executed and shall be terminated gracefully.
-        //
-        repeated Identifier target_action_id = 2; 
-    }
-
-    // \brief DynamicConstraints
-    //
-    // This message is used in Longitudinal and Lateral Distance Actions as
-    // constraints on the TrafficParticipant not allowing them to exceed/drop below
-    // certain speeds/acceleration levels.
-    //
-    message DynamicConstraints
-    {
-        // Maximum acceleration the distance contoller is allowed to use for keeping distance. 
-        //
-        // Unit: m/s^2
-        //
-        optional double max_acceleration = 1;
-
-        // Maximum deceleration the distance contoller is allowed to use for keeping distance. 
-        //
-        // Unit: m/s^2
-        //
-        optional double max_deceleration = 2;
-
-        // Maximum speed the distance contoller is allowed to use for keeping distance. 
-        //
-        // Unit: m/s
-        //
-        optional double max_speed = 3;
-    }
-
-    //
-    // \brief Custom Action.
-    //
-    // This action assigns a custom command to a traffic participant.
-    // The syntax and semantics of this action is implementation defined.
-    // It is entirely up to each individual traffic participant which
-    // custom commands it supports, if any, and how they must be phrased.
-    //
-    // \note This action is aligned with CustomCommandAction of OpenSCENARIO 1.0
-    // providing a customizable user defined action.
-    //
-    message CustomAction
-    {
-        // The Action Header.
-        //
-        optional ActionHeader action_header = 1;
-
-        // The custom command given to the traffic participant.
-        //
-        optional string command = 2;
     }
 }


### PR DESCRIPTION
Signed-off-by: Nader Thomas <thomas.nader@bmw.de>

#### Reference to a related issue in the repository
As discussed in the CCB-Meeting.

#### Add a description
Restructuring of the different traffic action definitions as discussed in the CCB-Meeting.
==> To make the code more structured and give a better overview (especially by implementing).

**Some questions to ask**:
What is this change?
Moved the different traffic action definitions in message TrafficAction as discussed in the CCB-Meeting.
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Mention a member
Add @mentions of the person or team responsible for reviewing proposed changes.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.