### PR TITLE
Additional laneboundary types to align with OpenDRIVE

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -1035,17 +1035,13 @@ message LaneBoundary
             //
             TYPE_STRUCTURE = 13;
 
-            // A barrier (e.g. a concrete barrier on a highway).
+            // A barrier to guide vehicles and to prevent them from entering other lanes (e.g. a concrete barrier on a highway).
             //
             TYPE_BARRIER = 14;
 
             // A sound barrier.
             //
             TYPE_SOUND_BARRIER = 15;
-
-            // A railing (e.g. divider between road and sidewalk).
-            //
-            TYPE_RAILING = 16;
         }
 
         // The semantic color of the lane boundary in case of a lane markings.


### PR DESCRIPTION
Introducing additional laneboundary types to align with OpenDRIVE. With this, repeating objects from OpenDRIVE with distance = 0, i.e. continuous objects, can be transformed into laneboundaries.


- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.


