### PR TITLE
Introducing new color models

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -728,7 +728,8 @@ message ColorHSV
 {
     // Hue
     //
-    // Range: [0,1]
+    // Unit: deg
+    // Range: [0,360[
     //
     optional double hue = 1;
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -551,6 +551,7 @@ message StatePoint
     //
     optional Orientation3d orientation = 3;
 }
+
 //
 // \brief Detailed WavelengthRange message.
 //
@@ -662,12 +663,12 @@ message ColorGrey
 }
 
 //
-// RGB color model
+// \brief RGB color model
 //
 // ColorRGB provides values for red, green and blue.
 //
 message ColorRGB
-{   
+{
     // Red ratio
     //
     // Range: [0,1]

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -611,3 +611,194 @@ message SpatialSignalStrength
     //
     optional double signal_strength = 3;
 }
+
+//
+// \brief The description of a color within available color spaces.
+//
+// ColorDescription represents the visual, non-semantic appearance of an object, structure or feature within various available color spaces.
+//
+// Depending on the context, this may define the color of an object or structure a priori (e.g. GroundTruth objects)
+// or describe a perceived color (e.g. CameraDetections).
+//
+message ColorDescription
+{
+    // Greyscale color model
+    //
+    optional ColorGrey grey = 1;
+
+    // RGB (Red, Green, Blue) color model
+    //
+    optional ColorRGB rgb = 2;
+
+    // RGBIR (Red, Green, Blue, Infrared) color model
+    //
+    optional ColorRGBIR rgbir = 3;
+
+    // HSV (Hue, Saturation, Value) color model
+    //
+    optional ColorHSV hsv = 4;
+
+    // LUV (Luminance, U-coordinate, V-coordinate) color model
+    //
+    optional ColorLUV luv = 5;
+
+    // CMYK (Cyan, Magenta, Yellow, Key) color model
+    //
+    optional ColorCMYK cmyk = 6;
+}
+
+//
+// \brief Greyscale color model
+//
+// ColorGrey defines a greyscale.
+//
+message ColorGrey
+{
+    // Definition of a greyscale
+    //
+    // Range: [0,1]
+    //
+    optional double grey = 1;
+}
+
+//
+// RGB color model
+//
+// ColorRGB provides values for red, green and blue.
+//
+message ColorRGB
+{   
+    // Red ratio
+    //
+    // Range: [0,1]
+    //
+    optional double red = 1;
+
+    // Green ratio
+    //
+    // Range: [0,1]
+    //
+    optional double green = 2;
+
+    // Blue ratio
+    //
+    // Range: [0,1]
+    //
+    optional double blue = 3;
+}
+
+//
+// \brief RGBIR color model
+//
+// ColorRGBIR provides values for red, green, blue and infrared.
+//
+message ColorRGBIR
+{
+    // Red ratio
+    //
+    // Range: [0,1]
+    //
+    optional double red = 1;
+
+    // Green ratio
+    //
+    // Range: [0,1]
+    //
+    optional double green = 2;
+
+    // Blue ratio
+    //
+    // Range: [0,1]
+    //
+    optional double blue = 3;
+
+    // Infrared
+    //
+    // Range: [0,1]
+    //
+    optional double infrared = 4;
+}
+
+//
+// \brief HSV color model
+//
+// ColorHSV provides values for hue, saturation and value/brightness.
+//
+message ColorHSV
+{
+    // Hue
+    //
+    // Range: [0,1]
+    //
+    optional double hue = 1;
+
+    // Saturation
+    //
+    // Range: [0,1]
+    //
+    optional double saturation = 2;
+
+    // Value
+    //
+    // Range: [0,1]
+    //
+    optional double value = 3;
+}
+
+//
+// \brief LUV color model
+//
+// ColorLUV provides values for luminance, U- and V-coordinate.
+//
+message ColorLUV
+{
+    // Luminance
+    //
+    // Range: [0,1]
+    //
+    optional double luminance = 1;
+
+    // U-coordinate
+    //
+    // Range: [0,1]
+    //
+    optional double u = 2;
+    
+    // V-Coordinate
+    //
+    // Range: [0,1]
+    //
+    optional double v = 3;
+}
+
+//
+// \brief CMYK colors model
+//
+// ColorCMYK provides values for cyan, magenta, yellow and key/black.
+//
+message ColorCMYK
+{
+    // Cyan ratio
+    //
+    // Range: [0,1]
+    //
+    optional double cyan = 1;
+
+    // Magenta ratio
+    //
+    // Range: [0,1]
+    //
+    optional double magenta = 2;
+
+    // Yellow ratio
+    //
+    // Range: [0,1]
+    //
+    optional double yellow = 3;
+
+    // Black ratio
+    //
+    // Range: [0,1]
+    //
+    optional double key = 4;
+}

--- a/osi_detectedlane.proto
+++ b/osi_detectedlane.proto
@@ -4,6 +4,7 @@ option optimize_for = SPEED;
 
 import "osi_lane.proto";
 import "osi_detectedobject.proto";
+import "osi_common.proto";
 
 package osi3;
 
@@ -103,6 +104,14 @@ message DetectedLaneBoundary
     // \endrules
     //
     repeated double boundary_line_confidences = 5;
+
+    // The visual color of the material of the lane boundary.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance. For semantic classification of the lane boundary use the color
+    // field in \c CandidateLaneBoundary::classification.
+    //
+    optional ColorDescription color_description = 6;
 
     //
     // \brief A candidate for a detected lane boundary as estimated by the

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -120,6 +120,10 @@ message DetectedStationaryObject
     //
     repeated CandidateStationaryObject candidate = 4;
 
+    // The dominating color of the material of the structure.
+    //
+    optional ColorDescription color_description = 5;
+
     //
     // \brief A candidate for a detected stationary object as estimated
     // by the sensor.
@@ -220,6 +224,10 @@ message DetectedMovingObject
     // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CandidateMovingObject candidate = 8;
+
+    // The dominating color of the material of the moving object.
+    //
+    optional ColorDescription color_description = 9;
 
     // Additional data that is specific to radar sensors.
     //

--- a/osi_detectedroadmarking.proto
+++ b/osi_detectedroadmarking.proto
@@ -59,6 +59,14 @@ message DetectedRoadMarking
     //
     repeated CandidateRoadMarking candidate = 4;
 
+    // The visual color of the material of the road marking.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance. For semantic classification of the road marking use the color
+    // field in \c CandidateRoadMarking::classification.
+    //
+    optional ColorDescription color_description = 5;
+
     //
     // \brief A candidate for a detected road marking as estimated by the
     // sensor.

--- a/osi_detectedtrafficlight.proto
+++ b/osi_detectedtrafficlight.proto
@@ -43,6 +43,14 @@ message DetectedTrafficLight
     //
     repeated CandidateTrafficLight candidate = 4;
 
+    // The visual color of the traffic light.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance.  For semantic classification of the traffic light use the color
+    // field in \c CandidateTrafficLight::classification.
+    //
+    optional ColorDescription color_description = 5;
+
     //
     // \brief A candidate for a detected traffic light as estimated by
     // the sensor.

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -853,6 +853,10 @@ message CameraDetection
 
     // The dominant color of the shape.
     //
+    // \attention DEPRECATED: This color enum will be removed in version
+    // 4.0.0. Use the field \c #color_description (\c ColorDescription)
+    // instead.
+    //
     optional Color color = 28;
 
     // The probability of the shape's color.
@@ -884,6 +888,11 @@ message CameraDetection
     // \endrules
     //
     optional uint32 number_of_points = 32;
+
+    //
+    // The dominant color of the shape.
+    //
+    optional ColorDescription color_description = 33;
 
     // Definition of shape dominant color.
     //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -896,6 +896,9 @@ message CameraDetection
 
     // Definition of shape dominant color.
     //
+    // \attention DEPRECATED: This color enum will be removed in version
+    // 4.0.0. Use \c ColorDescription instead.
+    //
     enum Color
     {
         // Color of the shape is unknown (must not be used in ground

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -905,7 +905,10 @@ message LaneBoundary
         //
         optional Type type = 1;
 
-        // The color of the lane boundary in case of lane markings.
+        // The semantic color of the lane boundary in case of lane markings.
+        //
+        // \note The color types represent the semantic classification of
+        // lane markings only. They do not represent an actual visual appearance.
         //
         optional Color color = 2;
 
@@ -987,9 +990,12 @@ message LaneBoundary
             TYPE_STRUCTURE = 13;
         }
 
-        // The color of the lane boundary in case of a lane markings.
+        // The semantic color of the lane boundary in case of a lane markings.
         // Lane markings that alternate in color must be represented by
         // individual \c LaneBoundary segments.
+        //
+        // \note The color types represent the semantic color classification of
+        // lane markings only. They do not represent an actual visual appearance.
         //
         enum Color
         {

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -763,6 +763,14 @@ message LaneBoundary
     //
     repeated ExternalReference source_reference = 4;
 
+    // The visual color of the material of the lane boundary.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance. For semantic classification of the lane boundary use the color
+    // field in \c Classification.
+    //
+    optional ColorDescription color_description = 5;
+
     //
     // \brief A single point of a lane boundary.
     //
@@ -921,12 +929,6 @@ message LaneBoundary
         // \endrules
         //
         repeated Identifier limiting_structure_id = 3;
-
-        //
-        // The visual color of the material of the lane boundary. This does not
-        // represent the semantic classification but the visual appearance.
-        //
-        optional ColorDescription color_description = 4;
 
         // The lane boundary type.
         // There is no special representation for double lines, e.g. solid /

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -922,6 +922,12 @@ message LaneBoundary
         //
         repeated Identifier limiting_structure_id = 3;
 
+        //
+        // The visual color of the material of the lane boundary. This does not
+        // represent the semantic classification but the visual appearance.
+        //
+        optional ColorDescription color_description = 4;
+
         // The lane boundary type.
         // There is no special representation for double lines, e.g. solid /
         // solid or dashed / solid. In such cases, each lane will define its own

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -94,11 +94,20 @@ message StationaryObject
 
         // The dominating color of the material of the structure.
         //
+        // \attention DEPRECATED: This color enum will be removed in version
+        // 4.0.0. Use the field \c #color_description (\c ColorDescription)
+        // instead.
+        //
         optional Color color = 4;
 
         // The attributes of the emitting structure if stationary object is classified as such.
         //
         optional EmittingStructureAttribute emitting_structure_attribute = 5;
+
+        //
+        // The dominating color of the material of the structure.
+        //
+        optional ColorDescription color_description = 6;
 
         // Definition of object types.
         //
@@ -265,6 +274,10 @@ message StationaryObject
         }
 
         // Definition of colors for structures.
+        //
+        // \attention DEPRECATED: This color enum will be removed in version
+        // 4.0.0. Use \c ColorDescription instead.
+        //
         //
         enum Color
         {

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -75,6 +75,10 @@ message StationaryObject
     //
     repeated ExternalReference source_reference = 5;
 
+    // The dominating color of the material of the structure.
+    //
+    optional ColorDescription color_description = 6;
+
     //
     // \brief Classification data for a stationary object.
     //
@@ -95,19 +99,14 @@ message StationaryObject
         // The dominating color of the material of the structure.
         //
         // \attention DEPRECATED: This color enum will be removed in version
-        // 4.0.0. Use the field \c #color_description (\c ColorDescription)
-        // instead.
+        // 4.0.0. Use the field \c #color_description (\c ColorDescription) of
+        // \c StationaryObject instead.
         //
         optional Color color = 4;
 
         // The attributes of the emitting structure if stationary object is classified as such.
         //
         optional EmittingStructureAttribute emitting_structure_attribute = 5;
-
-        //
-        // The dominating color of the material of the structure.
-        //
-        optional ColorDescription color_description = 6;
 
         // Definition of object types.
         //
@@ -464,6 +463,10 @@ message MovingObject
     //
     repeated ExternalReference source_reference = 10;
 
+    // The dominating color of the material of the moving object.
+    //
+    optional ColorDescription color_description = 11;
+
     // Definition of object types.
     //
     enum Type
@@ -679,10 +682,6 @@ message MovingObject
         //
         repeated double assigned_lane_percentage = 2;        
         
-        //
-        // The dominating color of the material of the moving object.
-        //
-        optional ColorDescription color_description = 3;
     }
 
     //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -678,6 +678,11 @@ message MovingObject
         // \note OSI uses singular instead of plural for repeated field names.
         //
         repeated double assigned_lane_percentage = 2;        
+        
+        //
+        // The dominating color of the material of the moving object.
+        //
+        optional ColorDescription color_description = 3;
     }
 
     //

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -113,7 +113,11 @@ message RoadMarking
         //
         optional TrafficSign.MainSign.Classification.Type traffic_main_sign_type = 2;
 
-        // The monochrome color of the road marking.
+        // The semantic monochrome color of the road marking.
+        //
+        // \note The color types represent the semantic color classification of
+        // road markings only. They do not represent an actual visual appearance.
+
         // \note Field need not be set (or set to \c #COLOR_OTHER)
         // if road marking type does not require it (e.g. for \c #type ==
         // \c #TYPE_PAINTED_TRAFFIC_SIGN).
@@ -286,7 +290,10 @@ message RoadMarking
             TYPE_GENERIC_TEXT = 7;
         }
 
-        // Definition of road marking colors
+        // Definition of semantic road marking colors
+        //
+        // \note The color types represent the semantic classification of
+        // road markings only. They do not represent an actual visual appearance.
         //
         enum Color
         {

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -82,6 +82,14 @@ message RoadMarking
     //
     repeated ExternalReference source_reference = 4;
 
+    // The visual color of the material of the road marking.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance. For semantic classification of the road marking use the color
+    // field in \c Classification.
+    //
+    optional ColorDescription color_description = 5;
+
     //
     // \brief \c Classification data for a road surface marking.
     //
@@ -247,12 +255,6 @@ message RoadMarking
         // \endrules
         //
         optional string sub_code = 11;
-
-        //
-        // The visual color of the material of the road marking. This does not
-        // represent the semantic classification but the visual appearance.
-        //
-        optional ColorDescription color_description = 12;
 
         // Definition of road marking types.
         //

--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -248,6 +248,12 @@ message RoadMarking
         //
         optional string sub_code = 11;
 
+        //
+        // The visual color of the material of the road marking. This does not
+        // represent the semantic classification but the visual appearance.
+        //
+        optional ColorDescription color_description = 12;
+
         // Definition of road marking types.
         //
         enum Type

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -68,7 +68,10 @@ message TrafficLight
     //
     message Classification
     {
-        // The color of the traffic light.
+        // The semantic color of the traffic light.
+        //
+        // \note The color types represent the semantic color classification of a 
+        // traffic light only. They do not represent an actual visual appearance.
         //
         // \note If the color of the traffic light is known (from history or
         // geometrical arrangement) and the state \c #mode is
@@ -116,7 +119,10 @@ message TrafficLight
         //
         optional bool is_out_of_service = 6;
 
-        // Definition of colors for traffic lights.
+        // Definition of semantic colors for traffic lights.
+        //
+        // \note The color types represent the semantic classification of a traffic light
+        // only. They do not represent an actual visual appearance.
         //
         enum Color
         {

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -119,6 +119,12 @@ message TrafficLight
         //
         optional bool is_out_of_service = 6;
 
+        //
+        // The visual color of the traffic light. This does not represent the semantic
+        // classification but the visual appearance.
+        //
+        optional ColorDescription color_description = 7;
+
         // Definition of semantic colors for traffic lights.
         //
         // \note The color types represent the semantic classification of a traffic light

--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -63,6 +63,14 @@ message TrafficLight
     //
     repeated ExternalReference source_reference = 5;
 
+    // The visual color of the traffic light.
+    //
+    // \note This does not represent the semantic classification but the visual
+    // appearance.  For semantic classification of the traffic light use the color
+    // field in \c Classification.
+    //
+    optional ColorDescription color_description = 6;
+
     //
     // \brief \c Classification data for a traffic light.
     //
@@ -118,12 +126,6 @@ message TrafficLight
         // or swiching the traffic light off.
         //
         optional bool is_out_of_service = 6;
-
-        //
-        // The visual color of the traffic light. This does not represent the semantic
-        // classification but the visual appearance.
-        //
-        optional ColorDescription color_description = 7;
 
         // Definition of semantic colors for traffic lights.
         //


### PR DESCRIPTION
Signed-off-by: Thomas Sedlmayer <tsedlmayer@pmsfit.de>

#### Description
This PR emerged from the Harmonisation group and the discussions related to https://github.com/OpenSimulationInterface/open-simulation-interface/issues/512. It should serve as a basis for further discussion. The color models (Grey, RGB, RGBIR, HSV, LUV) were adopted from the ISO-23150. 

It is not completely clear yet where and how to apply the new message and how to manage the transition to complement or replace existing color enums. As a result from discussions, color enums that represent **semantic meaning** (e.g. traffic light colors, lane marking colors, lane boundary colors) should probably be kept as is or could be unified as separate enums (e.g. "SemanticColors"). Semantic colors are colors that specifically specify an objects meaning in traffic and do not necessarily represent its visual color. E.g. a lane boundary that is semantically classified as orange does not have to be visually orange (e.g. washed out to white). Hence, we should clearly differentiate semantic colors from visual colors that represent appearance only.

Color enums for stationary objects and camera detections could be complemented (short-term) or replaced (long-term) with the new ColorDescription. Also, moving objects do not have a color field yet and could also contain the new ColorDescription.
The name of the message (ColorDescription) is still under discussion.
