### PR TITLE
clarified semantics currently supported with TrafficUpdate

### DIFF
--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -11,7 +11,9 @@ package osi3;
 //
 // \brief The traffic update message is provided by traffic
 // participant models to provide updates to their position, state
-// and future trajectory back to the simulation environment.
+// and future trajectory back to the simulation environment. The message is designed 
+// to update data of exactly ONE traffic participant, optionally with an attached 
+// trailer. 
 //
 // \note For reasons of convenience and consistency, the
 // updated information is provided as a MovingObject.  Certain fields

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -9,15 +9,15 @@ import "osi_object.proto";
 package osi3;
 
 //
-// \brief The traffic update message is provided by traffic
-// participant models to provide updates to their position, state
-// and future trajectory back to the simulation environment. The message is designed 
-// to update data of exactly ONE traffic participant, optionally with an attached 
-// trailer. 
+// \brief The traffic update message is provided by traffic participant
+// models to provide updates to their position, state and future
+// trajectory back to the simulation environment. The message is
+// designed to update data of exactly one traffic participant,
+// optionally with an attached trailer. 
 //
-// \note For reasons of convenience and consistency, the
-// updated information is provided as a MovingObject.  Certain fields
-// of this sub-message are not required to be set and will be ignored by the
+// \note For reasons of convenience and consistency, the updated
+// information is provided as a MovingObject.  Certain fields of this
+// sub-message are not required to be set and will be ignored by the
 // simulation environment, because they are static information.
 // Instead of creating a seperate message type for only the non-static
 // information, re-use existing message.

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -45,5 +45,9 @@ message TrafficUpdate
     // or vehicle category.  All dynamic fields should be populated where known,
     // for example, velocity, light states, or future trajectory.
     //
+    // \note The field is repeated because it is possible to have a trailer attached to
+    // a vehicle, see MovingObject::VehicleClassification::has_trailer and
+    // MovingObject::VehicleClassification::trailer_id. 
+    //
     repeated MovingObject update = 3;
 }


### PR DESCRIPTION
Signed-off-by: Habedank Clemens <qxs2704@europe.bmw.corp>

﻿#### Reference to a related issue in the repository
Add a reference to a related issue in the repository.

#### Add a description
Add a description of the changes proposed in the pull request.
Clarifying semantics after feedback from SETLevel project. The semantics for other potential use cases, e.g. multiple TrafficParticipants packaged in one model would need to be elaborated and specified (OSMP + OSI) and are therefore currently not supported. A trailer seems unproblematic in this regard, so keeping the field repeated is possible. 

**Some questions to ask**:
What is this change?
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
