### PR TITLE
OpenSimulationInterface/osi-documentation#43 replace world with globa…

### DIFF
--- a/doc/architecture/reference_points_coordinate_systems.adoc
+++ b/doc/architecture/reference_points_coordinate_systems.adoc
@@ -3,12 +3,12 @@
 OSI uses DIN ISO 8855:2013-11 for coordinate systems and transformations between coordinate systems.
 OSI uses three coordinate systems:
 
-World coordinate system::
+Global coordinate system::
 Coordinate system for all entities that are part of ground truth.
-The world coordinate system is an inertial x/y/z-coordinate system.
+The global coordinate system is an inertial x/y/z-coordinate system.
 The origin is the global reference point that is determined by the environment simulation.
 This reference point may be derived from map data or other considerations.
-World coordinates can be mapped to a geographic coordinate system via `osi3::GroundTruth::proj_string`.
+Global coordinates can be mapped to a geographic coordinate system via `osi3::GroundTruth::proj_string`.
 
 Sensor coordinate system::
 Coordinate system for all entities that are part of sensor data.

--- a/doc/usecases/transforming_coordinate_systems.adoc
+++ b/doc/usecases/transforming_coordinate_systems.adoc
@@ -2,21 +2,21 @@
 
 == Vehicle and sensor coordinate systems
 
-When running simulations, it is frequently necessary to transform coordinates from the world coordinate system for a specific vehicle and its sensors.
+When running simulations, it is frequently necessary to transform coordinates from the global coordinate system for a specific vehicle and its sensors.
 
 This section provides an overview of the messages and fields involved and their relationship for this task.
-It demonstrates how a world coordinate system, vehicle coordinate system, and sensor coordinate system are related on the basis of a specific (ego) vehicle.
+It demonstrates how a global coordinate system, vehicle coordinate system, and sensor coordinate system are related on the basis of a specific (ego) vehicle.
 
 //TODO: Should we add one or more sentences about the mathematical operations involved?
 
 **Corresponding messages**
 
 ``GroundTruth::moving_object::base::position``::
-This field defines the position of the vehicle's reference point in world coordinates.
+This field defines the position of the vehicle's reference point in global coordinates.
 In Open Simulation Interface, an object's position is defined by the coordinates of the center of the object's 3D bounding box.
 
 ``GroundTruth::moving_object::base::orientation``::
-This field defines the orientation of the vehicle's reference point in world coordinates.
+This field defines the orientation of the vehicle's reference point in global coordinates.
 
 ``GroundTruth::moving_object::vehicle_attributes::bbcenter_to_rear``::
 This field specifies the vector pointing from the vehicle's reference point to the middle of the rear axle under neutral load conditions in the vehicle coordinates.
@@ -28,7 +28,7 @@ The mounting position is given in the vehicle coordinate system.
 **Example**
 
 The following image shows the relationship between the coordinate systems.
-The reference point of the vehicle is given by a vector in the world coordinate system.
+The reference point of the vehicle is given by a vector in the global coordinate system.
 A vector pointing from the reference position of the vehicle to the center of the rear axle then yields the origin of the vehicle coordinate system.
 The mounting positions of the sensors and therefore the origins of the corresponding sensor coordinate systems are given with respect to the vehicle coordinate system.
 

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -513,7 +513,7 @@ message MovingObject
     //
     // This is an extension to the \c MovingObject with additional attributes,
     // such as type and lights. The origin of the rear (front) axis coordinate
-    // system in world coordinates is calculated as:
+    // system in global coordinates is calculated as:
     // \c MovingObject::base . \c BaseMoving::position + R * \c
     // MovingObject::VehicleAttributes::bbcenter_to_rear (front) for the host
     // vehicle (R rotates from vehicle to world frame, i.e. inverse orientation


### PR DESCRIPTION


Signed-off-by: Stefan Cyliax <stefan.cyliax@asam.net>

﻿#### Reference to a related issue in the repository
OpenSimulationInterface/osi-documentation#43

#### Add a description
Replaced all places where "world coordinate system" was used. There is no difference between "world..." and "global coordinate system" and the project decided to use "global" at all places. This was discussed in OSI CCB 15.09.2021.


#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [ ] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
