### PR TITLE
echo_pulse_width added in osi_featuredata.proto for message LidarDetection

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -453,14 +453,18 @@ message LidarDetection
     // Echo pulse width of the detection's echo.
     // Several sensors output an echo pulse width instead of an intensity for each individual detection.
     // The echo pulse is measured in m and measures the extent of the object parts or atmospheric particles that produce the echo.
-    // Fig. 7 shows an example where the two echos are reflected from the edges A-B and C-D. For more details, see [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
-    // Fig. 8 shows how the echo pulse width is measured as the range between the rising edge and the falling edge that crosses the intensity threshold. For more details, see [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
+    // \note For more details see [1] Fig. 7 and 8.
+    // \note Fig. 7 shows an example where the two echos are reflected from the edges A-B and C-D.
+    // \note Fig. 8 shows how the echo pulse width is measured as the range between the rising edge and the falling edge that crosses the intensity threshold.
     //
     // Unit: m
     //
     // \rules
     // is_greater_than_or_equal_to: 0
     // \endrules
+    //
+    // \par Reference:
+    // [1] Rosenberger, P., Holder, M.F., Cianciaruso, N. et al. (2020). <em>Sequential lidar sensor system simulation: a modular approach for simulation-based safety validation of automated driving</em> Automot. Engine Technol. 5, Fig 7, Fig 8. Retrieved May 10, 2021, from https://doi.org/10.1007/s41104-020-00066-x
     //
     optional double echo_pulse_width = 11;
 }

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -451,6 +451,10 @@ message LidarDetection
     optional double reflectivity = 10;
 
     // Echo pulse width of the detection's echo.
+	// Several sensors output an echo-pulse width instead of an intensity for each single detection.
+	// It is measured in m and measures the extend of the object parts or atmospheric particles that produce the echo.
+	// As an example, it is depicted for the two echos reflected from the edges A-B and C-D in Fig. 7 from [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
+	// Fig. 8 [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf) shows it in more detail, as the echo-pulse width is measured as the range between the rising and falling edge crossing the intensity threshold.
     //
     // Unit: m
     //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -451,10 +451,10 @@ message LidarDetection
     optional double reflectivity = 10;
 
     // Echo pulse width of the detection's echo.
-    // Several sensors output an echo-pulse width instead of an intensity for each single detection.
-    // It is measured in m and measures the extend of the object parts or atmospheric particles that produce the echo.
-    // As an example, it is depicted for the two echos reflected from the edges A-B and C-D in Fig. 7 from [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
-    // Fig. 8 [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf) shows it in more detail, as the echo-pulse width is measured as the range between the rising and falling edge crossing the intensity threshold.
+    // Several sensors output an echo pulse width instead of an intensity for each individual detection.
+    // The echo pulse is measured in m and measures the extent of the object parts or atmospheric particles that produce the echo.
+    // Fig. 7 shows an example where the two echos are reflected from the edges A-B and C-D. For more details, see [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
+    // Fig. 8 shows how the echo pulse width is measured as the range between the rising edge and the falling edge that crosses the intensity threshold. For more details, see [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
     //
     // Unit: m
     //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -449,6 +449,16 @@ message LidarDetection
     // Lambertian reflectivity.
     //
     optional double reflectivity = 10;
+
+    // Echo pulse width of the detection's echo.
+    //
+    // Unit: m
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // \endrules
+    //
+    optional double echo_pulse_width = 11;
 }
 
 //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -451,10 +451,10 @@ message LidarDetection
     optional double reflectivity = 10;
 
     // Echo pulse width of the detection's echo.
-	// Several sensors output an echo-pulse width instead of an intensity for each single detection.
-	// It is measured in m and measures the extend of the object parts or atmospheric particles that produce the echo.
-	// As an example, it is depicted for the two echos reflected from the edges A-B and C-D in Fig. 7 from [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
-	// Fig. 8 [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf) shows it in more detail, as the echo-pulse width is measured as the range between the rising and falling edge crossing the intensity threshold.
+    // Several sensors output an echo-pulse width instead of an intensity for each single detection.
+    // It is measured in m and measures the extend of the object parts or atmospheric particles that produce the echo.
+    // As an example, it is depicted for the two echos reflected from the edges A-B and C-D in Fig. 7 from [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf).
+    // Fig. 8 [Rosenberger et al.](https://link.springer.com/content/pdf/10.1007/s41104-020-00066-x.pdf) shows it in more detail, as the echo-pulse width is measured as the range between the rising and falling edge crossing the intensity threshold.
     //
     // Unit: m
     //


### PR DESCRIPTION
echo_pulse_width added in osi_featuredata.proto for message LidarDetection. 

#### Add a description
As intensity is in % and echo_pulse_width is in m, such a field is currently missing in OSI for LidarDetectionData.
It is necessary to transfer echo_pulse_width since sensors like Ibeo LUX or Valeo SCALA are having this as an output instead of intensity.
The PR comes out of the SET Level project, where it has already been approved by the project-internal OSI-CCB.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
