### PR TITLE
add moving direction to moving object classification

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -579,6 +579,8 @@ message MovingObject
         //
         optional MovingDirection moving_direction = 3;
 
+        // Definitions of moving direction.
+        //
         enum MovingDirection
         {
             // Moving direction is unkown.

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -585,23 +585,23 @@ message MovingObject
         {
             // Moving direction is unkown.
             //
-            MOVING_DIRECTION_UNKOWN = 1;
+            MOVING_DIRECTION_UNKOWN = 0;
             
             // Moving object is moving in the same direction.
             //
-            MOVING_DIRECTION_IN_SAME_DIRECTION = 2;
+            MOVING_DIRECTION_IN_SAME_DIRECTION = 1;
             
             // Moving object is moving towards the host vehicle.
             //
-            MOVING_DIRECTION_ONCOMING = 3;
+            MOVING_DIRECTION_ONCOMING = 2;
             
             // Moving object is crossing from left to right.
             //
-            MOVING_DIRECTION_CROSSING_LEFT_TO_RIGHT = 4;
+            MOVING_DIRECTION_CROSSING_LEFT_TO_RIGHT = 3;
             
             // Moving object is crossing from right to left.
             //
-            MOVING_DIRECTION_CROSSING_RIGHT_TO_LEFT = 5;
+            MOVING_DIRECTION_CROSSING_RIGHT_TO_LEFT = 4;
         }
     }
 

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -572,7 +572,35 @@ message MovingObject
         //
         // \note OSI uses singular instead of plural for repeated field names.
         //
-        repeated double assigned_lane_percentage = 2;        
+        repeated double assigned_lane_percentage = 2;
+
+        // Classification of the general moving direction of a moving object depeding on the relative yaw orientation between host vehicle and moving object.
+        // TODOD Maybe add grafic to illustrate the situation with relative yaw angle
+        //
+        optional MovingDirection moving_direction = 3;
+
+        enum MovingDirection
+        {
+            // Moving direction is unkown.
+            //
+            MOVING_DIRECTION_UNKOWN = 1;
+            
+            // Moving object is moving in the same direction.
+            //
+            MOVING_DIRECTION_IN_SAME_DIRECTION = 2;
+            
+            // Moving object is moving towards the host vehicle.
+            //
+            MOVING_DIRECTION_ONCOMING = 3;
+            
+            // Moving object is crossing from left to right.
+            //
+            MOVING_DIRECTION_CROSSING_LEFT_TO_RIGHT = 4;
+            
+            // Moving object is crossing from right to left.
+            //
+            MOVING_DIRECTION_CROSSING_RIGHT_TO_LEFT = 5;
+        }
     }
 
     //


### PR DESCRIPTION
Signed-off-by: Schloemicher, Thomas AVL,AT <thomas.schloemicher@avl.com>

﻿#### Reference to a related issue in the repository
Add a reference to a related issue in the repository.

#### Add a description
Adding moving direction to moving object classification to have a high level sematic information of the overall moving direction of a moving object whether it is oncoming, moving in the same direction or crossing.

**Some questions to ask**:
What is this change?
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
