### PR TITLE
Adding the missing field for echo pulse width to logical detections

### DIFF
--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -196,6 +196,24 @@ message LogicalDetection
     // Basic classification of the logical detection.
     //
     optional LogicalDetectionClassification classification = 11;
+
+    // Echo pulse width of the logical detection's echo.
+    // Several sensors output an echo pulse width instead of an intensity for each individual detection.
+    // The echo pulse is measured in m and measures the extent of the object parts or atmospheric particles that produce the echo.
+    // \note For more details see [1] Fig. 7 and 8.
+    // \note Fig. 7 shows an example where the two echos are reflected from the edges A-B and C-D.
+    // \note Fig. 8 shows how the echo pulse width is measured as the range between the rising edge and the falling edge that crosses the intensity threshold.
+    //
+    // Unit: m
+    //
+    // \rules
+    // is_greater_than_or_equal_to: 0
+    // \endrules
+    //
+    // \par Reference:
+    // [1] Rosenberger, P., Holder, M.F., Cianciaruso, N. et al. (2020). <em>Sequential lidar sensor system simulation: a modular approach for simulation-based safety validation of automated driving</em> Automot. Engine Technol. 5, Fig 7, Fig 8. Retrieved May 10, 2021, from https://doi.org/10.1007/s41104-020-00066-x
+    //
+    optional double echo_pulse_width = 12;
 }
 
 // Definition of basic logical detection classifications.


### PR DESCRIPTION
This is necessary to represent Ibeo LUX ECU data or similar that contain fused lidar point clouds with echo pulse width instead of intensity.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
