### PR TITLE
#550 cmake build is missing key features to be properly usable via fetchcontent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ osi_version.proto
 version.py
 pyproject.toml
 
+compile_commands.json
+
 # Eclipse-specific files, if any
 *.cproject
 *.project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,14 +244,9 @@ install(EXPORT ${PROJECT_NAME}_targets
 
 # add a target to generate API documentation with Doxygen
 # Dependencies: Doxygen and proto2cpp.py
-FIND_PACKAGE(Doxygen)
-set(FILTER_PROTO2CPP_PY_PATH CACHE PATH "directory to the filter proto2cpp.py")
-
-if(NOT DOXYGEN_FOUND)
-
-    message(WARNING  "Doxygen could not be found.")
-
-else()
+find_package(Doxygen)
+if(Doxygen_FOUND)
+    set(FILTER_PROTO2CPP_PY_PATH CACHE PATH "directory to the filter proto2cpp.py")
 
     if(NOT EXISTS ${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py)
 
@@ -270,4 +265,4 @@ else()
 
     endif(NOT EXISTS ${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py)
 
-endif(NOT DOXYGEN_FOUND)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if(BUILD_FLATBUFFER)
 endif()
 
 add_library(${PROJECT_NAME}_static STATIC ${PROTO_SRCS} ${PROTO_HEADERS})
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_static ALIAS ${PROJECT_NAME}_static)
 target_include_directories(${PROJECT_NAME}_static
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
@@ -145,6 +146,7 @@ install(TARGETS ${PROJECT_NAME}_static
 
 
 add_library(${PROJECT_NAME}_obj OBJECT ${PROTO_SRCS} ${PROTO_HEADERS})
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_obj ALIAS ${PROJECT_NAME}_obj)
 target_include_directories(${PROJECT_NAME}_obj
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
@@ -155,7 +157,7 @@ set_property(TARGET ${PROJECT_NAME}_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 
 add_library(${PROJECT_NAME}_pic STATIC $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
-
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_pic ALIAS ${PROJECT_NAME}_pic)
 target_include_directories(${PROJECT_NAME}_pic
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
@@ -171,6 +173,7 @@ install(TARGETS ${PROJECT_NAME}_pic
         ARCHIVE DESTINATION "${OSI_INSTALL_LIB_DIR}" COMPONENT lib)
 
 add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,19 +38,18 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Offer the user the choice of overriding the installation directories
-set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
-set(INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
+option(OSI_INSTALL_LIB_DIR "Installation directory for libraries" lib)
+option(OSI_INSTALL_INCLUDE_DIR "Installation directory for header files" include)
 
 if(WIN32 AND NOT CYGWIN)
   set(DEF_INSTALL_CMAKE_DIR CMake/${PROJECT_NAME}-${VERSION_MAJOR})
 else()
   set(DEF_INSTALL_CMAKE_DIR lib/cmake/${PROJECT_NAME}-${VERSION_MAJOR})
 endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
-    "Installation directory for CMake files")
+option(OSI_INSTALL_CMAKE_DIR "Installation directory for CMake files" ${DEF_INSTALL_CMAKE_DIR})
 
-set(INSTALL_LIB_DIR ${INSTALL_LIB_DIR}/osi${VERSION_MAJOR})
-set(INSTALL_INCLUDE_DIR ${INSTALL_INCLUDE_DIR}/osi${VERSION_MAJOR})
+set(OSI_INSTALL_LIB_DIR ${OSI_INSTALL_LIB_DIR}/osi${VERSION_MAJOR})
+set(OSI_INSTALL_INCLUDE_DIR ${OSI_INSTALL_INCLUDE_DIR}/osi${VERSION_MAJOR})
 
 configure_file(osi_version.proto.in ${CMAKE_CURRENT_SOURCE_DIR}/osi_version.proto)
 
@@ -137,12 +136,12 @@ target_include_directories(${PROJECT_NAME}_static
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${OSI_INSTALL_INCLUDE_DIR}>
 )
 target_link_libraries(${PROJECT_NAME}_static PUBLIC ${PROTOBUF_LIBRARY})
 install(TARGETS ${PROJECT_NAME}_static
         EXPORT ${PROJECT_NAME}_targets
-        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${OSI_INSTALL_LIB_DIR}" COMPONENT lib)
 
 
 add_library(${PROJECT_NAME}_obj OBJECT ${PROTO_SRCS} ${PROTO_HEADERS})
@@ -150,7 +149,7 @@ target_include_directories(${PROJECT_NAME}_obj
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${OSI_INSTALL_INCLUDE_DIR}>
 )
 set_property(TARGET ${PROJECT_NAME}_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -161,7 +160,7 @@ target_include_directories(${PROJECT_NAME}_pic
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${OSI_INSTALL_INCLUDE_DIR}>
 )
 target_link_libraries(${PROJECT_NAME}_pic PUBLIC ${PROTOBUF_LIBRARY})
 
@@ -169,14 +168,14 @@ set_property(TARGET ${PROJECT_NAME}_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 install(TARGETS ${PROJECT_NAME}_pic
         EXPORT ${PROJECT_NAME}_targets
-        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${OSI_INSTALL_LIB_DIR}" COMPONENT lib)
 
 add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         ${PROTOBUF_INCLUDE_DIR}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${OSI_INSTALL_INCLUDE_DIR}>
 )
 
 set_property(
@@ -191,7 +190,7 @@ set_property(
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROTOBUF_LIBRARY})
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}_targets
-        DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        DESTINATION "${OSI_INSTALL_LIB_DIR}" COMPONENT lib)
 
 # Create the open_simulation_interface.cmake and open_simulation_interface-version files
 
@@ -200,7 +199,7 @@ set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
 configure_file(open_simulation_interface-config.cmake.in
                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake" @ONLY)
 # ... for the install tree
-set(CONF_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR} ${PROTOBUF_INCLUDE_DIR})
+set(CONF_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/${OSI_INSTALL_INCLUDE_DIR} ${PROTOBUF_INCLUDE_DIR})
 configure_file(open_simulation_interface-config.cmake.in
                "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/open_simulation_interface-config.cmake" @ONLY)
 # ... for both
@@ -211,16 +210,16 @@ configure_file(open_simulation_interface-config-version.cmake.in
 install(FILES
         "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/open_simulation_interface-config.cmake"
         "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-        DESTINATION "${INSTALL_CMAKE_DIR}"
+        DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
         COMPONENT dev)
 
 # Header files
 install(FILES ${PROTO_HEADERS} ${FLAT_HEADERS}
-        DESTINATION "${INSTALL_INCLUDE_DIR}")
+        DESTINATION "${OSI_INSTALL_INCLUDE_DIR}")
 
 # Install the export set for use with the install-tree
 install(EXPORT ${PROJECT_NAME}_targets
-        DESTINATION "${INSTALL_CMAKE_DIR}"
+        DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
         COMPONENT dev)
 
 # add a target to generate API documentation with Doxygen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(open_simulation_interface)
 
-# set default compiler
+# Set the C++ standard
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Optional Flatbuffer support
 option(OSI_BUILD_FLATBUFFER "Build flatbuffer versions of libraries" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,15 +38,15 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Offer the user the choice of overriding the installation directories
-option(OSI_INSTALL_LIB_DIR "Installation directory for libraries" lib)
-option(OSI_INSTALL_INCLUDE_DIR "Installation directory for header files" include)
+set(OSI_INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
+set(OSI_INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
 
 if(WIN32 AND NOT CYGWIN)
   set(DEF_INSTALL_CMAKE_DIR CMake/${PROJECT_NAME}-${VERSION_MAJOR})
 else()
   set(DEF_INSTALL_CMAKE_DIR lib/cmake/${PROJECT_NAME}-${VERSION_MAJOR})
 endif()
-option(OSI_INSTALL_CMAKE_DIR "Installation directory for CMake files" ${DEF_INSTALL_CMAKE_DIR})
+set(OSI_INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
 set(OSI_INSTALL_LIB_DIR ${OSI_INSTALL_LIB_DIR}/osi${VERSION_MAJOR})
 set(OSI_INSTALL_INCLUDE_DIR ${OSI_INSTALL_INCLUDE_DIR}/osi${VERSION_MAJOR})
@@ -195,26 +195,41 @@ install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}_targets
         DESTINATION "${OSI_INSTALL_LIB_DIR}" COMPONENT lib)
 
-# Create the open_simulation_interface.cmake and open_simulation_interface-version files
+# Copy proto headers to where they are expected by the package config file
+add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+    ${CMAKE_CURRENT_BINARY_DIR}/${OSI_INSTALL_INCLUDE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROTO_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/${OSI_INSTALL_INCLUDE_DIR})
 
-# ... for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
-configure_file(open_simulation_interface-config.cmake.in
-               "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake" @ONLY)
-# ... for the install tree
-set(CONF_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/${OSI_INSTALL_INCLUDE_DIR} ${PROTOBUF_INCLUDE_DIR})
-configure_file(open_simulation_interface-config.cmake.in
-               "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/open_simulation_interface-config.cmake" @ONLY)
-# ... for both
-configure_file(open_simulation_interface-config-version.cmake.in
-               "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake" @ONLY)
+# Create the package config files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/open_simulation_interface-config-version.cmake"
+    VERSION ${OPEN_SIMULATION_INTERFACE_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+export(EXPORT ${PROJECT_NAME}_targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/open_simulation_interface-targets.cmake"
+    NAMESPACE ${PROJECT_NAME}::
+)
+
+configure_package_config_file(open_simulation_interface-config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/open_simulation_interface-config.cmake"
+    INSTALL_DESTINATION ${OSI_INSTALL_CMAKE_DIR}
+    PATH_VARS OSI_INSTALL_INCLUDE_DIR
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
 
 # Install the *cmake files
 install(FILES
-        "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/open_simulation_interface-config.cmake"
-        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-        DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
-        COMPONENT dev)
+    "${CMAKE_CURRENT_BINARY_DIR}/open_simulation_interface-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/open_simulation_interface-config-version.cmake"
+    DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
+    COMPONENT dev)
 
 # Header files
 install(FILES ${PROTO_HEADERS} ${FLAT_HEADERS}
@@ -222,8 +237,10 @@ install(FILES ${PROTO_HEADERS} ${FLAT_HEADERS}
 
 # Install the export set for use with the install-tree
 install(EXPORT ${PROJECT_NAME}_targets
-        DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
-        COMPONENT dev)
+    FILE open_simulation_interface-targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
+    COMPONENT dev)
 
 # add a target to generate API documentation with Doxygen
 # Dependencies: Doxygen and proto2cpp.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(open_simulation_interface)
 set(CMAKE_CXX_STANDARD 11)
 
 # Optional Flatbuffer support
-set(BUILD_FLATBUFFER OFF CACHE BOOLEAN "Build flatbuffer versions of libraries")
+option(OSI_BUILD_FLATBUFFER "Build flatbuffer versions of libraries" OFF)
 
 # Set a default build type if none was specified
 set(default_build_type "Release")
@@ -89,7 +89,7 @@ set(OSI_PROTO_FILES
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES})
 set(FLAT_HEADERS "")
-if(BUILD_FLATBUFFER)
+if(OSI_BUILD_FLATBUFFER)
   set(FLAT_FBS "")
   add_subdirectory("flatbuffers"
                    ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,19 @@ cmake_minimum_required(VERSION 3.5)
 
 project(open_simulation_interface)
 
+# Toplevel check
+set(OSI_IS_TOP_LEVEL OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(OSI_IS_TOP_LEVEL ON)
+endif()
+
 # Set the C++ standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Optional Flatbuffer support
 option(OSI_BUILD_FLATBUFFER "Build flatbuffer versions of libraries" OFF)
+option(OSI_BUILD_DOCUMENTATION "Build flatbuffer versions of libraries" ${OSI_IS_TOP_LEVEL})
 
 # Set a default build type if none was specified
 set(default_build_type "Release")
@@ -243,27 +250,23 @@ install(EXPORT ${PROJECT_NAME}_targets
     DESTINATION "${OSI_INSTALL_CMAKE_DIR}"
     COMPONENT dev)
 
-# add a target to generate API documentation with Doxygen
-# Dependencies: Doxygen and proto2cpp.py
-find_package(Doxygen)
-if(Doxygen_FOUND)
+if(OSI_BUILD_DOCUMENTATION)
+  # add a target to generate API documentation with Doxygen
+  # Dependencies: Doxygen and proto2cpp.py
+  find_package(Doxygen)
+  if(Doxygen_FOUND)
     set(FILTER_PROTO2CPP_PY_PATH CACHE PATH "directory to the filter proto2cpp.py")
-
     if(NOT EXISTS ${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py)
-
-    message(WARNING  "${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py could not be found.")
-
+      message(WARNING "${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py could not be found.")
     else()
+      set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxygen_config.cmake.in)
+      set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-        set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxygen_config.cmake.in)
-        set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+      configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 
-        configure_file(${doxyfile_in} ${doxyfile} @ONLY)
-
-        ADD_CUSTOM_TARGET(api_doc ALL
+      add_custom_target(api_doc ALL
         COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-    endif(NOT EXISTS ${FILTER_PROTO2CPP_PY_PATH}/proto2cpp.py)
-
+    endif()
+  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,13 @@ set(OSI_INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation dire
 set(OSI_INSTALL_LIB_DIR ${OSI_INSTALL_LIB_DIR}/osi${VERSION_MAJOR})
 set(OSI_INSTALL_INCLUDE_DIR ${OSI_INSTALL_INCLUDE_DIR}/osi${VERSION_MAJOR})
 
-configure_file(osi_version.proto.in ${CMAKE_CURRENT_SOURCE_DIR}/osi_version.proto)
+configure_file(osi_version.proto.in osi_version.proto)
 
 find_package(Protobuf 2.6.1 REQUIRED)
 set(PROTOBUF_IMPORT_DIRS ${PROTOBUF_INCLUDE_DIRS})
 
 set(OSI_PROTO_FILES
-    osi_version.proto
+    ${CMAKE_CURRENT_BINARY_DIR}/osi_version.proto
     osi_common.proto
     osi_datarecording.proto
     osi_detectedtrafficsign.proto

--- a/open_simulation_interface-config.cmake.in
+++ b/open_simulation_interface-config.cmake.in
@@ -1,11 +1,10 @@
-# Compute paths
-get_filename_component(OPEN_SIMULATION_INTERFACE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(OPEN_SIMULATION_INTERFACE_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+@PACKAGE_INIT@
 
-# Our library dependencies (contains definitions for IMPORTED targets)
-if(NOT TARGET OPEN_SIMULATION_INTERFACE AND NOT OPEN_SIMULATION_INTERFACE_BINARY_DIR)
-    include("${OPEN_SIMULATION_INTERFACE_CMAKE_DIR}/open_simulation_interface_targets.cmake")
+include(CMakeFindDependencyMacro)
+find_dependency(Protobuf)
+
+if(NOT TARGET @PROJECT_NAME@ AND NOT @PROJECT_NAME@_BINARY_DIR)
+  set_and_check(OPEN_SIMULATION_INTERFACE_INCLUDE_DIRS "@PACKAGE_OSI_INSTALL_INCLUDE_DIR@")
+  set(OPEN_SIMULATION_INTERFACE_LIBRARIES "@PROJECT_NAME@")
+  include("${CMAKE_CURRENT_LIST_DIR}/open_simulation_interface_targets.cmake")
 endif()
-
-# These are IMPORTED targets created by open_simulation_interface_targets.cmake
-set(OPEN_SIMULATION_INTERFACE_LIBRARIES open_simulation_interface)


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
Resolves #550 

#### Add a description
This PR aims to modernize the installation logic of the project by:
* removing redundant warnings
* prefix cache variables with the project name
* provide namespaced alias targets usable from the build tree
* provide a namespace for the export set

This modernization will make the project usable via [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) by a downstream project.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.