### PR TITLE
Add dash property to boundary points

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -833,18 +833,27 @@ message LaneBoundary
         //
         enum Dash
         {
+            // The current state of the dash alternation is not known (must
+            // not be used in ground truth). 
+            //
+            DASH_UNKNOWN = 0;
+
+            // Other (unspecified but known) type of dash alternation state. 
+            //
+            DASH_OTHER = 1;
+            
             // The current \c BoundaryPoint indicates the start of a dash.
             //
-            DASH_START = 0;
+            DASH_START = 2;
 
             // The current \c BoundaryPoint is located on a dash of a dashed
             // line. This enables a dash to continue across multiple points.
             //
-            DASH_CONTINUE = 1;
+            DASH_CONTINUE = 3;
 
             // The current \c BoundaryPoint indicates the end of a dash.
             //
-            DASH_END = 2;
+            DASH_END = 4;
         }
     }
 

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -827,9 +827,9 @@ message LaneBoundary
         // dashed lane boundary.
         //
         // \note The enum descriptions adhere to the definition direction
-        // of the lane boundary points, meaning that start or end of a dash
-        // are understood with respect to the direction in which the points
-        // of the boundary line are defined.
+        // of the lane boundary points. This means that start or end of a
+        // dash are understood with respect to the direction in which the
+        // points of the boundary line are defined.
         //
         enum Dash
         {

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -728,8 +728,7 @@ message LaneBoundary
     // another at the end of each dashed line segment. The first
     // \c BoundaryPoint defines the beginning of the first dashed lane marking.
     // The last \c BoundaryPoint defines the end of the last dashed lane
-    // marking. For example, the area between the second and third
-    // \c BoundaryPoint has no lane marking, and so on.
+    // marking.
     // \note For Botts' dots lines, one \c BoundaryPoint position has to define
     // each Botts' dot.
     //
@@ -817,6 +816,36 @@ message LaneBoundary
         // See \c LaneBoundary .
         //
         optional double height = 3;
+
+        // Alternation of dashes in case of a dashed lane boundary. In
+        // context, this field gives information about the location of
+        // dashes on the boundary line.
+        //
+        optional Dash dash = 4;
+
+        // This enum describes the alternation of dashes in case of a
+        // dashed lane boundary.
+        //
+        // \note The enum descriptions adhere to the definition direction
+        // of the lane boundary points, meaning that start or end of a dash
+        // are understood with respect to the direction in which the points
+        // of the boundary line are defined.
+        //
+        enum Dash
+        {
+            // The current \c BoundaryPoint indicates the start of a dash.
+            //
+            DASH_START = 0;
+
+            // The current \c BoundaryPoint is located on a dash of a dashed
+            // line. This enables a dash to continue across multiple points.
+            //
+            DASH_CONTINUE = 1;
+
+            // The current \c BoundaryPoint indicates the end of a dash.
+            //
+            DASH_END = 2;
+        }
     }
 
     //
@@ -947,7 +976,7 @@ message LaneBoundary
             //
             TYPE_OTHER = 1;
 
-            // An invisible lane boundary (e.g. unmarked part of a dashed line).
+            // An invisible lane boundary.
             //
             TYPE_NO_LINE = 2;
 


### PR DESCRIPTION
Signed-off-by: Thomas Sedlmayer <tsedlmayer@pmsfit.de>

Description:
Currently, there are some issues concerning the definition of dashed lines in OSI (e.g. https://github.com/OpenSimulationInterface/open-simulation-interface/issues/539, https://github.com/OpenSimulationInterface/open-simulation-interface/issues/205). Also, @HendrikAmelunxen named an issue with trimmed SensorView information, where some preceding boundary points could be missing and it would not be clear which boundary point has been the first one in order to restore where dashes or gaps are on the boundary line.

In the harmonisation working group it was proposed to add an enum to boundary points (for dashed lines only) that indicates start/end/continuation of a dash. This could independently describe dash locations even for a randomly trimmed SensorView section. The DASH_CONTINUE enum would enable the assignment of multiple points per dash and solve the problem of approximation errors of dashes in narrow curves (https://github.com/OpenSimulationInterface/open-simulation-interface/issues/539).

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
