### PR TITLE
Add osi3 and pyproject.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 doc/html
 doc/latex
 osi/
+osi3/
 
 # Specific extensions
 *.egg-info
@@ -20,6 +21,7 @@ cmake_install.cmake
 install_manifest.txt
 osi_version.proto
 version.py
+pyproject.toml
 
 # Eclipse-specific files, if any
 *.cproject


### PR DESCRIPTION
Signed-off-by: Yan QiDong <yanqd0@outlook.com>

2 lines are added to `.gitignore`.

- `osi3/`, this is missing after `pip install .` or `python setup.py develop` is executed. The python package name has changed from `osi` to `osi3` for a long time.
- `pyproject.toml`, this file will be generated when this project is used with `pipenv`.

This is a general, simple change. It is helpful for me, maybe also for others.

---

- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

I don't know which reviewer should be assigned to. An ownership table may be helpful in the guidelines, which is missing and recommended.
