### PR TITLE
Improve lane pairing documentation

### DIFF
--- a/doc/images/OSI_LaneBoundaries_And_CenterLine_Intersection.svg
+++ b/doc/images/OSI_LaneBoundaries_And_CenterLine_Intersection.svg
@@ -1,0 +1,2212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="283.11191mm"
+   height="166.65927mm"
+   viewBox="0 0 283.11191 166.65927"
+   version="1.1"
+   id="svg1002"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="OSI_LaneBoundaries_And_CenterLine_Intersection.svg">
+  <defs
+     id="defs996" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#002000"
+     bordercolor="#000000"
+     borderopacity="0.90196078"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70000001"
+     inkscape:cx="347.94309"
+     inkscape:cy="244.37872"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="false"
+     inkscape:snap-grids="false"
+     inkscape:guide-bbox="true"
+     inkscape:lockguides="false"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1052"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     units="mm"
+     height="225mm"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1547"
+       originx="-10.066611"
+       originy="-20.516049" />
+    <sodipodi:guide
+       position="45.698397,215.36896"
+       orientation="1,0"
+       id="guide4761"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.522568,215.36896"
+       orientation="1,0"
+       id="guide4763"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.346738,215.36896"
+       orientation="1,0"
+       id="guide4765"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.862413,215.35528"
+       orientation="1,0"
+       id="guide4769"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="63.170906,215.36897"
+       orientation="1,0"
+       id="guide4771"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="68.995076,215.36897"
+       orientation="1,0"
+       id="guide4773"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="94.179217,201.73395"
+       orientation="0,1"
+       id="guide5679"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="76.63778,194.88684"
+       orientation="1,0"
+       id="guide5683"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="68.234695,202.17159"
+       orientation="0,1"
+       id="guide5685"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="70.631307,211.13138"
+       orientation="1,0"
+       inkscape:locked="false"
+       id="guide5870" />
+    <sodipodi:guide
+       position="76.203019,196.44229"
+       orientation="0,1"
+       id="guide5874"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata999">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-10.066611,-109.82468)">
+    <g
+       inkscape:groupmode="layer"
+       id="g4335"
+       inkscape:label="background"
+       transform="matrix(0.01369319,0,0,0.01369319,45.615659,68.195014)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.36515173px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;overflow:hidden;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+       x="64.37365"
+       y="38.794231"
+       id="text4395"><tspan
+         sodipodi:role="line"
+         id="tspan4393"
+         x="64.37365"
+         y="39.117306"
+         style="stroke-width:0.02738638" /></text>
+    <g
+       transform="matrix(0,0.01369319,-0.01369319,0,91.721756,77.27194)"
+       inkscape:label="background"
+       id="layer5"
+       inkscape:groupmode="layer" />
+    <text
+       id="text1599"
+       y="-121.12596"
+       x="94.474472"
+       style="font-style:normal;font-weight:normal;font-size:0.36515173px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;overflow:hidden;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+       xml:space="preserve"
+       transform="rotate(90)"><tspan
+         style="stroke-width:0.02738638"
+         y="-120.80289"
+         x="94.474472"
+         id="tspan1597"
+         sodipodi:role="line" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.36515173px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;overflow:hidden;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+       x="118.94322"
+       y="39.890789"
+       id="text6048"><tspan
+         sodipodi:role="line"
+         id="tspan6046"
+         x="118.94322"
+         y="40.213863"
+         style="stroke-width:0.02738638" /></text>
+    <g
+       id="g1532"
+       transform="matrix(3.0384273,0,0,3.0384273,-129.80034,-72.178179)">
+      <path
+         style="fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 80.697922,76.350092 V 60.550001 l 23.812498,-5.44e-4 v 15.800091 c -2.64584,0 -4.04366,1.046285 -4.04366,3.692119 H 84.666667 c 0,-2.645831 -1.322917,-3.691575 -3.968745,-3.691575 z"
+         id="path5677"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path5063"
+         d="m 80.697917,75.181875 v -0.869514 c 3.439583,0 6.006832,2.818889 6.006476,5.729306 l -0.869516,-3e-6 c 0,-2.645831 -2.226544,-4.859789 -5.13696,-4.859789 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6926"
+         d="m 80.697918,74.75 2.779898,0.70294 2.13323,2.03622 0.655711,2.552504"
+         style="fill:none;stroke:#ffcc00;stroke-width:0.027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 104.51042,75.181337 v -0.868976 c -3.43959,0 -6.140324,2.818892 -6.139974,5.729306 h 0.848304 c 0,-2.645831 2.38125,-4.86033 5.29167,-4.86033 z"
+         id="path5681"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:none;stroke:#ffcc00;stroke-width:0.027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 104.37652,74.746641 -2.7799,0.70294 -2.133236,2.03622 -0.65571,2.552504"
+         id="path7188"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="61.785416"
+         x="80.697914"
+         height="0.86035216"
+         width="23.812502"
+         id="rect5687"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="60.550003"
+         x="47.625004"
+         height="15.800091"
+         width="33.072918"
+         id="rect4333"
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         y="61.783638"
+         x="47.625008"
+         height="0.86267102"
+         width="33.072922"
+         id="rect4337"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         y="74.312363"
+         x="47.625008"
+         height="0.86951792"
+         width="33.072914"
+         id="rect4339"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04320637;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         sodipodi:nodetypes="cc"
+         style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.02774047;stroke-miterlimit:8"
+         inkscape:connector-curvature="0"
+         id="path4351"
+         stroke-miterlimit="8"
+         d="M 47.625006,62.214976 H 80.697922" />
+      <path
+         sodipodi:nodetypes="cc"
+         style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.02774047;stroke-miterlimit:8"
+         inkscape:connector-curvature="0"
+         id="path4353"
+         stroke-miterlimit="8"
+         d="M 47.625006,74.750001 H 80.697922" />
+      <g
+         transform="matrix(-1,0,0,1,130.31954,1.1933669)"
+         id="g5086">
+        <rect
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect4341"
+           width="7.5183368"
+           height="0.87155259"
+           x="59.27272"
+           y="67.61676"
+           transform="matrix(1,0,-0.14091606,0.99002155,0,0)" />
+        <rect
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect4343"
+           width="7.5183368"
+           height="0.87155259"
+           x="72.486649"
+           y="67.61676"
+           transform="matrix(1,0,-0.14091606,0.99002155,0,0)" />
+        <rect
+           y="-82.694534"
+           x="66.976616"
+           height="6.6725059"
+           width="0.79374999"
+           id="rect5061"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.33687559;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="rotate(90)" />
+        <path
+           d="m 49.224314,67.369643 h 33.47022"
+           stroke-miterlimit="8"
+           id="path4349"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.0279066;stroke-miterlimit:8"
+           sodipodi:nodetypes="cc" />
+        <g
+           id="g4365"
+           style="fill:#4d59b3;stroke:none;stroke-opacity:1"
+           transform="matrix(0.01369319,0,0,0.01369319,42.219748,73.659312)">
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path4355"
+             stroke-miterlimit="8"
+             d="m 508.05621,-459.04728 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 17.67428,0 31.99972,14.32534 31.99972,32.00001 0,17.67466 -14.32544,32 -31.99972,32 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path4357"
+             stroke-miterlimit="8"
+             d="m 1058.1788,-459.04728 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path4359"
+             stroke-miterlimit="8"
+             d="m 2022.4241,-459.04728 c 0,-17.67467 14.3254,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6746,0 -32,-14.32534 -32,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999976;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path4361"
+             stroke-miterlimit="8"
+             d="m 1472.3014,-459.04728 c 0,-17.67467 14.3252,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6748,0 -32,-14.32534 -32,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path4363"
+             stroke-miterlimit="8"
+             d="m 2436.5466,-459.04728 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z" />
+        </g>
+      </g>
+      <path
+         sodipodi:nodetypes="cc"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.04161071;stroke-miterlimit:8;stroke-dasharray:0.24966425, 0.04161071;stroke-dashoffset:0"
+         inkscape:connector-curvature="0"
+         id="path4377"
+         stroke-miterlimit="8"
+         d="M 47.625005,65.352575 H 80.697922" />
+      <path
+         sodipodi:nodetypes="cc"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.04161071;stroke-miterlimit:8;stroke-dasharray:0.24966425, 0.04161071;stroke-dashoffset:0"
+         inkscape:connector-curvature="0"
+         id="path4379"
+         stroke-miterlimit="8"
+         d="M 47.625005,71.613512 H 80.697922" />
+      <text
+         id="text4399"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         font-size="24"
+         font-weight="400"
+         x="45.181252"
+         y="66.790222">
+        <tspan
+           id="tspan4397"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           y="66.790222"
+           x="56.104668"
+           font-style="italic">centerline_is_driving_direction=true</tspan>
+      </text>
+      <path
+         d="m 56.96305,65.352576 c 0,-0.242023 0.196152,-0.438182 0.438175,-0.438182 0.242022,0 0.438182,0.196159 0.438182,0.438182 0,0.242022 -0.19616,0.438182 -0.438182,0.438182 -0.242023,0 -0.438175,-0.19616 -0.438175,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4401"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <path
+         d="m 51.138879,65.352576 c 0,-0.242023 0.196153,-0.438182 0.438175,-0.438182 0.242023,0 0.438183,0.196159 0.438183,0.438182 0,0.242022 -0.19616,0.438182 -0.438183,0.438182 -0.242022,0 -0.438175,-0.19616 -0.438175,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4411"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text4431"
+         font-size="24"
+         font-weight="400"
+         x="45.980473"
+         y="68.744019">
+        <tspan
+           id="tspan4429"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb2</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text4435"
+         font-size="24"
+         font-weight="400"
+         x="45.980473"
+         y="62.485825">
+        <tspan
+           id="tspan4433"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb1</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text4439"
+         font-size="24"
+         font-weight="400"
+         x="45.980473"
+         y="75.024773">
+        <tspan
+           id="tspan4437"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb3</tspan>
+      </text>
+      <text
+         id="text4443"
+         y="64.373466"
+         x="61.916695"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1"
+           y="64.373466"
+           x="61.916695"
+           id="tspan4441"
+           sodipodi:role="line">lane 1</tspan></text>
+      <text
+         id="text4447"
+         y="70.645844"
+         x="61.901539"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1"
+           y="70.645844"
+           x="61.901539"
+           id="tspan4445"
+           sodipodi:role="line">lane 2</tspan></text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+         id="text4451"
+         font-size="24"
+         font-weight="400"
+         x="46.002048"
+         y="65.623428">
+        <tspan
+           id="tspan4449"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">cl1</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+         id="text4455"
+         font-size="24"
+         font-weight="400"
+         x="46.002048"
+         y="71.887894">
+        <tspan
+           id="tspan4453"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">cl2</tspan>
+      </text>
+      <text
+         id="text4459"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         font-size="24"
+         font-weight="400"
+         x="45.26284"
+         y="73.049637">
+        <tspan
+           id="tspan4457"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           y="73.049637"
+           x="56.186256"
+           font-style="italic">centerline_is_driving_direction=false</tspan>
+      </text>
+      <path
+         d="m 56.963052,71.575 c 0,-0.242022 0.196152,-0.438182 0.438175,-0.438182 0.242022,0 0.438182,0.19616 0.438182,0.438182 0,0.242023 -0.19616,0.438182 -0.438182,0.438182 -0.242023,0 -0.438175,-0.196159 -0.438175,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4461"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <path
+         d="m 51.13888,71.575 c 0,-0.242023 0.196153,-0.438182 0.438175,-0.438182 0.242023,0 0.438183,0.196159 0.438183,0.438182 0,0.242023 -0.19616,0.438182 -0.438183,0.438182 -0.242022,0 -0.438175,-0.196159 -0.438175,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4471"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <path
+         d="m 56.963064,62.214976 c 0,-0.242022 0.196146,-0.438182 0.438185,-0.438182 0.242035,0 0.438179,0.19616 0.438179,0.438182 0,0.242023 -0.196144,0.438182 -0.438179,0.438182 -0.242039,0 -0.438185,-0.196159 -0.438185,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4489"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <g
+         id="g5697"
+         transform="translate(1.6362376,1.0999886)">
+        <path
+           d="m 72.799339,61.114987 c 0,-0.242023 0.196162,-0.438182 0.43818,-0.438182 0.242025,0 0.438184,0.196159 0.438184,0.438182 0,0.242022 -0.196159,0.438182 -0.438184,0.438182 -0.242018,0 -0.43818,-0.19616 -0.43818,-0.438182 z"
+           stroke-miterlimit="8"
+           id="path4367"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+        <text
+           y="61.385708"
+           x="70.659096"
+           font-weight="400"
+           font-size="24"
+           id="text4495"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">
+          <tspan
+             x="72.992752"
+             y="61.413094"
+             id="tspan4491"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638">2</tspan>
+          <tspan
+             x="70.679176"
+             y="55.03207"
+             id="tspan4493"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638" />
+        </text>
+      </g>
+      <g
+         id="g5701"
+         transform="translate(1.6362376,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path4511"
+           stroke-miterlimit="8"
+           d="m 66.975168,61.114987 c 0,-0.242022 0.196146,-0.438182 0.438185,-0.438182 0.242036,0 0.43818,0.19616 0.43818,0.438182 0,0.242023 -0.196144,0.438182 -0.43818,0.438182 -0.242039,0 -0.438185,-0.196159 -0.438185,-0.438182 z" />
+        <text
+           y="61.40741"
+           x="67.15937"
+           font-weight="400"
+           font-size="24"
+           id="text4507"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">3</text>
+      </g>
+      <g
+         id="g5705"
+         transform="translate(1.6362376,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path4505"
+           stroke-miterlimit="8"
+           d="m 61.150997,61.114987 c 0,-0.242022 0.196146,-0.438182 0.438185,-0.438182 0.242035,0 0.438179,0.19616 0.438179,0.438182 0,0.242023 -0.196144,0.438182 -0.438179,0.438182 -0.242039,0 -0.438185,-0.196159 -0.438185,-0.438182 z" />
+        <text
+           y="61.164806"
+           x="61.206146"
+           font-weight="400"
+           font-size="24"
+           id="text4513"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      </g>
+      <path
+         d="m 56.963052,74.750547 c 0,-0.242023 0.196146,-0.438183 0.438185,-0.438183 0.242035,0 0.438179,0.19616 0.438179,0.438183 0,0.242022 -0.196144,0.438182 -0.438179,0.438182 -0.242039,0 -0.438185,-0.19616 -0.438185,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4517"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <path
+         d="m 51.138882,74.750547 c 0,-0.242023 0.196176,-0.438182 0.438186,-0.438182 0.242017,0 0.438178,0.196159 0.438178,0.438182 0,0.242022 -0.196161,0.438182 -0.438178,0.438182 -0.24201,0 -0.438186,-0.19616 -0.438186,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4527"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <path
+         d="m 51.127082,62.228669 c 0,-0.242023 0.196162,-0.438182 0.438181,-0.438182 0.242025,0 0.438184,0.196159 0.438184,0.438182 0,0.242022 -0.196159,0.438182 -0.438184,0.438182 -0.242019,0 -0.438181,-0.19616 -0.438181,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path4759"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <g
+         id="g5733"
+         transform="translate(1.6362171,1.0999886)">
+        <path
+           d="m 72.799348,64.252587 c 0,-0.242023 0.196153,-0.438183 0.438176,-0.438183 0.242021,0 0.438182,0.19616 0.438182,0.438183 0,0.242022 -0.196161,0.438182 -0.438182,0.438182 -0.242023,0 -0.438176,-0.19616 -0.438176,-0.438182 z"
+           stroke-miterlimit="8"
+           id="path4381"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+        <text
+           y="64.523308"
+           x="70.659096"
+           font-weight="400"
+           font-size="24"
+           id="text4495-6"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">
+          <tspan
+             x="72.992752"
+             y="64.550697"
+             id="tspan4491-1"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638">2</tspan>
+          <tspan
+             x="70.679176"
+             y="58.16967"
+             id="tspan4493-8"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638" />
+        </text>
+      </g>
+      <g
+         id="g5727"
+         transform="translate(1.6362171,1.0999886)">
+        <path
+           d="m 78.623521,64.252587 c 0,-0.242023 0.196152,-0.438183 0.438175,-0.438183 0.242022,0 0.438182,0.19616 0.438182,0.438183 0,0.242022 -0.19616,0.438182 -0.438182,0.438182 -0.242023,0 -0.438175,-0.19616 -0.438175,-0.438182 z"
+           stroke-miterlimit="8"
+           id="path4383"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+        <text
+           y="64.545403"
+           x="78.79908"
+           font-weight="400"
+           font-size="24"
+           id="text4501-7"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">1</text>
+      </g>
+      <g
+         id="g5737"
+         transform="translate(1.6362171,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path4423"
+           stroke-miterlimit="8"
+           d="m 66.975177,64.252587 c 0,-0.242023 0.196152,-0.438182 0.438175,-0.438182 0.242021,0 0.438182,0.196159 0.438182,0.438182 0,0.242022 -0.196161,0.438182 -0.438182,0.438182 -0.242023,0 -0.438175,-0.19616 -0.438175,-0.438182 z" />
+        <text
+           y="64.545013"
+           x="67.15937"
+           font-weight="400"
+           font-size="24"
+           id="text4507-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">3</text>
+      </g>
+      <g
+         id="g5741"
+         transform="translate(1.6362171,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path4417"
+           stroke-miterlimit="8"
+           d="m 61.151003,64.252587 c 0,-0.242023 0.196153,-0.438182 0.438176,-0.438182 0.242021,0 0.438182,0.196159 0.438182,0.438182 0,0.242022 -0.196161,0.438182 -0.438182,0.438182 -0.242023,0 -0.438176,-0.19616 -0.438176,-0.438182 z" />
+        <text
+           y="64.302406"
+           x="61.206146"
+           font-weight="400"
+           font-size="24"
+           id="text4513-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      </g>
+      <g
+         id="g5757"
+         transform="translate(1.6362176,1.0614765)">
+        <path
+           d="m 72.799351,70.513523 c 0,-0.242022 0.196152,-0.438182 0.438175,-0.438182 0.242022,0 0.438182,0.19616 0.438182,0.438182 0,0.242023 -0.19616,0.438183 -0.438182,0.438183 -0.242023,0 -0.438175,-0.19616 -0.438175,-0.438183 z"
+           stroke-miterlimit="8"
+           id="path4385"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+           id="text4931"
+           font-size="24"
+           font-weight="400"
+           x="70.659103"
+           y="70.784248">
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+             id="tspan4927"
+             y="70.811638"
+             x="72.99276">2</tspan>
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+             id="tspan4929"
+             y="64.430611"
+             x="70.679184" />
+        </text>
+      </g>
+      <g
+         id="g5761"
+         transform="translate(1.6362176,1.0614765)">
+        <path
+           d="m 78.62352,70.513523 c 0,-0.242022 0.196153,-0.438182 0.438176,-0.438182 0.242021,0 0.438182,0.19616 0.438182,0.438182 0,0.242023 -0.196161,0.438183 -0.438182,0.438183 -0.242023,0 -0.438176,-0.19616 -0.438176,-0.438183 z"
+           stroke-miterlimit="8"
+           id="path4387"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+           id="text4933"
+           font-size="24"
+           font-weight="400"
+           x="78.799088"
+           y="70.806343">1</text>
+      </g>
+      <g
+         id="g5749"
+         transform="translate(1.6362176,1.0614765)">
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path4483"
+           stroke-miterlimit="8"
+           d="m 66.975178,70.513523 c 0,-0.242022 0.196152,-0.438182 0.438175,-0.438182 0.242021,0 0.438182,0.19616 0.438182,0.438182 0,0.242023 -0.196161,0.438182 -0.438182,0.438182 -0.242023,0 -0.438175,-0.196159 -0.438175,-0.438182 z" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+           id="text4935"
+           font-size="24"
+           font-weight="400"
+           x="67.159378"
+           y="70.805954">3</text>
+      </g>
+      <g
+         id="g5745"
+         transform="translate(1.6362176,1.0614765)">
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path4477"
+           stroke-miterlimit="8"
+           d="m 61.151005,70.513523 c 0,-0.242022 0.196153,-0.438182 0.438176,-0.438182 0.242021,0 0.438182,0.19616 0.438182,0.438182 0,0.242023 -0.196161,0.438182 -0.438182,0.438182 -0.242023,0 -0.438176,-0.196159 -0.438176,-0.438182 z" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+           id="text4937"
+           font-size="24"
+           font-weight="400"
+           x="61.206158"
+           y="70.563347">...</text>
+      </g>
+      <g
+         id="g5719"
+         transform="translate(1.6362261,1.0999886)">
+        <path
+           d="m 72.799339,73.650557 c 0,-0.242022 0.196162,-0.438182 0.43818,-0.438182 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 -0.242018,0 -0.43818,-0.196159 -0.43818,-0.438182 z"
+           stroke-miterlimit="8"
+           id="path4371"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+        <text
+           y="73.92128"
+           x="70.659096"
+           font-weight="400"
+           font-size="24"
+           id="text4943"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">
+          <tspan
+             x="72.992752"
+             y="73.948669"
+             id="tspan4939"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638">2</tspan>
+          <tspan
+             x="70.679176"
+             y="67.567642"
+             id="tspan4941"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:0.02738638" />
+        </text>
+      </g>
+      <g
+         id="g5723"
+         transform="translate(1.6362261,1.0999886)">
+        <path
+           d="m 78.623508,73.650557 c 0,-0.242022 0.196162,-0.438182 0.438181,-0.438182 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 -0.242019,0 -0.438181,-0.196159 -0.438181,-0.438182 z"
+           stroke-miterlimit="8"
+           id="path4373"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+        <path
+           style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6457"
+           stroke-miterlimit="8"
+           d="m 79.061689,73.212375 c 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 5e-6,-0.356739 0.0056,-0.584367 0,-0.876364 z"
+           sodipodi:nodetypes="cscc" />
+        <text
+           y="73.943375"
+           x="78.79908"
+           font-weight="400"
+           font-size="24"
+           id="text4945"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">1</text>
+      </g>
+      <g
+         id="g5709"
+         transform="translate(1.6362261,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path4539"
+           stroke-miterlimit="8"
+           d="m 66.975168,73.650558 c 0,-0.242023 0.196146,-0.438183 0.438185,-0.438183 0.242036,0 0.43818,0.19616 0.43818,0.438183 0,0.242022 -0.196144,0.438182 -0.43818,0.438182 -0.242039,0 -0.438185,-0.19616 -0.438185,-0.438182 z" />
+        <text
+           y="73.942986"
+           x="67.15937"
+           font-weight="400"
+           font-size="24"
+           id="text4947"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">3</text>
+      </g>
+      <g
+         id="g5713"
+         transform="translate(1.6362261,1.0999886)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path4533"
+           stroke-miterlimit="8"
+           d="m 61.150997,73.650558 c 0,-0.242023 0.196146,-0.438183 0.438185,-0.438183 0.242035,0 0.438179,0.19616 0.438179,0.438183 0,0.242022 -0.196144,0.438182 -0.438179,0.438182 -0.242039,0 -0.438185,-0.19616 -0.438185,-0.438182 z" />
+        <text
+           y="73.700378"
+           x="61.206154"
+           font-weight="400"
+           font-size="24"
+           id="text4949"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      </g>
+      <rect
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect1166"
+         width="33.072918"
+         height="15.800091"
+         x="80.041664"
+         y="-100.46676"
+         transform="rotate(90)" />
+      <rect
+         transform="rotate(90)"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect1168"
+         width="33.072922"
+         height="0.84830379"
+         x="80.041664"
+         y="-99.21875" />
+      <rect
+         transform="rotate(90)"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect1168-2"
+         width="33.072914"
+         height="0.86951625"
+         x="80.041664"
+         y="-86.704391" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect1204"
+         width="7.5183368"
+         height="0.87155259"
+         x="66.868843"
+         y="-93.915688"
+         transform="matrix(0,1,-0.99002155,-0.14091606,0,0)" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect1204-3"
+         width="7.5183368"
+         height="0.87155259"
+         x="80.07299"
+         y="-93.911804"
+         transform="matrix(0,1,-0.99002155,-0.14091606,0,0)" />
+      <path
+         d="M 95.664184,80.277021 V 113.11458"
+         stroke-miterlimit="8"
+         id="path99"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.04146239;stroke-miterlimit:8;stroke-dasharray:0.24877434, 0.04146239;stroke-dashoffset:0"
+         sodipodi:nodetypes="cc" />
+      <path
+         d="M 89.403247,80.277021 V 113.11458"
+         stroke-miterlimit="8"
+         id="path99-8"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.04146239;stroke-miterlimit:8;stroke-dasharray:0.24877434, 0.04146239;stroke-dashoffset:0"
+         sodipodi:nodetypes="cc" />
+      <path
+         d="m 95.664183,104.45563 c 0.242023,0 0.438183,0.19615 0.438183,0.43817 0,0.24203 -0.19616,0.43819 -0.438183,0.43819 -0.242022,0 -0.438182,-0.19616 -0.438182,-0.43819 0,-0.24202 0.19616,-0.43817 0.438182,-0.43817 z"
+         stroke-miterlimit="8"
+         id="path101-0-2-6-3"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <path
+         d="m 95.664183,110.2798 c 0.242023,0 0.438183,0.19615 0.438183,0.43818 0,0.24202 -0.19616,0.43818 -0.438183,0.43818 -0.242022,0 -0.438182,-0.19616 -0.438182,-0.43818 0,-0.24203 0.19616,-0.43818 0.438182,-0.43818 z"
+         stroke-miterlimit="8"
+         id="path101-0-2-6-5-8"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <g
+         id="g1393"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.39312,73.985574)">
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path101-0-2-6-3-5"
+           stroke-miterlimit="8"
+           d="m 2225.1979,145.31846 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+        <path
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path101-0-2-6-5-8-21"
+           stroke-miterlimit="8"
+           d="m 2650.5312,145.31846 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+      </g>
+      <rect
+         y="106.44885"
+         x="92.125374"
+         height="6.6657324"
+         width="0.87089467"
+         id="rect4951"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.35268739;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         d="M 92.547127,79.651141 V 113.11458"
+         stroke-miterlimit="8"
+         id="path53"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.02738638;stroke-miterlimit:8"
+         sodipodi:nodetypes="cc" />
+      <path
+         d="M 98.801783,80.041667 V 113.11458"
+         stroke-miterlimit="8"
+         id="path53-0"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.02738638;stroke-miterlimit:8"
+         sodipodi:nodetypes="cc" />
+      <path
+         d="m 86.269634,80.041664 -0.0029,33.072916"
+         stroke-miterlimit="8"
+         id="path53-7"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:0.02738638;stroke-miterlimit:8"
+         sodipodi:nodetypes="cc" />
+      <g
+         id="g1029-0-6"
+         style="fill:#4d59b3;stroke:none;stroke-opacity:1"
+         transform="matrix(0,0.01369319,-0.01369319,0,86.257458,72.646575)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path23-2-8"
+           stroke-miterlimit="8"
+           d="m 508.05621,-459.04728 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 17.67428,0 31.99972,14.32534 31.99972,32.00001 0,17.67466 -14.32544,32 -31.99972,32 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z" />
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path25-40-0"
+           stroke-miterlimit="8"
+           d="m 1058.1788,-459.04728 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path27-4-1"
+           stroke-miterlimit="8"
+           d="m 2022.4241,-459.04728 c 0,-17.67467 14.3254,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6746,0 -32,-14.32534 -32,-32 z" />
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999976;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path31-9-9"
+           stroke-miterlimit="8"
+           d="m 1472.3014,-459.04728 c 0,-17.67467 14.3252,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6748,0 -32,-14.32534 -32,-32 z" />
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path33-8-5"
+           stroke-miterlimit="8"
+           d="m 2436.5466,-459.04728 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z" />
+      </g>
+      <path
+         d="m 98.801783,103.22617 c 0.242023,0 0.438182,0.19616 0.438182,0.43818 0,0.24202 -0.196159,0.43818 -0.438182,0.43818 -0.242022,0 -0.438182,-0.19616 -0.438182,-0.43818 0,-0.24202 0.19616,-0.43818 0.438182,-0.43818 z"
+         stroke-miterlimit="8"
+         id="path33"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <path
+         d="m 98.801783,109.05034 c 0.242023,0 0.438182,0.19616 0.438182,0.43818 0,0.24202 -0.196159,0.43818 -0.438182,0.43818 -0.242022,0 -0.438182,-0.19616 -0.438182,-0.43818 0,-0.24202 0.19616,-0.43818 0.438182,-0.43818 z"
+         stroke-miterlimit="8"
+         id="path33-4"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <path
+         d="m 86.266213,103.22617 c 0.242022,0 0.438182,0.19616 0.438182,0.43818 0,0.24202 -0.19616,0.43818 -0.438182,0.43818 -0.242023,0 -0.438182,-0.19616 -0.438182,-0.43818 0,-0.24202 0.196159,-0.43818 0.438182,-0.43818 z"
+         stroke-miterlimit="8"
+         id="path33-8"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <path
+         d="m 86.266213,109.05034 c 0.242022,0 0.438182,0.19616 0.438182,0.43818 0,0.24202 -0.19616,0.43818 -0.438182,0.43818 -0.242023,0 -0.438182,-0.19616 -0.438182,-0.43818 0,-0.24202 0.196159,-0.43818 0.438182,-0.43818 z"
+         stroke-miterlimit="8"
+         id="path33-8-3"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <text
+         transform="rotate(90)"
+         y="-94.229965"
+         x="76.869278"
+         font-weight="400"
+         font-size="24"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         id="text1464">
+        <tspan
+           font-style="italic"
+           x="87.792694"
+           y="-94.229965"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           id="tspan1466">centerline_is_driving_direction=false</tspan>
+      </text>
+      <g
+         id="g1507"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,77.834366)">
+        <path
+           d="m 794.53069,-311.91148 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101-0"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4"
+           font-size="24"
+           font-weight="400"
+           x="401.43896"
+           y="-269.64456">
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan131-0"
+             y="-267.64456"
+             x="571.86377">2</tspan>
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan145-2"
+             y="-733.64447"
+             x="402.90527" />
+        </text>
+      </g>
+      <g
+         id="g1500"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,75.716486)">
+        <path
+           d="m 523.86401,-311.91149 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-5"
+           font-size="24"
+           font-weight="400"
+           x="301.13983"
+           y="-267.90237">1</text>
+      </g>
+      <g
+         id="g1512"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,79.952246)">
+        <path
+           d="m 1065.1974,-311.91149 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101-0-7"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-7"
+           font-size="24"
+           font-weight="400"
+           x="842.88855"
+           y="-267.84509">3</text>
+      </g>
+      <text
+         transform="rotate(90)"
+         y="-92.276169"
+         x="113.53844"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-79-3-1"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan2476">lb5</tspan>
+      </text>
+      <text
+         transform="rotate(90)"
+         y="-98.534355"
+         x="113.53844"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-79-3-1-6"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan2474">lb6</tspan>
+      </text>
+      <text
+         transform="rotate(90)"
+         y="-85.995407"
+         x="113.53844"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-79-3-1-8"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan2478">lb4</tspan>
+      </text>
+      <text
+         transform="rotate(90)"
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         x="93.604721"
+         y="-96.646713"
+         id="text2442"><tspan
+           sodipodi:role="line"
+           id="tspan2440"
+           x="93.604721"
+           y="-96.646713"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1">lane 4</tspan></text>
+      <text
+         transform="rotate(90)"
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         x="93.589569"
+         y="-90.374344"
+         id="text2446"><tspan
+           sodipodi:role="line"
+           id="tspan2444"
+           x="93.589569"
+           y="-90.374344"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1">lane 3</tspan></text>
+      <text
+         transform="rotate(90)"
+         y="-95.396751"
+         x="113.56002"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-79-3-1-6-9"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan2474-5">cl4</tspan>
+      </text>
+      <text
+         transform="rotate(90)"
+         y="-89.132286"
+         x="113.56002"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-79-3-1-6-9-3"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan2474-5-4">cl3</tspan>
+      </text>
+      <text
+         transform="rotate(90)"
+         y="-87.970551"
+         x="76.950867"
+         font-weight="400"
+         font-size="24"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         id="text1464-5">
+        <tspan
+           font-style="italic"
+           x="87.874283"
+           y="-87.970551"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           id="tspan1466-1">centerline_is_driving_direction=true</tspan>
+      </text>
+      <g
+         id="g1490"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,77.834367)">
+        <path
+           d="m 794.53069,145.31845 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101-0-6"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-2"
+           font-size="24"
+           font-weight="400"
+           x="401.43896"
+           y="187.58539">
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan131-0-2"
+             y="189.58539"
+             x="571.86377">2</tspan>
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan145-2-4"
+             y="-276.41449"
+             x="402.90527" />
+        </text>
+      </g>
+      <g
+         id="g1495"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,75.716486)">
+        <path
+           d="m 523.86401,145.31844 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101-8"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-5-3"
+           font-size="24"
+           font-weight="400"
+           x="301.13983"
+           y="189.32756">1</text>
+      </g>
+      <g
+         id="g1483"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,79.952248)">
+        <path
+           d="m 1065.1974,145.31845 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path101-0-6-2"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-7-2"
+           font-size="24"
+           font-weight="400"
+           x="842.88855"
+           y="189.38486">3</text>
+      </g>
+      <g
+         id="g1534"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,77.834367)">
+        <path
+           d="m 794.53015,-541.04725 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z"
+           stroke-miterlimit="8"
+           id="path25-1"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-0"
+           font-size="24"
+           font-weight="400"
+           x="401.43869"
+           y="-498.78033">
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan131-0-4"
+             y="-496.78033"
+             x="571.86346">2</tspan>
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan145-2-3"
+             y="-962.78021"
+             x="402.905" />
+        </text>
+      </g>
+      <g
+         id="g1527"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,79.952248)">
+        <path
+           d="m 1065.1968,-541.04725 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z"
+           stroke-miterlimit="8"
+           id="path25-4-6"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-7-4"
+           font-size="24"
+           font-weight="400"
+           x="842.88818"
+           y="-496.98083">3</text>
+      </g>
+      <g
+         id="g1463"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,77.834367)">
+        <path
+           d="m 794.53015,374.41296 c 0,-17.67468 14.3243,-32.00002 32.0002,-32.00002 17.6756,0 31.9998,14.32534 31.9998,32.00002 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z"
+           stroke-miterlimit="8"
+           id="path25-40-2"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-2-6"
+           font-size="24"
+           font-weight="400"
+           x="401.43896"
+           y="416.67987">
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan131-0-2-7"
+             y="418.67987"
+             x="571.86377">2</tspan>
+          <tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2"
+             id="tspan145-2-4-4"
+             y="-47.32003"
+             x="402.90527" />
+        </text>
+      </g>
+      <g
+         id="g6971">
+        <g
+           id="g6932"
+           transform="matrix(0,0.01369319,-0.01369319,0,88.942765,75.719844)"
+           style="fill:#ffcc00">
+          <path
+             d="m 283.61793,195.21614 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 0,28.60867 0,29.11448 0,64.00001 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z"
+             stroke-miterlimit="8"
+             id="path6928"
+             inkscape:connector-curvature="0"
+             style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             sodipodi:nodetypes="sccs" />
+        </g>
+        <path
+           d="m 86.707816,80.041669 c 0,0.242017 -0.196159,0.438178 -0.438182,0.438178 -0.242022,0 -0.438182,-0.196161 -0.438182,-0.438178 0.435306,0 0.435306,0 0.876364,0 z"
+           stroke-miterlimit="8"
+           id="path23-2"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           sodipodi:nodetypes="cscc" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502"
+           id="text195-4-5-3-4"
+           font-size="24"
+           font-weight="400"
+           x="80.065819"
+           y="-86.09008"
+           transform="rotate(90)">1</text>
+        <text
+           y="-86.079262"
+           x="79.65834"
+           font-weight="400"
+           font-size="24"
+           id="text6934"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502"
+           transform="rotate(90)">4</text>
+      </g>
+      <g
+         id="g1468"
+         transform="matrix(0,0.01369319,-0.01369319,0,91.725179,79.952248)">
+        <path
+           d="m 1065.1968,374.41296 c 0,-17.67468 14.3243,-32.00002 32.0002,-32.00002 17.6756,0 31.9998,14.32534 31.9998,32.00002 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z"
+           stroke-miterlimit="8"
+           id="path25-40-8-1"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           transform="translate(-240,23.999998)" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2"
+           id="text195-4-7-2-4"
+           font-size="24"
+           font-weight="400"
+           x="842.88855"
+           y="418.47937">3</text>
+      </g>
+      <path
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+         inkscape:connector-curvature="0"
+         id="path101-0-2-6"
+         stroke-miterlimit="8"
+         d="m 95.667605,97.076004 c 0.242023,0 0.438182,0.196152 0.438182,0.438175 0,0.242021 -0.196159,0.438182 -0.438182,0.438182 -0.242022,0 -0.438182,-0.196161 -0.438182,-0.438182 0,-0.242023 0.19616,-0.438175 0.438182,-0.438175 z" />
+      <text
+         transform="rotate(90)"
+         y="-95.61779"
+         x="97.131142"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      <path
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8"
+         inkscape:connector-curvature="0"
+         id="path101-0-2-6-0"
+         stroke-miterlimit="8"
+         d="m 89.406669,97.076005 c 0.242022,0 0.438182,0.196152 0.438182,0.438175 0,0.242021 -0.19616,0.438182 -0.438182,0.438182 -0.242023,0 -0.438182,-0.196161 -0.438182,-0.438182 0,-0.242023 0.196159,-0.438175 0.438182,-0.438175 z" />
+      <text
+         transform="rotate(90)"
+         y="-89.356857"
+         x="97.131142"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-8-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      <path
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         id="path25-4"
+         stroke-miterlimit="8"
+         d="m 98.805205,97.075995 c 0.242022,0 0.438182,0.196146 0.438182,0.438185 0,0.242036 -0.19616,0.43818 -0.438182,0.43818 -0.242023,0 -0.438182,-0.196144 -0.438182,-0.43818 0,-0.242039 0.196159,-0.438185 0.438182,-0.438185 z" />
+      <text
+         transform="rotate(90)"
+         y="-98.755394"
+         x="97.131142"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-8-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      <path
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         id="path25-40-8"
+         stroke-miterlimit="8"
+         d="m 86.269634,97.075995 c 0.242023,0 0.438183,0.196146 0.438183,0.438185 0,0.242036 -0.19616,0.43818 -0.438183,0.43818 -0.242022,0 -0.438182,-0.196144 -0.438182,-0.43818 0,-0.242039 0.19616,-0.438185 0.438182,-0.438185 z" />
+      <text
+         transform="rotate(90)"
+         y="-86.219818"
+         x="97.131142"
+         font-weight="400"
+         font-size="24"
+         id="text195-4-8-6-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">...</text>
+      <rect
+         y="60.549995"
+         x="104.51041"
+         height="15.800091"
+         width="33.072918"
+         id="rect5990"
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         y="61.798"
+         x="104.51041"
+         height="0.84830379"
+         width="33.072922"
+         id="rect5992"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         y="74.312355"
+         x="104.51041"
+         height="0.86951625"
+         width="33.072914"
+         id="rect5994"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04107957;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         transform="matrix(1,0,-0.14091606,0.99002155,0,0)"
+         y="68.723953"
+         x="114.25613"
+         height="0.87155259"
+         width="7.5183368"
+         id="rect5996"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <rect
+         transform="matrix(1,0,-0.14091606,0.99002155,0,0)"
+         y="68.727837"
+         x="127.46028"
+         height="0.87155259"
+         width="7.5183368"
+         id="rect5998"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04128607;stroke-linecap:butt;stroke-miterlimit:8;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <g
+         id="g6014"
+         inkscape:label="cl"
+         transform="matrix(0.01369319,0,0,0.01369319,101.74069,69.294995)">
+        <path
+           d="M 219.45803,-287.91149 H 2617.5525"
+           stroke-miterlimit="8"
+           id="path6000"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:3.0279572;stroke-miterlimit:8;stroke-dasharray:18.1677417, 3.02795696;stroke-dashoffset:0"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="M 219.45803,169.31844 H 2617.5525"
+           stroke-miterlimit="8"
+           id="path6002"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:3.0279572;stroke-miterlimit:8;stroke-dasharray:18.1677417, 3.02795696;stroke-dashoffset:0"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="m 1985.1977,-287.91147 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path6004"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8" />
+        <path
+           d="m 2410.5312,-287.91147 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z"
+           stroke-miterlimit="8"
+           id="path6006"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8" />
+        <g
+           id="g6012"
+           transform="translate(-240,24)">
+          <path
+             style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+             inkscape:connector-curvature="0"
+             id="path6008"
+             stroke-miterlimit="8"
+             d="m 2225.1979,145.31846 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+          <path
+             style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+             inkscape:connector-curvature="0"
+             id="path6010"
+             stroke-miterlimit="8"
+             d="m 2650.5312,145.31846 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+        </g>
+      </g>
+      <rect
+         transform="rotate(-90)"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.35268739;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect6016"
+         width="0.87089467"
+         height="6.6657324"
+         x="-68.89138"
+         y="130.9176" />
+      <g
+         id="g6044"
+         inkscape:label="lb"
+         transform="matrix(0.01369319,0,0,0.01369319,100.51124,69.294995)">
+        <path
+           d="M 263.53648,-60.275916 H 2707.3383"
+           stroke-miterlimit="8"
+           id="path6018"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:1.99999988;stroke-miterlimit:8"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="M 263.53648,-517.04725 H 2707.3383"
+           stroke-miterlimit="8"
+           id="path6020"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:1.99999988;stroke-miterlimit:8"
+           sodipodi:nodetypes="cc" />
+        <path
+           d="M 263.53648,398.37316 H 2707.3383"
+           stroke-miterlimit="8"
+           id="path6022"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:none;fill-rule:evenodd;stroke:#4d59b3;stroke-width:1.99999988;stroke-miterlimit:8"
+           sodipodi:nodetypes="cc" />
+        <g
+           id="g6034"
+           style="fill:#4d59b3;stroke:none;stroke-opacity:1"
+           transform="translate(-247.99999,399.05228)">
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path6024"
+             stroke-miterlimit="8"
+             d="m 508.05621,-459.04728 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 17.67428,0 31.99972,14.32534 31.99972,32.00001 0,17.67466 -14.32544,32 -31.99972,32 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path6026"
+             stroke-miterlimit="8"
+             d="m 1058.1788,-459.04728 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path6028"
+             stroke-miterlimit="8"
+             d="m 2022.4241,-459.04728 c 0,-17.67467 14.3254,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6746,0 -32,-14.32534 -32,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999976;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path6030"
+             stroke-miterlimit="8"
+             d="m 1472.3014,-459.04728 c 0,-17.67467 14.3252,-32.00001 32,-32.00001 17.6747,0 32,14.32534 32,32.00001 0,17.67466 -14.3253,32 -32,32 -17.6748,0 -32,-14.32534 -32,-32 z" />
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path6032"
+             stroke-miterlimit="8"
+             d="m 2436.5466,-459.04728 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z" />
+        </g>
+        <path
+           d="m 1985.197,-517.04725 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z"
+           stroke-miterlimit="8"
+           id="path6036"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1" />
+        <path
+           d="m 2410.5303,-517.04725 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z"
+           stroke-miterlimit="8"
+           id="path6038"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1" />
+        <path
+           d="m 1985.197,398.41296 c 0,-17.67467 14.3255,-32.00001 31.9999,-32.00001 17.6748,0 32.0001,14.32534 32.0001,32.00001 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z"
+           stroke-miterlimit="8"
+           id="path6040"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1" />
+        <path
+           d="m 2410.5303,398.41296 c 0,-17.67466 14.3255,-32 31.9999,-32 17.6748,0 32.0001,14.32534 32.0001,32 0,17.67466 -14.3253,32 -32.0001,32 -17.6744,0 -31.9999,-14.32534 -31.9999,-32 z"
+           stroke-miterlimit="8"
+           id="path6042"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-miterlimit:8;stroke-opacity:1" />
+      </g>
+      <text
+         id="text6052"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         font-size="24"
+         font-weight="400"
+         x="101.33803"
+         y="66.786781">
+        <tspan
+           id="tspan6050"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           y="66.786781"
+           x="112.26144"
+           font-style="italic">centerline_is_driving_direction=false</tspan>
+      </text>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,102.30312,69.291573)"
+         id="g6062">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6054"
+           stroke-miterlimit="8"
+           d="m 794.53069,-311.91148 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z" />
+        <text
+           y="-269.64456"
+           x="401.43896"
+           font-weight="400"
+           font-size="24"
+           id="text6060"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">
+          <tspan
+             x="571.86377"
+             y="-267.64456"
+             id="tspan6056"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2">2</tspan>
+          <tspan
+             x="402.90527"
+             y="-733.64447"
+             id="tspan6058"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2" />
+        </text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,100.18524,69.291573)"
+         id="g6068">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6064"
+           stroke-miterlimit="8"
+           d="m 523.86401,-311.91149 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z" />
+        <text
+           y="-267.90237"
+           x="301.13983"
+           font-weight="400"
+           font-size="24"
+           id="text6066"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">1</text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,104.421,69.291573)"
+         id="g6074">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6070"
+           stroke-miterlimit="8"
+           d="m 1065.1974,-311.91149 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+        <text
+           y="-267.84509"
+           x="842.88855"
+           font-weight="400"
+           font-size="24"
+           id="text6072"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">3</text>
+      </g>
+      <path
+         d="m 121.54475,65.349147 c 0,-0.242023 0.19615,-0.438182 0.43817,-0.438182 0.24203,0 0.43819,0.196159 0.43819,0.438182 0,0.242022 -0.19616,0.438182 -0.43819,0.438182 -0.24202,0 -0.43817,-0.19616 -0.43817,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path6076"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <text
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text6078"
+         font-size="24"
+         font-weight="400"
+         x="121.59989"
+         y="65.398964">...</text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text6084"
+         font-size="24"
+         font-weight="400"
+         x="138.00719"
+         y="68.740578">
+        <tspan
+           id="tspan6082"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb8</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text6088"
+         font-size="24"
+         font-weight="400"
+         x="138.00719"
+         y="62.482395">
+        <tspan
+           id="tspan6086"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;fill-opacity:1;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb9</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text6092"
+         font-size="24"
+         font-weight="400"
+         x="138.00719"
+         y="75.021339">
+        <tspan
+           id="tspan6090"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">lb7</tspan>
+      </text>
+      <text
+         id="text6096"
+         y="64.370033"
+         x="118.07347"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1"
+           y="64.370033"
+           x="118.07347"
+           id="tspan6094"
+           sodipodi:role="line">lane 6</tspan></text>
+      <text
+         id="text6100"
+         y="70.642403"
+         x="118.05832"
+         style="font-style:normal;font-weight:normal;font-size:1.02242482px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.02738638"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;stroke:none;stroke-width:0.02738638;stroke-opacity:1"
+           y="70.642403"
+           x="118.05832"
+           id="tspan6098"
+           sodipodi:role="line">lane 5</tspan></text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+         id="text6104"
+         font-size="24"
+         font-weight="400"
+         x="138.02878"
+         y="65.619995">
+        <tspan
+           id="tspan6102"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">cl6</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1"
+         id="text6108"
+         font-size="24"
+         font-weight="400"
+         x="138.02878"
+         y="71.88446">
+        <tspan
+           id="tspan6106"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:#ffffff;fill-opacity:1;stroke:#b34d4d;stroke-width:0.02738638;stroke-opacity:1">cl5</tspan>
+      </text>
+      <text
+         id="text6112"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#b34d4d;stroke-width:0.02738638"
+         font-size="24"
+         font-weight="400"
+         x="101.41962"
+         y="73.046196">
+        <tspan
+           id="tspan6110"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#b34d4d;stroke-width:0.02738638"
+           y="73.046196"
+           x="112.34303"
+           font-style="italic">centerline_is_driving_direction=true</tspan>
+      </text>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,102.30312,69.291573)"
+         id="g6122">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6114"
+           stroke-miterlimit="8"
+           d="m 794.53069,145.31845 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z" />
+        <text
+           y="187.58539"
+           x="401.43896"
+           font-weight="400"
+           font-size="24"
+           id="text6120"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">
+          <tspan
+             x="571.86377"
+             y="189.58539"
+             id="tspan6116"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2">2</tspan>
+          <tspan
+             x="402.90527"
+             y="-276.41449"
+             id="tspan6118"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2" />
+        </text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,100.18524,69.291573)"
+         id="g6128">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6124"
+           stroke-miterlimit="8"
+           d="m 523.86401,145.31844 c 0,-17.67467 14.32481,-32 31.99948,-32 17.67468,0 32.00002,14.32533 32.00002,32 0,17.67467 -14.32534,32.00001 -32.00002,32.00001 -17.67467,0 -31.99948,-14.32534 -31.99948,-32.00001 z" />
+        <text
+           y="189.32756"
+           x="301.13983"
+           font-weight="400"
+           font-size="24"
+           id="text6126"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">1</text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,104.421,69.291573)"
+         id="g6134">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:1.9999876;stroke-miterlimit:8"
+           inkscape:connector-curvature="0"
+           id="path6130"
+           stroke-miterlimit="8"
+           d="m 1065.1974,145.31845 c 0,-17.67467 14.3248,-32 31.9995,-32 17.6746,0 32,14.32533 32,32 0,17.67467 -14.3254,32.00001 -32,32.00001 -17.6747,0 -31.9995,-14.32534 -31.9995,-32.00001 z" />
+        <text
+           y="189.38486"
+           x="842.88855"
+           font-weight="400"
+           font-size="24"
+           id="text6132"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">3</text>
+      </g>
+      <path
+         d="m 121.54475,71.610083 c 0,-0.242022 0.19615,-0.438182 0.43817,-0.438182 0.24203,0 0.43819,0.19616 0.43819,0.438182 0,0.242023 -0.19616,0.438182 -0.43819,0.438182 -0.24202,0 -0.43817,-0.196159 -0.43817,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path6136"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#b34d4d;fill-rule:evenodd;stroke:#b34d4d;stroke-width:0.02738621;stroke-miterlimit:8" />
+      <text
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text6138"
+         font-size="24"
+         font-weight="400"
+         x="121.59989"
+         y="71.659897">...</text>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,102.30312,69.291573)"
+         id="g6150">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6142"
+           stroke-miterlimit="8"
+           d="m 794.53015,-541.04725 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+        <text
+           y="-498.78033"
+           x="401.43869"
+           font-weight="400"
+           font-size="24"
+           id="text6148"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">
+          <tspan
+             x="571.86346"
+             y="-496.78033"
+             id="tspan6144"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2">2</tspan>
+          <tspan
+             x="402.905"
+             y="-962.78021"
+             id="tspan6146"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2" />
+        </text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,104.421,69.291573)"
+         id="g6162">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6158"
+           stroke-miterlimit="8"
+           d="m 1065.1968,-541.04725 c 0,-17.67467 14.3243,-32.00001 32.0002,-32.00001 17.6756,0 31.9998,14.32534 31.9998,32.00001 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+        <text
+           y="-496.98083"
+           x="842.88818"
+           font-weight="400"
+           font-size="24"
+           id="text6160"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">3</text>
+      </g>
+      <path
+         d="m 121.54474,62.211547 c 0,-0.242022 0.19615,-0.438182 0.43819,-0.438182 0.24203,0 0.43818,0.19616 0.43818,0.438182 0,0.242023 -0.19615,0.438182 -0.43818,0.438182 -0.24204,0 -0.43819,-0.196159 -0.43819,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path6164"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <text
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text6166"
+         font-size="24"
+         font-weight="400"
+         x="121.59989"
+         y="62.261364">...</text>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,102.30312,69.291573)"
+         id="g6178">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6170"
+           stroke-miterlimit="8"
+           d="m 794.53015,374.41296 c 0,-17.67468 14.3243,-32.00002 32.0002,-32.00002 17.6756,0 31.9998,14.32534 31.9998,32.00002 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+        <text
+           y="416.67987"
+           x="401.43896"
+           font-weight="400"
+           font-size="24"
+           id="text6176"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">
+          <tspan
+             x="571.86377"
+             y="418.67987"
+             id="tspan6172"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2">2</tspan>
+          <tspan
+             x="402.90527"
+             y="-47.32003"
+             id="tspan6174"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;stroke:none;stroke-width:2" />
+        </text>
+      </g>
+      <g
+         transform="matrix(0.01369319,0,0,0.01369319,104.421,69.291573)"
+         id="g6190">
+        <path
+           transform="translate(-240,23.999998)"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6186"
+           stroke-miterlimit="8"
+           d="m 1065.1968,374.41296 c 0,-17.67468 14.3243,-32.00002 32.0002,-32.00002 17.6756,0 31.9998,14.32534 31.9998,32.00002 0,17.67466 -14.3242,32 -31.9998,32 -17.6759,0 -32.0002,-14.32534 -32.0002,-32 z" />
+        <text
+           y="418.47937"
+           x="842.88855"
+           font-weight="400"
+           font-size="24"
+           id="text6188"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:58.66666794px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:2">3</text>
+      </g>
+      <path
+         d="m 121.54474,74.747118 c 0,-0.242023 0.19615,-0.438183 0.43819,-0.438183 0.24203,0 0.43818,0.19616 0.43818,0.438183 0,0.242022 -0.19615,0.438182 -0.43818,0.438182 -0.24204,0 -0.43819,-0.19616 -0.43819,-0.438182 z"
+         stroke-miterlimit="8"
+         id="path6192"
+         inkscape:connector-curvature="0"
+         style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      <text
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333382px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text6194"
+         font-size="24"
+         font-weight="400"
+         x="121.59989"
+         y="74.796928">...</text>
+      <g
+         id="g7192">
+        <path
+           style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path6459"
+           stroke-miterlimit="8"
+           d="m 83.048907,75.233168 c 0.121009,-0.209599 0.388982,-0.281393 0.59857,-0.16039 0.209594,0.121006 0.281397,0.388965 0.160388,0.598564 -0.121009,0.209599 -0.388969,0.281401 -0.598563,0.160394 -0.209588,-0.121003 -0.281404,-0.38897 -0.160395,-0.598568 z" />
+        <text
+           y="23.904446"
+           x="109.77538"
+           font-weight="400"
+           font-size="24"
+           id="text6461"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.803334px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738639"
+           transform="rotate(29.999438)">2</text>
+      </g>
+      <g
+         id="g7196">
+        <path
+           d="m 85.349807,77.073551 c 0.209597,-0.121011 0.477564,-0.0492 0.598569,0.160389 0.121009,0.209594 0.04921,0.477554 -0.160388,0.598565 -0.209597,0.121011 -0.477557,0.04921 -0.598565,-0.160383 -0.121005,-0.209587 -0.04921,-0.47756 0.160384,-0.598571 z"
+           stroke-miterlimit="8"
+           id="path6465"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#ffd42a;fill-rule:evenodd;stroke:none;stroke-width:0.02738637;stroke-miterlimit:8;stroke-opacity:1" />
+        <text
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333364px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738637"
+           id="text6467"
+           font-size="24"
+           font-weight="400"
+           x="109.65911"
+           y="-35.10437"
+           transform="rotate(60.000017)">3</text>
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path7061"
+         d="M 80.697913,62.214974 H 104.51042"
+         style="fill:none;fill-opacity:1;stroke:#ffcc00;stroke-width:0.027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g7179"
+         transform="matrix(0,-1,-1,0,172.45234,159.10336)">
+        <path
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path7063"
+           stroke-miterlimit="8"
+           d="m 79.499873,73.650557 c 0,-0.242022 -0.196162,-0.438182 -0.438181,-0.438182 -0.242025,0 -0.438184,0.19616 -0.438184,0.438182 0,0.242023 0.196159,0.438182 0.438184,0.438182 0.242019,0 0.438181,-0.196159 0.438181,-0.438182 z" />
+        <path
+           sodipodi:nodetypes="cscc"
+           d="m 79.061689,73.212375 c 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 5e-6,-0.356739 0.0056,-0.584367 0,-0.876364 z"
+           stroke-miterlimit="8"
+           id="path7065"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      </g>
+      <text
+         transform="rotate(90)"
+         y="-98.508965"
+         x="79.77906"
+         font-weight="400"
+         font-size="24"
+         id="text7067"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">1</text>
+      <text
+         transform="rotate(90)"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text7210"
+         font-size="24"
+         font-weight="400"
+         x="79.77906"
+         y="-98.508965">1</text>
+      <g
+         transform="matrix(-1,0,0,1,185.02501,-0.00267638)"
+         id="g7202">
+        <path
+           d="m 83.048907,75.233168 c 0.121009,-0.209599 0.388982,-0.281393 0.59857,-0.16039 0.209594,0.121006 0.281397,0.388965 0.160388,0.598564 -0.121009,0.209599 -0.388969,0.281401 -0.598563,0.160394 -0.209588,-0.121003 -0.281404,-0.38897 -0.160395,-0.598568 z"
+           stroke-miterlimit="8"
+           id="path7198"
+           inkscape:connector-curvature="0"
+           style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,1,185.31436,0.1976958)"
+         id="g7208">
+        <path
+           style="overflow:hidden;fill:#ffd42a;fill-rule:evenodd;stroke:none;stroke-width:0.02738637;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path7204"
+           stroke-miterlimit="8"
+           d="m 85.631879,76.908627 c 0.209597,-0.121011 0.477564,-0.0492 0.598569,0.160389 0.121009,0.209594 0.04921,0.477554 -0.160388,0.598565 -0.209597,0.121011 -0.477557,0.04921 -0.598565,-0.160383 -0.121005,-0.209587 -0.04921,-0.47756 0.160384,-0.598571 z" />
+      </g>
+      <text
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638"
+         id="text7227"
+         font-size="24"
+         font-weight="400"
+         x="49.997849"
+         y="116.43238"
+         transform="rotate(-30)">3</text>
+      <text
+         transform="rotate(-45.550065)"
+         y="125.55355"
+         x="14.090984"
+         font-weight="400"
+         font-size="24"
+         id="text7212"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">2</text>
+      <text
+         transform="rotate(45)"
+         y="-3.6103036"
+         x="112.79903"
+         font-weight="400"
+         font-size="24"
+         id="text7231"
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1">
+        <tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#ffcc00;stroke-width:0.02738638;stroke-opacity:1"
+           id="tspan7229">lb10</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text7235"
+         font-size="24"
+         font-weight="400"
+         x="16.298729"
+         y="127.18574"
+         transform="rotate(-45)">
+        <tspan
+           id="tspan7233"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#ffcc00;stroke-width:0.02738638;stroke-opacity:1">lb11</tspan>
+      </text>
+      <text
+         style="font-weight:400;font-size:0.80333382px;font-family:Calibri, Calibri_MSFontService, sans-serif;overflow:hidden;fill:#843c0c;stroke:#4d59b3;stroke-width:0.02738638;stroke-opacity:1"
+         id="text7239"
+         font-size="24"
+         font-weight="400"
+         x="91.715324"
+         y="60.524387">
+        <tspan
+           id="tspan7237"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT';fill:none;stroke:#ffcc00;stroke-width:0.02738638;stroke-opacity:1">lb12</tspan>
+      </text>
+      <g
+         transform="rotate(-90,92.744454,68.275717)"
+         id="g7251">
+        <g
+           style="fill:#ffcc00"
+           transform="matrix(0,0.01369319,-0.01369319,0,88.942765,75.719844)"
+           id="g7243">
+          <path
+             sodipodi:nodetypes="sccs"
+             style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path7241"
+             stroke-miterlimit="8"
+             d="m 283.61793,195.21614 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 0,28.60867 0,29.11448 0,64.00001 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z" />
+        </g>
+        <path
+           sodipodi:nodetypes="cscc"
+           style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           id="path7245"
+           stroke-miterlimit="8"
+           d="m 86.707816,80.041669 c 0,0.242017 -0.196159,0.438178 -0.438182,0.438178 -0.242022,0 -0.438182,-0.196161 -0.438182,-0.438178 0.435306,0 0.435306,0 0.876364,0 z" />
+        <text
+           transform="rotate(90)"
+           y="-86.09008"
+           x="80.065819"
+           font-weight="400"
+           font-size="24"
+           id="text7247"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502">1</text>
+        <text
+           transform="rotate(90)"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502"
+           id="text7249"
+           font-size="24"
+           font-weight="400"
+           x="79.65834"
+           y="-86.079262">4</text>
+      </g>
+      <g
+         id="g7362"
+         transform="translate(25.448716,-11.435583)">
+        <g
+           transform="matrix(-1,0,0,1,158.12338,0)"
+           id="g7366">
+          <path
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             id="path7356"
+             stroke-miterlimit="8"
+             d="m 78.623508,73.650557 c 0,-0.242022 0.196162,-0.438182 0.438181,-0.438182 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 -0.242019,0 -0.438181,-0.196159 -0.438181,-0.438182 z" />
+          <path
+             sodipodi:nodetypes="cscc"
+             d="m 79.061689,73.212375 c 0.242025,0 0.438184,0.19616 0.438184,0.438182 0,0.242023 -0.196159,0.438182 -0.438184,0.438182 5e-6,-0.356739 0.0056,-0.584367 0,-0.876364 z"
+             stroke-miterlimit="8"
+             id="path7358"
+             inkscape:connector-curvature="0"
+             style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1" />
+        </g>
+        <text
+           y="73.943375"
+           x="78.79908"
+           font-weight="400"
+           font-size="24"
+           id="text7360"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.80333388px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.02738638">1</text>
+      </g>
+      <g
+         transform="rotate(-90,74.570435,73.914175)"
+         id="g6983">
+        <g
+           transform="matrix(1,0,0,-1,0,160.08333)"
+           id="g7371">
+          <g
+             id="g6975"
+             transform="matrix(0,0.01369319,-0.01369319,0,88.942765,75.719844)"
+             style="fill:#ffcc00">
+            <path
+               d="m 283.61793,195.21614 c 0,-17.67467 14.32652,-32.00001 32.00028,-32.00001 0,28.60867 0,29.11448 0,64.00001 -17.67376,0 -32.00028,-14.32534 -32.00028,-32 z"
+               stroke-miterlimit="8"
+               id="path6973"
+               inkscape:connector-curvature="0"
+               style="overflow:hidden;fill:#ffcc00;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-miterlimit:8;stroke-opacity:1"
+               sodipodi:nodetypes="sccs" />
+          </g>
+          <path
+             d="m 86.707816,80.041669 c 0,0.242017 -0.196159,0.438178 -0.438182,0.438178 -0.242022,0 -0.438182,-0.196161 -0.438182,-0.438178 0.435306,0 0.435306,0 0.876364,0 z"
+             stroke-miterlimit="8"
+             id="path6977"
+             inkscape:connector-curvature="0"
+             style="overflow:hidden;fill:#4d59b3;fill-rule:evenodd;stroke:none;stroke-width:0.02738638;stroke-miterlimit:8;stroke-opacity:1"
+             sodipodi:nodetypes="cscc" />
+        </g>
+        <text
+           transform="rotate(90)"
+           y="-86.082703"
+           x="79.646736"
+           font-weight="400"
+           font-size="24"
+           id="text6979"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502">1</text>
+        <text
+           transform="rotate(90)"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:0.52228057px;font-family:'Gill Sans MT';-inkscape-font-specification:'Gill Sans MT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;overflow:hidden;fill:#ffffff;stroke:none;stroke-width:0.01780502"
+           id="text6981"
+           font-size="24"
+           font-weight="400"
+           x="80.077423"
+           y="-86.086639">2</text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -202,7 +202,8 @@ message Lane
         // the centerline of lane l4 (black line) is given by
         // (cl4_1, cl4_2, cl4_3, cl4_4, cl4_5).
         //
-        // \image html OSI_LaneBoundaries_And_CenterLine.svg "Centerline" width=500px
+        // \anchor Centerline_LaneBoundaries
+        // \image html OSI_LaneBoundaries_And_CenterLine_Intersection.svg "centerline & lane boundaries" width=900px
         //
         // \note 
         // cl: center line
@@ -298,11 +299,24 @@ message Lane
 
         // The antecessor/successor lane pairings of this lane. There can be
         // multiple pairings with the same antecessor and different successor
-        // lanes and vice versa. The antecessor lanes end in the same point that
-        // this lane starts from. The successor lanes start in the same point
-        // that this lane ends in.
+        // lanes and vice versa. The antecessor lanes are connected to the first
+        // and successor lanes to the last centerline and lane boundary points
+        // (w.r.t ascending order of centerline and lane boundary points) of the lane.
         //
-        // Example: See image \ref Intersection.
+        // Example: See image \ref Centerline_LaneBoundaries "centerline & lane boundaries" .
+        //
+        // \attention For intersections, it's possible that a lane pairing consists
+        // exclusively of antecessors or successors. Such a case appears for example 
+        // for the lane pairing of lane 2 and lane 3 of the intersection in image 
+        // \ref Centerline_LaneBoundaries "centerline & lane boundaries". Both lanes start 
+        // (w.r.t ascending order of centerline and lane boundary points) at the intersection, 
+        // which makes them antecessors for the intersection's lane pairing. The resulting lane 
+        // pairing should therefore be (l2l3,), with two antecessors and no successor.
+        //
+        // \note The antecessor/successor (w.r.t. driving direction) of a driving lane can be
+        // determined from the \c #centerline_is_driving_direction. In the case of intersections,
+        // the antecessor/successor (w.r.t. driving direction) has to be determined by comparison
+        // with the current/previous lane.
         //
         // \note OSI uses singular instead of plural for repeated field names.
         //


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository

Antecessor and successor definition for lanes #530 

#### Add a description

* Added an extended version of the image OSI_LaneBoundaries_And_CenterLine.svg
  that includes, connected by a junction.
  - The new image is called
    OSI_LaneBoundaries_And_CenterLine_Intersection.svg and will replace
    the old one in the Lane/Classification/Centerline section.
  - The old image will still be used in the LaneBoundary/BoundaryPoint
    section.

* Added a more precise description to Lane/Classification/lane_pairing
  on how antecessor and successor have to be set.


**Some questions to ask**:

What is this change?

- Improvement for OSI documentation

What does it fix?

- Documentation for OSI lane pairing

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
