### PR TITLE
Harmonization of road mark colors with OpenDRIVE

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -993,6 +993,10 @@ message LaneBoundary
             // Marking with violet color.
             //
             COLOR_VIOLET = 8;
+
+            // Marking with orange color.
+            //
+            COLOR_ORANGE = 9;
         }
     }
 }

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -121,8 +121,8 @@ message RoadMarking
 
 
         // Boolean flag to indicate that the road marking is taken out of service.
-        // This can be achieved by visibly crossing the road marking with stripes, 
-        // or completly covering a road marking making it not visible. 
+        // This can be achieved by visibly crossing the road marking with stripes,
+        // or completly covering a road marking making it not visible.
         //
         // \image html OSI_RoadMaking_is_out_of_service.jpg width=800px
         //
@@ -206,6 +206,10 @@ message RoadMarking
             // Marking with violet color.
             //
             COLOR_VIOLET = 8;
+
+            // Marking with orange color.
+            //
+            COLOR_ORANGE = 9;
         }
     }
 }


### PR DESCRIPTION
As suggested in #504:
**1. Color orange is added to road mark colors**
**2. Color violet is marked as deprecated**

**Some questions to ask**:
What is this change? --> only extension
What does it fix? --> harmonisation with OpenDrive
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested? --> only extension

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [ ] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
