### PR TITLE
Add automated driving function state to host vehicle data

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -886,7 +886,6 @@ message GeodeticPosition
     optional double altitude = 3;
 }
 
-
 //
 // \brief Generic key-value pair structure
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -885,3 +885,21 @@ message GeodeticPosition
     //
     optional double altitude = 3;
 }
+
+
+//
+// \brief Generic key-value pair structure
+//
+// A generic key-value pair structure which can be used to capture information
+// which is opaque to the general OSI interface.
+//
+message KeyValuePair
+{
+    // A generic string key.
+    //
+    optional string key = 1;
+
+    // A generic string value.
+    //
+    optional string value = 2;
+}

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -85,7 +85,7 @@ message HostVehicleData
     //
     // \note OSI uses singular instead of plural for repeated field names.
     //
-    repeated VehicleAutomatedDrivingFunction automated_driving_function = 12;
+    repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
 
     //
     // \brief The absolute base parameters of the vehicle. 
@@ -440,7 +440,6 @@ message HostVehicleData
             // Speed limit control
             //
             FUNCTION_NAME_SPEED_LIMIT_CONTROL = 25;
-
         }
 
         // The activation state of a feature.

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -293,29 +293,33 @@ message HostVehicleData
     //
     message VehicleAutomatedDrivingFunction
     {
-        // The particular function being reported about.
+        // The particular driving function being reported about.
         //
-        optional FunctionName function_name = 1;
+        optional Name name = 1;
 
-        // Custom function name.
+        // Custom driving function name.
         //
-        // Only used if function_name is set to FUNCTION_NAME_OTHER.
+        // Only used if name is set to NAME_OTHER.
         //
         optional string custom_name = 2;
 
-        // The activation state of the function.
+        // The state of the function.
         //
         // This is whether the function has actually been triggered, for
         // example, a warning has been raised, or additional braking is
         // in effect.
         //
-        optional ActivationState activation_state = 3;
+        optional State state = 3;
 
-        // Custom activation state.
+        // Custom state.
         //
-        // Only used if the activation_state is set to ACTIVATION_STATE_OTHER.
+        // Only used if the state is set to STATE_OTHER.
         //
-        optional string custom_activation_state = 4;
+        optional string custom_state = 4;
+
+        // Whether, and how, the driver has overridden this function.
+        //
+        optional DriverOverride driver_override = 5;
 
         // Custom detail.
         //
@@ -325,7 +329,7 @@ message HostVehicleData
         // be about settings which would influence evaluation, such as
         // sensitivity settings.
         //
-        repeated KeyValuePair custom_detail = 5;
+        repeated KeyValuePair custom_detail = 6;
 
         // A list of possible automated driving features.
         //
@@ -335,157 +339,185 @@ message HostVehicleData
         // - https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
         // - https://www.vda.de/en/topics/innovation-and-technology/automated-driving/automated-driving
         //
-        enum FunctionName
+        enum Name
         {
             // Unknown feature, should not be used.
             //
-            FUNCTION_NAME_UNKNOWN = 0;
+            NAME_UNKNOWN = 0;
 
             // Custom feature, see custom_name.
             //
-            FUNCTION_NAME_OTHER = 1;
+            NAME_OTHER = 1;
 
             // Blind spot warning.
             //
-            FUNCTION_NAME_BLIND_SPOT_WARNING = 2;
+            NAME_BLIND_SPOT_WARNING = 2;
 
             // Forward collision warning.
             //
-            FUNCTION_NAME_FORWARD_COLLISION_WARNING = 3;
+            NAME_FORWARD_COLLISION_WARNING = 3;
 
             // Lane departure warning.
             //
-            FUNCTION_NAME_LANE_DEPARTURE_WARNING = 4;
+            NAME_LANE_DEPARTURE_WARNING = 4;
 
             // Parking collision warning.
             //
-            FUNCTION_NAME_PARKING_COLLISION_WARNING = 5;
+            NAME_PARKING_COLLISION_WARNING = 5;
 
             // Rear cross-traffic warning
             //
-            FUNCTION_NAME_REAR_CROSS_TRAFFIC_WARNING = 6;
+            NAME_REAR_CROSS_TRAFFIC_WARNING = 6;
 
             // Automatic emergency braking
             //
-            FUNCTION_NAME_AUTOMATIC_EMERGENCY_BRAKING = 7;
+            NAME_AUTOMATIC_EMERGENCY_BRAKING = 7;
 
             // Emergency steering
             //
-            FUNCTION_NAME_AUTOMATIC_EMERGENCY_STEERING = 8;
+            NAME_AUTOMATIC_EMERGENCY_STEERING = 8;
 
             // Reverse automatic emergency braking
             //
-            FUNCTION_NAME_REVERSE_AUTOMATIC_EMERGENCY_BRAKING = 9;
+            NAME_REVERSE_AUTOMATIC_EMERGENCY_BRAKING = 9;
 
             // Adaptive cruise control
             //
-            FUNCTION_NAME_ADAPTIVE_CRUISE_CONTROL = 10;
+            NAME_ADAPTIVE_CRUISE_CONTROL = 10;
 
             // Lane keeping assist
             //
-            FUNCTION_NAME_LANE_KEEPING_ASSIST = 11;
+            NAME_LANE_KEEPING_ASSIST = 11;
 
             // Active driving assistance
             //
-            FUNCTION_NAME_ACTIVE_DRIVING_ASSISTANCE = 12;
+            NAME_ACTIVE_DRIVING_ASSISTANCE = 12;
 
             // Backup camera
             //
-            FUNCTION_NAME_BACKUP_CAMERA = 13;
+            NAME_BACKUP_CAMERA = 13;
 
             // Surround view camera
             //
-            FUNCTION_NAME_SURROUND_VIEW_CAMERA = 14;
+            NAME_SURROUND_VIEW_CAMERA = 14;
 
             // Active parking assistance
             //
-            FUNCTION_NAME_ACTIVE_PARKING_ASSISTANCE = 15;
+            NAME_ACTIVE_PARKING_ASSISTANCE = 15;
 
             // Remote parking assistance
             //
-            FUNCTION_NAME_REMOTE_PARKING_ASSISTANCE = 16;
+            NAME_REMOTE_PARKING_ASSISTANCE = 16;
 
             // Trailer assistance
             //
-            FUNCTION_NAME_TRAILER_ASSISTANCE = 17;
+            NAME_TRAILER_ASSISTANCE = 17;
 
             // Automatic high beams
             //
-            FUNCTION_NAME_AUTOMATIC_HIGH_BEAMS = 18;
+            NAME_AUTOMATIC_HIGH_BEAMS = 18;
 
             // Driver monitoring
             //
-            FUNCTION_NAME_DRIVER_MONITORING = 19;
+            NAME_DRIVER_MONITORING = 19;
 
             // Head up display
             //
-            FUNCTION_NAME_HEAD_UP_DISPLAY = 20;
+            NAME_HEAD_UP_DISPLAY = 20;
 
             // Night vision
             //
-            FUNCTION_NAME_NIGHT_VISION = 21;
+            NAME_NIGHT_VISION = 21;
 
             // Urban driving
             //
-            FUNCTION_NAME_URBAN_DRIVING = 22;
+            NAME_URBAN_DRIVING = 22;
 
             // Highway autopilot.
             //
-            FUNCTION_NAME_HIGHWAY_AUTOPILOT = 23;
+            NAME_HIGHWAY_AUTOPILOT = 23;
 
             // Cruise control.
             //
-            FUNCTION_NAME_CRUISE_CONTROL = 24;
+            NAME_CRUISE_CONTROL = 24;
 
             // Speed limit control
             //
-            FUNCTION_NAME_SPEED_LIMIT_CONTROL = 25;
+            NAME_SPEED_LIMIT_CONTROL = 25;
         }
 
-        // The activation state of a feature.
+        // The state that the feature is in.
         //
         // \note Not all of these will be applicable for all vehicles
         // and features.
         //
-        enum ActivationState
+        enum State
         {
-            // An unknown activation state, this should not be used.
+            // An unknown state, this should not be used.
             //
-            ACTIVATION_STATE_UNKNOWN = 0;
+            STATE_UNKNOWN = 0;
 
             // Used for custom states not covered by the definitions below.
             //
-            // A string state can be specified in custom_activation_state.
+            // A string state can be specified in custom_state.
             //
-            ACTIVATION_STATE_OTHER = 1;
-
-            // The function has been disabled.
-            //
-            ACTIVATION_STATE_TURNED_OFF = 2;
+            STATE_OTHER = 1;
 
             // The function has errored in some way that renders it ineffective.
             //
-            ACTIVATION_STATE_ERRORED = 3;
+            STATE_ERRORED = 2;
 
-            // The function is initialized but not ready to start.
+            // The function cannot be used due to unfulfilled preconditions,
+            // for example it is a highway only feature and the vehicle is in
+            // an urban environment.
             //
-            ACTIVATION_STATE_UNAVAILABLE = 4;
+            STATE_UNAVAILABLE = 3;
 
-            // The function is enabled but conditions have not caused it to be
+            // The function can be used as all preconditions are satisfied, but
+            // it hasn't been enabled.
+            //
+            STATE_AVAILABLE = 4;
+
+            // The function is available but conditions have not caused it to be
             // triggered, for example, no vehicles in front to trigger a FCW.
             //
-            ACTIVATION_STATE_STANDBY = 5;
+            STATE_STANDBY = 5;
 
             // The function is currently active, for example, a warning is being
             // shown to the driver, or emergency braking is being applied/
             //
-            ACTIVATION_STATE_ACTIVE = 6;
+            STATE_ACTIVE = 6;
+        }
 
-            // The function would be ACTIVE, but the user has show sufficient
-            // input to override, for example, by applying throttle or steering
-            // input.
+        //
+        // \brief Driver override information
+        //
+        // Information about whether and how and driver may have overridden
+        // an automated driving function.
+        //
+        message DriverOverride
+        {
+            // The feature has been overridden by a driver action.
             //
-            ACTIVATION_STATE_ACTIVE_DRIVER_OVERRIDE = 7;
+            // \note If false, the rest of this message should be ignored.
+            optional bool active = 1;
+
+            // What driver inputs have caused the override.
+            //
+            repeated Reason override_reason = 2;
+
+            // Ways in which a driver could override a driving function.
+            //
+            enum Reason
+            {
+                // The driver has applied sufficient input via the break pedal.
+                //
+                REASON_BRAKE_PEDAL = 0;
+
+                // The driver has applied sufficient steering input.
+                //
+                REASON_STEERING_INPUT = 1;
+            }
         }
     }
 }

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -75,7 +75,7 @@ message HostVehicleData
     //
     optional VehicleLocalization vehicle_localization = 8;
 
-        // What driver assistance is active.
+    // State of driver assistance systems.
     //
     // This can include:
     //  - information presented to the driver, for example, parking sensors
@@ -323,7 +323,7 @@ message HostVehicleData
         // be about settings which would influence evaluation, such as
         // sensitivity settings.
         //
-        repeated CustomDetail custom_detail = 5;
+        repeated KeyValuePair custom_detail = 5;
 
         // ADAS feature that is raising the notification.
         //
@@ -462,23 +462,6 @@ message HostVehicleData
             // input.
             //
             ACTIVATION_STATE_ACTIVE_DRIVER_OVERRIDE = 6;
-        }
-
-        //
-        // \brief Custom detail message
-        //
-        // To contain driver-assist related information that is too function
-        // specific to be captured in a generic way.
-        //
-        message CustomDetail
-        {
-            // A generic string key to identify the information.
-            //
-            optional string key = 1;
-
-            // A generic string value to capture the information.
-            //
-            optional string value = 2;
         }
     }
 }

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -75,14 +75,17 @@ message HostVehicleData
     //
     optional VehicleLocalization vehicle_localization = 8;
 
-    // State of driver assistance systems.
+    // State of any automated driving functions.
     //
     // This can include:
     //  - information presented to the driver, for example, parking sensors
     //  - warnings raised by the vehicle, for example, forward collision warning
     //  - corrective action taken by the vehicle, for example, auto emergency braking
+    //  - full level 4 self driving systems
     //
-    repeated DriverAssistState driver_assist_state = 12;
+    // \note OSI uses singular instead of plural for repeated field names.
+    //
+    repeated VehicleAutomatedDrivingFunction automated_driving_function = 12;
 
     //
     // \brief The absolute base parameters of the vehicle. 
@@ -286,24 +289,23 @@ message HostVehicleData
     }
 
     //
-    // \brief The driver assist state specifically relating to recognised
-    // Advanced Driver Assistance Systems.
+    // \brief State of one automated driving function on the host vehicle.
     //
-    message DriverAssistState
+    message VehicleAutomatedDrivingFunction
     {
-        // The particular feature being reported about.
+        // The particular function being reported about.
         //
-        optional AssistFeature assist_feature = 1;
+        optional FunctionName function_name = 1;
 
-        // Custom feature name.
+        // Custom function name.
         //
-        // Only used if assist_feature is set to ASSIST_FEATURE_OTHER.
+        // Only used if function_name is set to FUNCTION_NAME_OTHER.
         //
         optional string custom_name = 2;
 
-        // The activation state of the feature.
+        // The activation state of the function.
         //
-        // This is whether the feature has actually been triggered, for
+        // This is whether the function has actually been triggered, for
         // example, a warning has been raised, or additional braking is
         // in effect.
         //
@@ -325,101 +327,120 @@ message HostVehicleData
         //
         repeated KeyValuePair custom_detail = 5;
 
-        // ADAS feature that is raising the notification.
+        // A list of possible automated driving features.
         //
-        // \note The naming convention is taken from the SAE guidance on ADAS
-        // nomenclature:
-        // https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
+        // \note This can span (in theory) from Level 0 all the way to Level 5.
         //
-        enum AssistFeature
+        // References:
+        // - https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
+        // - https://www.vda.de/en/topics/innovation-and-technology/automated-driving/automated-driving
+        //
+        enum FunctionName
         {
             // Unknown feature, should not be used.
             //
-            ASSIST_FEATURE_UNKNOWN = 0;
+            FUNCTION_NAME_UNKNOWN = 0;
 
             // Custom feature, see custom_name.
             //
-            ASSIST_FEATURE_OTHER = 1;
+            FUNCTION_NAME_OTHER = 1;
 
             // Blind spot warning.
             //
-            ASSIST_FEATURE_BLIND_SPOT_WARNING = 2;
+            FUNCTION_NAME_BLIND_SPOT_WARNING = 2;
 
             // Forward collision warning.
             //
-            ASSIST_FEATURE_FORWARD_COLLISION_WARNING = 3;
+            FUNCTION_NAME_FORWARD_COLLISION_WARNING = 3;
 
             // Lane departure warning.
             //
-            ASSIST_FEATURE_LANE_DEPARTURE_WARNING = 4;
+            FUNCTION_NAME_LANE_DEPARTURE_WARNING = 4;
 
             // Parking collision warning.
             //
-            ASSIST_FEATURE_PARKING_COLLISION_WARNING = 5;
+            FUNCTION_NAME_PARKING_COLLISION_WARNING = 5;
 
             // Rear cross-traffic warning
             //
-            ASSIST_FEATURE_REAR_CROSS_TRAFFIC_WARNING = 6;
+            FUNCTION_NAME_REAR_CROSS_TRAFFIC_WARNING = 6;
 
             // Automatic emergency braking
             //
-            ASSIST_FEATURE_AUTOMATIC_EMERGENCY_BRAKING = 7;
+            FUNCTION_NAME_AUTOMATIC_EMERGENCY_BRAKING = 7;
 
             // Emergency steering
             //
-            ASSIST_FEATURE_AUTOMATIC_EMERGENCY_STEERING = 8;
+            FUNCTION_NAME_AUTOMATIC_EMERGENCY_STEERING = 8;
 
             // Reverse automatic emergency braking
             //
-            ASSIST_FEATURE_REVERSE_AUTOMATIC_EMERGENCY_BRAKING = 9;
+            FUNCTION_NAME_REVERSE_AUTOMATIC_EMERGENCY_BRAKING = 9;
 
             // Adaptive cruise control
             //
-            ASSIST_FEATURE_ADAPTIVE_CRUISE_CONTROL = 10;
+            FUNCTION_NAME_ADAPTIVE_CRUISE_CONTROL = 10;
 
             // Lane keeping assist
             //
-            ASSIST_FEATURE_LANE_KEEPING_ASSIST = 11;
+            FUNCTION_NAME_LANE_KEEPING_ASSIST = 11;
 
             // Active driving assistance
             //
-            ASSIST_FEATURE_ACTIVE_DRIVING_ASSISTANCE = 12;
+            FUNCTION_NAME_ACTIVE_DRIVING_ASSISTANCE = 12;
 
             // Backup camera
             //
-            ASSIST_FEATURE_BACKUP_CAMERA = 13;
+            FUNCTION_NAME_BACKUP_CAMERA = 13;
 
             // Surround view camera
             //
-            ASSIST_FEATURE_SURROUND_VIEW_CAMERA = 14;
+            FUNCTION_NAME_SURROUND_VIEW_CAMERA = 14;
 
             // Active parking assistance
             //
-            ASSIST_FEATURE_ACTIVE_PARKING_ASSISTANCE = 15;
+            FUNCTION_NAME_ACTIVE_PARKING_ASSISTANCE = 15;
 
             // Remote parking assistance
             //
-            ASSIST_FEATURE_REMOTE_PARKING_ASSISTANCE = 16;
+            FUNCTION_NAME_REMOTE_PARKING_ASSISTANCE = 16;
 
             // Trailer assistance
             //
-            ASSIST_FEATURE_TRAILER_ASSISTANCE = 17;
+            FUNCTION_NAME_TRAILER_ASSISTANCE = 17;
 
             // Automatic high beams
             //
-            ASSIST_FEATURE_AUTOMATIC_HIGH_BEAMS = 18;
+            FUNCTION_NAME_AUTOMATIC_HIGH_BEAMS = 18;
 
             // Driver monitoring
             //
-            ASSIST_FEATURE_DRIVER_MONITORING = 19;
+            FUNCTION_NAME_DRIVER_MONITORING = 19;
 
             // Head up display
             //
-            ASSIST_FEATURE_HEAD_UP_DISPLAY = 20;
+            FUNCTION_NAME_HEAD_UP_DISPLAY = 20;
 
             // Night vision
             //
-            ASSIST_FEATURE_NIGHT_VISION = 21;
+            FUNCTION_NAME_NIGHT_VISION = 21;
+
+            // Urban driving
+            //
+            FUNCTION_NAME_URBAN_DRIVING = 22;
+
+            // Highway autopilot.
+            //
+            FUNCTION_NAME_HIGHWAY_AUTOPILOT = 23;
+
+            // Cruise control.
+            //
+            FUNCTION_NAME_CRUISE_CONTROL = 24;
+
+            // Speed limit control
+            //
+            FUNCTION_NAME_SPEED_LIMIT_CONTROL = 25;
+
         }
 
         // The activation state of a feature.
@@ -439,29 +460,33 @@ message HostVehicleData
             //
             ACTIVATION_STATE_OTHER = 1;
 
-            // The feature has been disabled.
+            // The function has been disabled.
             //
             ACTIVATION_STATE_TURNED_OFF = 2;
 
-            // The feature has errored in some way that renders it ineffective.
+            // The function has errored in some way that renders it ineffective.
             //
             ACTIVATION_STATE_ERRORED = 3;
 
-            // The feature is enabled but conditions have not caused it to be
+            // The function is initialized but not ready to start.
+            //
+            ACTIVATION_STATE_UNAVAILABLE = 4;
+
+            // The function is enabled but conditions have not caused it to be
             // triggered, for example, no vehicles in front to trigger a FCW.
             //
-            ACTIVATION_STATE_STANDBY = 4;
+            ACTIVATION_STATE_STANDBY = 5;
 
-            // The feature is currently active, for example, a warning is being
+            // The function is currently active, for example, a warning is being
             // shown to the driver, or emergency braking is being applied/
             //
-            ACTIVATION_STATE_ACTIVE = 5;
+            ACTIVATION_STATE_ACTIVE = 6;
 
-            // The feature would be ACTIVE, but the user has show sufficient
+            // The function would be ACTIVE, but the user has show sufficient
             // input to override, for example, by applying throttle or steering
             // input.
             //
-            ACTIVATION_STATE_ACTIVE_DRIVER_OVERRIDE = 6;
+            ACTIVATION_STATE_ACTIVE_DRIVER_OVERRIDE = 7;
         }
     }
 }

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -88,7 +88,7 @@ message HostVehicleData
     repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
 
     //
-    // \brief The absolute base parameters of the vehicle. 
+    // \brief The absolute base parameters of the vehicle.
     //
     message VehicleBasics
     {
@@ -182,7 +182,7 @@ message HostVehicleData
     }
 
     //
-    // \brief The focus here is on the description of the brake system. 
+    // \brief The focus here is on the description of the brake system.
     //
     message VehicleBrakeSystem
     {
@@ -193,7 +193,7 @@ message HostVehicleData
     }
 
     //
-    // \brief The focus here is on the description of the steering train. 
+    // \brief The focus here is on the description of the steering train.
     //
     message VehicleSteering
     {
@@ -235,7 +235,7 @@ message HostVehicleData
 
             // Rotation rate of the wheel based on the processed output of the hall sensor measurements at the wheel.
             // The rotation rate around the y-axis with respect to the wheel's coordinate system.
-            // 
+            //
             // Unit: rad/s.
             //
             // The sign convention is defined using the right-hand rule.
@@ -249,7 +249,7 @@ message HostVehicleData
 
             // Contains the longitudinal, measured slip of the tire.
             // \par References:
-            // - https://www.kfz-tech.de/Biblio/Formelsammlung/Schlupf.htm
+            // [1] kfz-tech.de, Schlupf, Retrieved June 30, 2021, from https://www.kfz-tech.de/Biblio/Formelsammlung/Schlupf.htm
             //
             // Unit: %
             //
@@ -282,7 +282,7 @@ message HostVehicleData
         // in context to the global coordinate system.
         //
         optional Orientation3d orientation = 2;
- 
+
         // Most accurate geodetic information of the vehicle available in the on-board network.
         //
         optional GeodeticPosition geodetic_position = 3;
@@ -335,9 +335,9 @@ message HostVehicleData
         //
         // \note This can span (in theory) from Level 0 all the way to Level 5.
         //
-        // References:
-        // - https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
-        // - https://www.vda.de/en/topics/innovation-and-technology/automated-driving/automated-driving
+        // \par References:
+        // [1] CLEARING THE CONFUSION: Recommended Common Naming for Advanced Driver Assistance Technologies, SAE International, Retrieved October 22, 2021, from https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
+        // [2] Automated Driving, German Association of the Automotive Industry (VDA), Retrieved October 22, 2021, from https://www.vda.de/en/topics/innovation-and-technology/automated-driving/automated-driving
         //
         enum Name
         {

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -75,6 +75,15 @@ message HostVehicleData
     //
     optional VehicleLocalization vehicle_localization = 8;
 
+        // What driver assistance is active.
+    //
+    // This can include:
+    //  - information presented to the driver, for example, parking sensors
+    //  - warnings raised by the vehicle, for example, forward collision warning
+    //  - corrective action taken by the vehicle, for example, auto emergency braking
+    //
+    repeated DriverAssistState driver_assist_state = 12;
+
     //
     // \brief The absolute base parameters of the vehicle. 
     //
@@ -274,5 +283,202 @@ message HostVehicleData
         // Most accurate geodetic information of the vehicle available in the on-board network.
         //
         optional GeodeticPosition geodetic_position = 3;
+    }
+
+    //
+    // \brief The driver assist state specifically relating to recognised
+    // Advanced Driver Assistance Systems.
+    //
+    message DriverAssistState
+    {
+        // The particular feature being reported about.
+        //
+        optional AssistFeature assist_feature = 1;
+
+        // Custom feature name.
+        //
+        // Only used if assist_feature is set to ASSIST_FEATURE_OTHER.
+        //
+        optional string custom_name = 2;
+
+        // The activation state of the feature.
+        //
+        // This is whether the feature has actually been triggered, for
+        // example, a warning has been raised, or additional braking is
+        // in effect.
+        //
+        optional ActivationState activation_state = 3;
+
+        // Custom activation state.
+        //
+        // Only used if the activation_state is set to ACTIVATION_STATE_OTHER.
+        //
+        optional string custom_activation_state = 4;
+
+        // Custom detail.
+        //
+        // An opaque set of key-value pairs which capture any user specific
+        // details that may be relevant.  This could include details about
+        // how a warning was raised (dashboard, audible, etc.) or it could
+        // be about settings which would influence evaluation, such as
+        // sensitivity settings.
+        //
+        repeated CustomDetail custom_detail = 5;
+
+        // ADAS feature that is raising the notification.
+        //
+        // \note The naming convention is taken from the SAE guidance on ADAS
+        // nomenclature:
+        // https://www.sae.org/binaries/content/assets/cm/content/miscellaneous/adas-nomenclature.pdf
+        //
+        enum AssistFeature
+        {
+            // Unknown feature, should not be used.
+            //
+            ASSIST_FEATURE_UNKNOWN = 0;
+
+            // Custom feature, see custom_name.
+            //
+            ASSIST_FEATURE_OTHER = 1;
+
+            // Blind spot warning.
+            //
+            ASSIST_FEATURE_BLIND_SPOT_WARNING = 2;
+
+            // Forward collision warning.
+            //
+            ASSIST_FEATURE_FORWARD_COLLISION_WARNING = 3;
+
+            // Lane departure warning.
+            //
+            ASSIST_FEATURE_LANE_DEPARTURE_WARNING = 4;
+
+            // Parking collision warning.
+            //
+            ASSIST_FEATURE_PARKING_COLLISION_WARNING = 5;
+
+            // Rear cross-traffic warning
+            //
+            ASSIST_FEATURE_REAR_CROSS_TRAFFIC_WARNING = 6;
+
+            // Automatic emergency braking
+            //
+            ASSIST_FEATURE_AUTOMATIC_EMERGENCY_BRAKING = 7;
+
+            // Emergency steering
+            //
+            ASSIST_FEATURE_AUTOMATIC_EMERGENCY_STEERING = 8;
+
+            // Reverse automatic emergency braking
+            //
+            ASSIST_FEATURE_REVERSE_AUTOMATIC_EMERGENCY_BRAKING = 9;
+
+            // Adaptive cruise control
+            //
+            ASSIST_FEATURE_ADAPTIVE_CRUISE_CONTROL = 10;
+
+            // Lane keeping assist
+            //
+            ASSIST_FEATURE_LANE_KEEPING_ASSIST = 11;
+
+            // Active driving assistance
+            //
+            ASSIST_FEATURE_ACTIVE_DRIVING_ASSISTANCE = 12;
+
+            // Backup camera
+            //
+            ASSIST_FEATURE_BACKUP_CAMERA = 13;
+
+            // Surround view camera
+            //
+            ASSIST_FEATURE_SURROUND_VIEW_CAMERA = 14;
+
+            // Active parking assistance
+            //
+            ASSIST_FEATURE_ACTIVE_PARKING_ASSISTANCE = 15;
+
+            // Remote parking assistance
+            //
+            ASSIST_FEATURE_REMOTE_PARKING_ASSISTANCE = 16;
+
+            // Trailer assistance
+            //
+            ASSIST_FEATURE_TRAILER_ASSISTANCE = 17;
+
+            // Automatic high beams
+            //
+            ASSIST_FEATURE_AUTOMATIC_HIGH_BEAMS = 18;
+
+            // Driver monitoring
+            //
+            ASSIST_FEATURE_DRIVER_MONITORING = 19;
+
+            // Head up display
+            //
+            ASSIST_FEATURE_HEAD_UP_DISPLAY = 20;
+
+            // Night vision
+            //
+            ASSIST_FEATURE_NIGHT_VISION = 21;
+        }
+
+        // The activation state of a feature.
+        //
+        // \note Not all of these will be applicable for all vehicles
+        // and features.
+        //
+        enum ActivationState
+        {
+            // An unknown activation state, this should not be used.
+            //
+            ACTIVATION_STATE_UNKNOWN = 0;
+
+            // Used for custom states not covered by the definitions below.
+            //
+            // A string state can be specified in custom_activation_state.
+            //
+            ACTIVATION_STATE_OTHER = 1;
+
+            // The feature has been disabled.
+            //
+            ACTIVATION_STATE_TURNED_OFF = 2;
+
+            // The feature has errored in some way that renders it ineffective.
+            //
+            ACTIVATION_STATE_ERRORED = 3;
+
+            // The feature is enabled but conditions have not caused it to be
+            // triggered, for example, no vehicles in front to trigger a FCW.
+            //
+            ACTIVATION_STATE_STANDBY = 4;
+
+            // The feature is currently active, for example, a warning is being
+            // shown to the driver, or emergency braking is being applied/
+            //
+            ACTIVATION_STATE_ACTIVE = 5;
+
+            // The feature would be ACTIVE, but the user has show sufficient
+            // input to override, for example, by applying throttle or steering
+            // input.
+            //
+            ACTIVATION_STATE_ACTIVE_DRIVER_OVERRIDE = 6;
+        }
+
+        //
+        // \brief Custom detail message
+        //
+        // To contain driver-assist related information that is too function
+        // specific to be captured in a generic way.
+        //
+        message CustomDetail
+        {
+            // A generic string key to identify the information.
+            //
+            optional string key = 1;
+
+            // A generic string value to capture the information.
+            //
+            optional string value = 2;
+        }
     }
 }

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -5,6 +5,7 @@ option optimize_for = SPEED;
 import "osi_version.proto";
 import "osi_common.proto";
 import "osi_object.proto";
+import "osi_hostvehicledata.proto";
 
 package osi3;
 
@@ -52,4 +53,14 @@ message TrafficUpdate
     // MovingObject::VehicleClassification::trailer_id. 
     //
     repeated MovingObject update = 3;
+
+    // Internal state for each vehicle.
+    //
+    // \note This covers any information which cannot be externally perceived
+    // and therefore cannot be included in messages available in ground truth.
+    //
+    // \note The id field from this should match the id in the update field
+    // above where the same vehicle is being referenced.
+    //
+    repeated HostVehicleData internal_state = 4;
 }

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -56,6 +56,11 @@ message TrafficUpdate
 
     // Internal state for each vehicle.
     //
+    // This is an optional field as internal state may not be known or relevant,
+    // for example, a trailer is not going to have any internal state.
+    // It is also allowed to only specify internal_state for a subset of the
+    // objects referenced in the update.
+    //
     // \note This covers any information which cannot be externally perceived
     // and therefore cannot be included in messages available in ground truth.
     //

--- a/osi_trafficupdate.proto
+++ b/osi_trafficupdate.proto
@@ -57,7 +57,7 @@ message TrafficUpdate
     // Internal state for each vehicle.
     //
     // This is an optional field as internal state may not be known or relevant,
-    // for example, a trailer is not going to have any internal state.
+    // for example, a trailer might not have any internal state.
     // It is also allowed to only specify internal_state for a subset of the
     // objects referenced in the update.
     //


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#545 

#### Add a description
See the linked issue for more details, but at a high level, this adds the ability for a host vehicle to report details about the internal state of automated driving functions.

It also adds `HostVehicleData` to a `TrafficUpdate` to allow this information to be reported from a SuT to the simulator, or other simulation entities.

(`HostVehicleData` is already a top level message, and embedded in other "reporting" type messages, to allow this information to be propagated further if necessary)

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.