### PR TITLE
Add steering wheel angle

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -456,6 +456,15 @@ message MovingObject
         //
         repeated WheelData wheel_data = 7;
 
+        // Angle of the steering wheel. 
+        // Zero means the steering wheel is in its center postion, a positive value
+        // means the steering wheel is turned to the left and a negative value
+        // means the steering wheel is turned to the right of the center position.
+        //
+        // Unit: rad
+        //
+        optional double steering_wheel_angle = 8;
+
         // \brief Detailed wheel data.
         // The focus is on the description of a wheel regarding the perceivable 
         // information from the outside. 


### PR DESCRIPTION
#### Add a description
The value is needed for visualization needs. To see how the steering wheel moves from other cars, but also your own (especially VR, when you sit in the car.
It can not be derived from the wheel angle in an accurate way.

**Some questions to ask**:
What is this change? What does it fix?
The value is needed for visualization needs. To see how the steering wheel moves from other cars, but also your own (especially VR, when you sit in the car.
It can not be derived from the wheel angle in an accurate way.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
New feature.
How has it been tested?
In another branch the signal was implemented and tested.

#### Check the checklist

- [x] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.