### PR TITLE
Added Timestamp for each Moving Object.

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -422,6 +422,28 @@ message MovingObject
     //
     repeated ExternalReference source_reference = 10;
 
+    // The simulation timestamp the calculated "base" parameters (especially
+    // "position") of the moving object apply to.
+    // Background: The timestamps can differ between e.g. host vehicle, rest of
+    // the vehicle traffic and pedestrians (or other types), because they may be
+    // calculated in different modules. And even inside those groups the
+    // timestamps can differ if one part is calculated in one cycle and the rest
+    // in the following cycle out of performance reasons.
+    // Usage: E.g. for extrapolation of the whole traffic in graphic engines.
+    //
+    // Regarding the "simulation timestamp":
+    // The zero time point is arbitrary but must be identical for all messages.
+    // Recommendation: Zero time point for start point of the simulation.
+    //
+    // \note Zero time point does not need to coincide with the UNIX epoch.
+    //
+    // \note For ground truth data this timestamp coincides both with the
+    // notional simulation time the data applies to and the time it was sent
+    // (there is no inherent latency for ground truth data, as opposed to
+    // sensor data).
+    //
+    optional Timestamp timestamp = 11;
+
     // Definition of object types.
     //
     enum Type


### PR DESCRIPTION
Signed-off-by: Nader Thomas <thomas.nader@bmw.de>

#### Add a description
The simulation timestamp the calculated "base" parameters (especially "position") of the moving object apply to.
Background: The timestamps can differ between e.g. host vehicle, rest of the vehicle traffic and pedestrians (or other types), because they may be calculated in different modules. And even inside those groups the timestamps can differ if one part is calculated in one cycle and the rest in the following cycle out of performance reasons.
Usage: E.g. for extrapolation of the whole traffic in graphic engines.

**Some questions to ask**:
What is this change? What does it fix?
The groundTruth timestamp is too unspecific and not working for that use case.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
No.
How has it been tested?
Yes and working. Tested by Christopher Kiwus.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [ ] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
