### PR TITLE
Environmental conditions, added Sun, Wind, CloudState

### DIFF
--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -22,25 +22,6 @@ message EnvironmentalConditions
     // The time of day at the host vehicles location.
     //
     optional TimeOfDay time_of_day = 2;
-    
-    // The Unix epoch (or Unix time or POSIX time or Unix timestamp) is
-    // the number of seconds that have elapsed since January 1, 1970
-    // (midnight UTC/GMT [1]), not counting leap seconds [2].
-    // Historically, the origin of UNIX system time was referred to as
-    // "00:00:00 GMT, January 1, 1970" [2]. Literally speaking the epoch
-    // is Unix time 0 (midnight 1/1/1970), but 'epoch' is often used as
-    // a synonym for 'Unix time'. Many Unix systems store epoch dates as
-    // a signed 32-bit integer, which might cause problems on January 19,
-    // 2038 (known as the Year 2038 problem or Y2038). 
-    //
-    // \note You can convert the timestamp using the following [routines
-    // sorted by languages](https://www.epochconverter.com/#code).
-    //
-    // \par References:
-    // [1] ITU Radiocommunication Assembly. (2002). <em>Recommondation  ITU-R  TF.460-6 Standard-frequency and time-signal emissions</em>. (Rec.  ITU-R  TF.460-6). Retrieved January 25, 2020, from http://www.itu.int/dms_pubrec/itu-r/rec/tf/R-REC-TF.460-6-200202-I!!PDF-E.pdf \n
-    // [2] The Open Group. (2018). <em>POSIX.1-2017</em> The Open Group Base Specifications Issue 7, 2018 edition. IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008). Retrieved January 25, 2020, from https://pubs.opengroup.org/onlinepubs/9699919799/xrat/contents.html
-    //
-    optional int64 unix_timestamp = 8;
 
     // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325
     // Pa).
@@ -87,6 +68,25 @@ message EnvironmentalConditions
     // Description of the fog.
     //
     optional Fog fog = 7;
+
+    // The Unix epoch (or Unix time or POSIX time or Unix timestamp) is
+    // the number of seconds that have elapsed since January 1, 1970
+    // (midnight UTC/GMT [1]), not counting leap seconds [2].
+    // Historically, the origin of UNIX system time was referred to as
+    // "00:00:00 GMT, January 1, 1970" [2]. Literally speaking the epoch
+    // is Unix time 0 (midnight 1/1/1970), but 'epoch' is often used as
+    // a synonym for 'Unix time'. Many Unix systems store epoch dates as
+    // a signed 32-bit integer, which might cause problems on January 19,
+    // 2038 (known as the Year 2038 problem or Y2038).
+    //
+    // \note You can convert the timestamp using the following [routines
+    // sorted by languages](https://www.epochconverter.com/#code).
+    //
+    // \par References:
+    // [1] ITU Radiocommunication Assembly. (2002). <em>Recommondation  ITU-R  TF.460-6 Standard-frequency and time-signal emissions</em>. (Rec.  ITU-R  TF.460-6). Retrieved January 25, 2020, from http://www.itu.int/dms_pubrec/itu-r/rec/tf/R-REC-TF.460-6-200202-I!!PDF-E.pdf \n
+    // [2] The Open Group. (2018). <em>POSIX.1-2017</em> The Open Group Base Specifications Issue 7, 2018 edition. IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008). Retrieved January 25, 2020, from https://pubs.opengroup.org/onlinepubs/9699919799/xrat/contents.html
+    //
+    optional int64 unix_timestamp = 8;
     
     // Optional external reference to the environmental condition sources.
     //
@@ -101,13 +101,13 @@ message EnvironmentalConditions
     //
     repeated ExternalReference source_reference = 9;
 
-    // Definition of the wind speed and direction.
+    // Definition of clouds.
+    //
+    optional Clouds clouds = 10;
+
+    // Definition of the wind properties
     //
     optional Wind wind = 11;
-
-    // Definition of cloud states and the skybox.
-    //
-    optional CloudState cloud_state = 10;
 
     // Definition of the Sun.
     //
@@ -338,9 +338,95 @@ message EnvironmentalConditions
     }
 
     //
+    // \brief Specification of the cloud states
+    //
+    // \note within this message there is the cloud state level
+    //
+    message Clouds
+    {
+        // Definition of the cloud state level, i.e. cloud state and sky visualization settings.
+        //
+        optional CloudStateLevel cloud_state_level = 1;
+
+        // Defines the cloud state levels given by observation of total cloud amount in oktas.
+        //
+        // The total degree of coverage indicates how large the part of the sky vault is which is covered
+        // with clouds altogether. It is given in eighths, because this division is easier to estimate
+        // for the observer. 0 eighths means that there are no traces of clouds in the sky,
+        // 4 eighths means that the sky is covered with clouds up to half, 8 eighths means that the sky is
+        // completely covered with clouds and no sky blue can be recognized.
+        //
+        // For cloud determination, the observer will choose a location from which he can overlook the entire sky.
+        // When determining the total cloud cover, all clouds or parts of clouds, regardless of height and genus,
+        // that are above his location will be added. Aircraft contrails are also counted as cloud cover if they remain
+        // in the sky for more than 15 minutes. On the other hand, fog is not counted as cloud cover.
+        //
+        // With a little practice, the observer can easily determine the total amount of cloud cover.
+        // Problems occur only with scattered clouds or many single clouds (cumulus).
+        // Their cloud cover is often overestimated. On the other hand,
+        // the coverage of thin ice clouds (cirrus) is often underestimated.[3]
+        //
+        // \par References:
+        // [1] ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
+        // [2] https://en.wikipedia.org/wiki/Cloud_cover
+        // [3] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
+        //
+        enum CloudStateLevel
+        {
+            // Cloud State is unknown (must not be used in ground truth).
+            //
+            CLOUD_STATE_LEVEL_UNKNOWN = 0;
+
+            // Other (unspecified but known) CloudState.
+            //
+            CLOUD_STATE_LEVEL_OTHER = 1;
+
+            // Cloudless (0/8)
+            //
+            CLOUD_STATE_LEVEL_CLOUDLESS = 2;
+
+            // Sunny (1/8)
+            //
+            CLOUD_STATE_LEVEL_SUNNY = 3;
+
+            // Serene (2/8))
+            //
+            CLOUD_STATE_LEVEL_SERENE = 4;
+
+            // Slightly Cloudy (3/8)
+            //
+            CLOUD_STATE_LEVEL_SLIGHTLY_CLOUDY = 5;
+
+            // Light Cloudy (4/8)
+            //
+            CLOUD_STATE_LEVEL_LIGHT_CLOUDY = 6;
+
+            // Cloudy (5/8)
+            //
+            CLOUD_STATE_LEVEL_CLOUDY = 7;
+
+            // Heavy Cloudy (6/8)
+            //
+            CLOUD_STATE_LEVEL_HEAVY_CLOUDY = 8;
+
+            // Almost Covered (7/8)
+            //
+            CLOUD_STATE_LEVEL_ALMOST_COVERED = 9;
+
+            // Covered (8/8)
+            //
+            CLOUD_STATE_LEVEL_COVERED = 10;
+
+            // No Sky
+            //
+            CLOUD_STATE_LEVEL_NO_SKY = 11;
+        }
+    }
+
+    //
     // \brief Defines wind properties.
     //
-    // \note Describes the wind speed and direction from ASAM OpenSCENARIO
+    // \note Aligns with the wind speed and direction as defined in ASAM OpenSCENARIO
     //
     message Wind
     {
@@ -355,96 +441,42 @@ message EnvironmentalConditions
         optional double speed = 2;
     }
 
-    // Definition of the cloud state, i.e. cloud state and sky visualization settings.
-    //
-    // The total degree of coverage indicates how large the part of the sky vault is which is covered
-    // with clouds altogether. It is given in eighths, because this division is easier to estimate
-    // for the observer. 0 eighths means that there are no traces of clouds in the sky,
-    // 4 eighths means that the sky is covered with clouds up to half, 8 eighths means that the sky is
-    // completely covered with clouds and no sky blue can be recognized.
-    //
-    // For cloud determination, the observer will choose a location from which he can overlook the entire sky.
-    // When determining the total cloud cover, all clouds or parts of clouds, regardless of height and genus,
-    // that are above his location will be added. Aircraft contrails are also counted as cloud cover if they remain
-    // in the sky for more than 15 minutes. On the other hand, fog is not counted as cloud cover.
-    //
-    // With a little practice, the observer can easily determine the total amount of cloud cover.
-    // Problems occur only with scattered clouds or many single clouds (cumulus).
-    // Their cloud cover is often overestimated. On the other hand,
-    // the coverage of thin ice clouds (cirrus) is often underestimated.[3]
-    //
-    // \par References:
-    // [1] ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
-    // [2] https://de.wikipedia.org/wiki/Bewölkung
-    // [3] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
-    //
-    enum CloudState
-    {
-        // Cloud State is unknown (must not be used in ground truth).
-        //
-        CLOUD_STATE_UNKNOWN = 0;
-
-        // Other (unspecified but known) CloudState.
-        //
-        CLOUD_STATE_OTHER = 1;
-
-        // Cloudless (0/8)
-        //
-        CLOUD_STATE_CLOUDLESS = 2;
-
-        // Sunny (1/8)
-        //
-        CLOUD_STATE_SUNNY = 3;
-
-        // Serene (2/8))
-        //
-        CLOUD_STATE_SERENE = 4;
-
-        // Slightly Cloudy (3/8)
-        //
-        CLOUD_STATE_SLIGHTLY_CLOUDY = 5;
-
-        // Light Cloudy (4/8)
-        //
-        CLOUD_STATE_LIGHT_CLOUDY = 6;
-
-        // Cloudy (5/8)
-        //
-        CLOUD_STATE_CLOUDY = 7;
-
-        // Heavy Cloudy (6/8)
-        //
-        CLOUD_STATE_HEAVY_CLOUDY = 8;
-
-        // Almost Covered (7/8)
-        //
-        CLOUD_STATE_ALMOST_COVERED = 9;
-
-        // Covered (8/8)
-        //
-        CLOUD_STATE_COVERED = 10;
-
-        // No Sky
-        //
-        CLOUD_STATE_NO_SKY = 11;
-    }
-
     //
     // \brief Specification of sun properties.
     //
-    // \note Defines the specification of sun properties according to ASAM OpenSCENARIO
+    // \note Aligns with the specification of sun properties according to ASAM OpenSCENARIO
     //
     message Sun
     {
-        // Azimuth of the sun, counted counterclockwise, 0=north, PI/2 = east, PI=south, 3/2 PI=west. Unit: radian; Range: [0..2PI].
+        // Azimuth of the sun, counted counterclockwise
+        //
+        // Unit: rad
+        //
+        // \rules
+        // is_greater_than_or_equal_to: -PI
+        // is_less_than_or_equal_to: 2PI
+        // \endrules
         //
         optional double azimuth = 1;
 
-        // Solar elevation angle, 0=x/y plane, PI/2=zenith. Unit: rad; Range: [-PI..PI].
+        // Solar elevation angle
+        //
+        // Unit: rad
+        //
+        // \rules
+        // is_greater_than_or_equal_to: -PI
+        // is_less_than_or_equal_to: PI
+        // \endrules
         //
         optional double elevation = 2;
 
-        // Illuminance of the sun, direct sunlight is around 100,00 lx. Unit: lux; Range: [0..inf[.
+        // Illuminance of the sun, direct sunlight is around 100,00 lx.
+        //
+        // Unit: lx
+        //
+        // \rules
+        // is_greater_than_or_equal_to: 0
+        // \endrules
         //
         optional double intensity = 3;
     }

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -23,6 +23,25 @@ message EnvironmentalConditions
     //
     optional TimeOfDay time_of_day = 2;
 
+    // The Unix epoch (or Unix time or POSIX time or Unix timestamp) is
+    // the number of seconds that have elapsed since January 1, 1970
+    // (midnight UTC/GMT [1]), not counting leap seconds [2].
+    // Historically, the origin of UNIX system time was referred to as
+    // "00:00:00 GMT, January 1, 1970" [2]. Literally speaking the epoch
+    // is Unix time 0 (midnight 1/1/1970), but 'epoch' is often used as
+    // a synonym for 'Unix time'. Many Unix systems store epoch dates as
+    // a signed 32-bit integer, which might cause problems on January 19,
+    // 2038 (known as the Year 2038 problem or Y2038).
+    //
+    // \note You can convert the timestamp using the following [routines
+    // sorted by languages](https://www.epochconverter.com/#code).
+    //
+    // \par References:
+    // [1] ITU Radiocommunication Assembly. (2002). <em>Recommondation  ITU-R  TF.460-6 Standard-frequency and time-signal emissions</em>. (Rec.  ITU-R  TF.460-6). Retrieved January 25, 2020, from http://www.itu.int/dms_pubrec/itu-r/rec/tf/R-REC-TF.460-6-200202-I!!PDF-E.pdf \n
+    // [2] The Open Group. (2018). <em>POSIX.1-2017</em> The Open Group Base Specifications Issue 7, 2018 edition. IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008). Retrieved January 25, 2020, from https://pubs.opengroup.org/onlinepubs/9699919799/xrat/contents.html
+    //
+    optional int64 unix_timestamp = 8;
+
     // Atmospheric pressure in Pascal at z=0.0 in world frame (about 101325
     // Pa).
     //
@@ -68,25 +87,6 @@ message EnvironmentalConditions
     // Description of the fog.
     //
     optional Fog fog = 7;
-
-    // The Unix epoch (or Unix time or POSIX time or Unix timestamp) is
-    // the number of seconds that have elapsed since January 1, 1970
-    // (midnight UTC/GMT [1]), not counting leap seconds [2].
-    // Historically, the origin of UNIX system time was referred to as
-    // "00:00:00 GMT, January 1, 1970" [2]. Literally speaking the epoch
-    // is Unix time 0 (midnight 1/1/1970), but 'epoch' is often used as
-    // a synonym for 'Unix time'. Many Unix systems store epoch dates as
-    // a signed 32-bit integer, which might cause problems on January 19,
-    // 2038 (known as the Year 2038 problem or Y2038).
-    //
-    // \note You can convert the timestamp using the following [routines
-    // sorted by languages](https://www.epochconverter.com/#code).
-    //
-    // \par References:
-    // [1] ITU Radiocommunication Assembly. (2002). <em>Recommondation  ITU-R  TF.460-6 Standard-frequency and time-signal emissions</em>. (Rec.  ITU-R  TF.460-6). Retrieved January 25, 2020, from http://www.itu.int/dms_pubrec/itu-r/rec/tf/R-REC-TF.460-6-200202-I!!PDF-E.pdf \n
-    // [2] The Open Group. (2018). <em>POSIX.1-2017</em> The Open Group Base Specifications Issue 7, 2018 edition. IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008). Retrieved January 25, 2020, from https://pubs.opengroup.org/onlinepubs/9699919799/xrat/contents.html
-    //
-    optional int64 unix_timestamp = 8;
     
     // Optional external reference to the environmental condition sources.
     //
@@ -103,7 +103,7 @@ message EnvironmentalConditions
 
     // Definition of clouds.
     //
-    optional Clouds clouds = 10;
+    optional CloudLayer clouds = 10;
 
     // Definition of the wind properties.
     //
@@ -338,11 +338,11 @@ message EnvironmentalConditions
     }
 
     //
-    // \brief Specification of the cloud states.
+    // \brief Specification of the cloud layer.
     //
     // \note within this message there is the cloud state level.
     //
-    message Clouds
+    message CloudLayer
     {
         // Definition of the cloud state level, i.e. cloud state and sky visualization settings.
         //
@@ -422,11 +422,11 @@ message EnvironmentalConditions
     //
     // \brief Defines wind properties.
     //
-    // \note Aligns with the wind speed and direction as defined in ASAM OpenSCENARIO.
+    // \note Inspired by the wind speed and direction as defined in ASAM OpenSCENARIO.
     //
     message Wind
     {
-        // The target direction of the wind (not the origin direction) in the ground/xy-plane of the \c
+        // The origin direction of the wind (not the target direction) in the ground/xy-plane of the \c
         // world coordinate system. Corresponds to the heading/yaw angle. \c
         // x-axis-direction is 0 rad.
         //
@@ -434,9 +434,10 @@ message EnvironmentalConditions
         //
         // The preferred angular range is [-pi, pi]
         //
-        // \note The range in openSCENARIO is Range [0...2 pi[. Mind the conversion.
+        // \note The direction is the origin, not the target direction. \c
+        // The range in openSCENARIO is Range [0...2 pi[. Mind the conversion.
         //
-        optional Vector3d direction = 1;
+        optional Vector3d origin_direction = 1;
 
         // The wind speed.
         //
@@ -458,7 +459,7 @@ message EnvironmentalConditions
         //
         // Unit: rad
         //
-        // The preferred angular range is [0, 2pi]
+        // The preferred angular range is [-pi, pi]
         //
         optional double azimuth = 1;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -101,15 +101,15 @@ message EnvironmentalConditions
     //
     repeated ExternalReference source_reference = 9;
 
-    // Definition of clouds.
+    // Description of the clouds.
     //
     optional CloudLayer clouds = 10;
 
-    // Definition of the wind properties.
+    // Description of the wind.
     //
     optional Wind wind = 11;
 
-    // Definition of the Sun.
+    // Description of the sun.
     //
     optional Sun sun = 12;
 
@@ -338,89 +338,75 @@ message EnvironmentalConditions
     }
 
     //
-    // \brief Specification of a cloud layer.
+    // \brief Description of a cloud layer.
     //
     message CloudLayer
     {
-        // Definition of the cloud layer, i.e. cloud layer level and sky visualization settings.
+        // Properties of a cloud layer by discrete cloud layer levels.
         //
-        optional CloudLayerLevel cloud_layer_level = 1;
+        optional FractionalCloudCover cloud_layer_level = 1;
 
-        // Defines the cloud layer levels given by observation of total cloud amount in oktas.
+        // Defines the fractional cloud cover given by observation of total cloud amount in eights (oktas) of the sky.
         //
         // For visual alignment please see reference[1].
         //
-        // The total degree of coverage indicates how large the part of the sky vault is which is covered
-        // with clouds altogether. It is given in eighths, because this division is easier to estimate
-        // for the observer. 0 eighths means that there are no traces of clouds in the sky,
-        // 4 eighths means that the sky is covered with clouds up to half, 8 eighths means that the sky is
-        // completely covered with clouds and no sky blue can be recognized.
-        //
-        // For cloud determination, the observer will choose a location from which he can overlook the entire sky.
-        // When determining the total cloud cover, all clouds or parts of clouds, regardless of height and genus,
-        // that are above his location will be added. Aircraft contrails are also counted as cloud cover if they remain
-        // in the sky for more than 15 minutes. On the other hand, fog is not counted as cloud cover.
-        //
-        // With a little practice, the observer can easily determine the total amount of cloud cover.
-        // Problems occur only with scattered clouds or many single clouds (cumulus).
-        // Their cloud cover is often overestimated. On the other hand,
-        // the coverage of thin ice clouds (cirrus) is often underestimated [2].
+        // The total degree of coverage indicates how much of the sky is covered with clouds altogether.
+        // 0 oktas means that there are no traces of clouds in the sky, \c
+        // 8 oktas means that the sky is completely covered with clouds and no sky blue can be recognized.
         //
         // \par References:
-        // ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
-        // https://en.wikipedia.org/wiki/Cloud_cover
+        // https://cie.co.at/eilvterm/17-29-116
         // [1] https://www.eoas.ubc.ca/courses/atsc113/flying/met_concepts/01-met_concepts/01c-cloud_coverage/index.html
-        // [2] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
         //
-        enum CloudLayerLevel
+        enum FractionalCloudCover
         {
             // Cloud layer level is unknown (must not be used in ground truth).
             //
-            CLOUD_LAYER_LEVEL_UNKNOWN = 0;
+            FRACTIONAL_CLOUD_COVER_UNKNOWN = 0;
 
             // Other (unspecified but known) cloud layer level.
             //
-            CLOUD_LAYER_LEVEL_OTHER = 1;
+            FRACTIONAL_CLOUD_COVER_OTHER = 1;
 
             // 0/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_0 = 2;
+            FRACTIONAL_CLOUD_COVER_ZERO_OKTAS = 2;
 
             // 1/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_1 = 3;
+            FRACTIONAL_CLOUD_COVER_ONE_OKTAS = 3;
 
             // 2/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_2 = 4;
+            FRACTIONAL_CLOUD_COVER_TWO_OKTAS = 4;
 
             // 3/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_3 = 5;
+            FRACTIONAL_CLOUD_COVER_THREE_OKTAS = 5;
 
             // 4/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_4 = 6;
+            FRACTIONAL_CLOUD_COVER_FOUR_OKTAS = 6;
 
             // 5/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_5 = 7;
+            FRACTIONAL_CLOUD_COVER_FIVE_OKTAS = 7;
 
             // 6/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_6 = 8;
+            FRACTIONAL_CLOUD_COVER_SIX_OKTAS = 8;
 
             // 7/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_7 = 9;
+            FRACTIONAL_CLOUD_COVER_SEVEN_OKTAS = 9;
 
             // 8/8 of the sky is covered with clouds.
             //
-            CLOUD_LAYER_LEVEL_8 = 10;
+            FRACTIONAL_CLOUD_COVER_EIGHT_OKTAS = 10;
 
             // Sky obscured, describes situations where the sky is not perceivable, e.g. in dense fog.
             //
-            CLOUD_LAYER_LEVEL_SKY_OBSCURED = 11;
+            FRACTIONAL_CLOUD_COVER_SKY_OBSCURED = 11;
         }
     }
 
@@ -434,11 +420,11 @@ message EnvironmentalConditions
         // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
         // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
         //
+        // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.
+        //
         // Unit: rad
         //
         // The preferred angular range is [0, 2pi].
-        //
-        // \note The direction is the origin, not the target direction.
         //
         // \par References:
         // [1] https://proj.org/usage/projections.html#:~:text=E%20%20%20%200dN%200.000-,Axis%20orientation,%C2%B6,-Starting%20in%20PROJ
@@ -449,19 +435,21 @@ message EnvironmentalConditions
         //
         // Unit: m/s
         //
-        // Range [0...inf[
+        // \rules
+        // is_greater_than_or_equal_to: 0
+        // \endrules
         //
         optional double speed = 2;
     }
 
     //
-    // \brief Specification of sun properties.
+    // \brief Properties of the sun.
     //
     message Sun
     {
         // Azimuth of the sun, counted counterclockwise.
         // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
-        // then north is pointing in y-axis direction. The default orientation (x, y, z) is “easting, northing, up” [1].
+        // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
         //
         // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.
         //
@@ -470,14 +458,13 @@ message EnvironmentalConditions
         // The preferred angular range is [0, 2pi].
         //
         // \par References:
-        // [1] https://proj.org/usage/projections.html#:~:text=E%20%20%20%200dN%200.000-,Axis%20orientation,%C2%B6,-Starting%20in%20PROJ
+        // [1] https://proj.org/usage/projections.html
         //
         optional double azimuth = 1;
 
-        // Solar elevation angle. Counted in positive direction around x-axis.
+        // Solar elevation angle. Counted in positive direction (clockwise) around xy-plane.
         //
-        // \note This is different to ASAM OpenSCENARIO for an unique definition of azimuth and elevation.\c
-        // 0: xy-plane; +pi/2: zenith.
+        // \note 0: xy-plane; +pi/2: zenith.
         //
         // Unit: rad
         //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -90,7 +90,7 @@ message EnvironmentalConditions
     
     // Optional external reference to the environmental condition sources.
     //
-    // \note For OpenDRIVE and OpenSECNARIO there is no direct counterpart.
+    // \note For OpenDRIVE and OpenSCENARIO there is no direct counterpart.
     //
     // \note For non-ASAM standards, it is implementation-specific how
     //       source_reference is resolved.
@@ -254,55 +254,55 @@ message EnvironmentalConditions
         //
         AMBIENT_ILLUMINATION_OTHER = 1;
 
-        // Level 1 illumination in ]0.001, 0.01[ lx
+        // Level 1 illumination in ]0.001, 0.01[ lx. \n
         // E.g. Night with no artificial light.
         //
         // \note Use \c #AMBIENT_ILLUMINATION_LEVEL1 if illumination is less
-        // than 0.001 lx
+        // than 0.001 lx.
         //
         AMBIENT_ILLUMINATION_LEVEL1 = 2;
 
-        // Level 2 illumination in [0.01, 1[ lx
+        // Level 2 illumination in [0.01, 1[ lx. \n
         // E.g. Night full moon / Deep twilight.
         //
         AMBIENT_ILLUMINATION_LEVEL2 = 3;
 
-        // Level 3 illumination in [1, 3[ lx
+        // Level 3 illumination in [1, 3[ lx. \n
         // E.g. Deep to average twilight / Minimum lighting on local low
         // pedestrian conflict roads.
         //
         AMBIENT_ILLUMINATION_LEVEL3 = 4;
 
-        // Level 4 illumination in [3, 10[ lx
+        // Level 4 illumination in [3, 10[ lx. \n
         // E.g. Average to full twilight / Minimum lighting on collector roads /
         // Minimum lighting on major and expressway roads with low to average
         // pedestrian conflict.
         //
         AMBIENT_ILLUMINATION_LEVEL4 = 5;
 
-        // Level 5 illumination in [10, 20[ lx
+        // Level 5 illumination in [10, 20[ lx. \n
         // E.g. Minimum lighting on major and expressway roads with high
         // pedestrian conflict.
         //
         AMBIENT_ILLUMINATION_LEVEL5 = 6;
 
-        // Level 6 illumination in [20, 400[ lx
+        // Level 6 illumination in [20, 400[ lx. \n
         // E.g. Roads with more lighting / Very dark overcast day to sunrise or
         // sunset on a clear day.
         //
         AMBIENT_ILLUMINATION_LEVEL6 = 7;
 
-        // Level 7 illumination in [400, 1000[ lx
+        // Level 7 illumination in [400, 1000[ lx. \n
         // E.g. Sunrise or sunset on a clear day / Overcast day.
         //
         AMBIENT_ILLUMINATION_LEVEL7 = 8;
 
-        // Level 8 illumination in [1000, 10000[ lx
+        // Level 8 illumination in [1000, 10000[ lx. \n
         // E.g. Average to full daylight.
         //
         AMBIENT_ILLUMINATION_LEVEL8 = 9;
 
-        // Level 9 illumination in [10000, 120000[ lx
+        // Level 9 illumination in [10000, 120000[ lx. \n
         // E.g. Full daylight to intense sunlight.
         //
         // \note Use \c #AMBIENT_ILLUMINATION_LEVEL9 if illumination is more
@@ -348,14 +348,14 @@ message EnvironmentalConditions
 
         // Defines the fractional cloud cover [1] given by observation of total cloud amount in eights (oktas) of the sky.
         //
-        // For visual alignment please see reference[2].
+        // For visual alignment please see reference [2].
         //
         // The total degree of coverage indicates how much of the sky is covered with clouds altogether.
-        // 0 oktas means that there are no traces of clouds in the sky, \c
+        // 0 oktas means that there are no traces of clouds in the sky,
         // 8 oktas means that the sky is completely covered with clouds and no sky blue can be recognized.
         //
         // \par References:
-        // [1] CIE engl. International Commission on Illumination. (2020). <em>CIE S017:2020 ILV: Intl. Lighitng Vocabulary, 2nd edn.</em>. Retrieved March 8, 2022, from https://cie.co.at/eilvterm/17-29-116
+        // [1] CIE engl. International Commission on Illumination. (2020). <em>CIE S017:2020 ILV: Intl. Lighitng Vocabulary, 2nd edn.</em>. Retrieved March 8, 2022, from https://cie.co.at/eilvterm/17-29-116 \n
         // [2] UBC The University of British Columbia. (2018). <em>ATSC 113 Weather for Sailing, Flying & Snow Sports</em>. Retrieved March 8, 2022, from https://www.eoas.ubc.ca/courses/atsc113/flying/met_concepts/01-met_concepts/01c-cloud_coverage/index.html
         //
         enum FractionalCloudCover
@@ -415,9 +415,9 @@ message EnvironmentalConditions
     //
     message Wind
     {
-        // The origin direction of the wind (not the target direction) in the ground/xy-plane of the \c
-        // world coordinate system. Corresponds to the heading/yaw angle, counted counterclockwise. \c
-        // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
+        // The origin direction of the wind (not the target direction) in the ground/xy-plane of the
+        // world coordinate system. Corresponds to the heading/yaw angle, counted counterclockwise.
+        // 0 pointing north. If north is not explicitly defined via \c #osi3::GroundTruth::proj_string,
         // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
         //
         // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.
@@ -448,7 +448,7 @@ message EnvironmentalConditions
     message Sun
     {
         // Azimuth of the sun, counted counterclockwise.
-        // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
+        // 0 pointing north. If north is not explicitly defined via \c #osi3::GroundTruth::proj_string,
         // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
         //
         // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -453,6 +453,7 @@ message EnvironmentalConditions
         // Azimuth of the sun, counted counterclockwise.
         // 0 pointing north. If north is not explicitly defined via \c #osi3::GroundTruth::proj_string,
         // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
+        // The point of observation is defined to be the global coordinate system's origin.
         //
         // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.
         //
@@ -468,6 +469,7 @@ message EnvironmentalConditions
         // Solar elevation angle.
         // The elevation angle is positive when the sun is above the xy-plane, negative when
         // the sun is below the xy-plane.
+        // The point of observation is defined to be the global coordinate system's origin.
         //
         // \note 0: xy-plane; +pi/2: zenith; -pi/2: nadir.
         //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -101,6 +101,18 @@ message EnvironmentalConditions
     //
     repeated ExternalReference source_reference = 9;
 
+    // Definition of the wind speed and direction.
+    //
+    optional Wind wind = 11;
+
+    // Definition of cloud states and the skybox.
+    //
+    optional CloudState cloud_state = 10;
+
+    // Definition of the Sun.
+    //
+    optional Sun sun = 12;
+
     // Definition of discretized precipitation states according to [1].
     // (I = Intensity of precipitation in mm per hour mm/h)
     //
@@ -323,5 +335,117 @@ message EnvironmentalConditions
         // \endrules
         //
         optional uint32 seconds_since_midnight = 1;
+    }
+
+    //
+    // \brief Defines wind properties.
+    //
+    // \note Describes the wind speed and direction from ASAM OpenSCENARIO
+    //
+    message Wind
+    {
+        // The target direction of the wind (not the origin direction) in the ground/xy-plane of the \c
+        // world coordinate system. Corresponds to the heading/yaw angle. \c
+        // x-axis-direction is 0 rad. Unit [rad]. Range [0...2 pi[
+        //
+        optional Vector3d direction = 1;
+
+        // The wind speed. Unit [m/s]. Range [0...inf[
+        //
+        optional double speed = 2;
+    }
+
+    // Definition of the cloud state, i.e. cloud state and sky visualization settings.
+    //
+    // The total degree of coverage indicates how large the part of the sky vault is which is covered
+    // with clouds altogether. It is given in eighths, because this division is easier to estimate
+    // for the observer. 0 eighths means that there are no traces of clouds in the sky,
+    // 4 eighths means that the sky is covered with clouds up to half, 8 eighths means that the sky is
+    // completely covered with clouds and no sky blue can be recognized.
+    //
+    // For cloud determination, the observer will choose a location from which he can overlook the entire sky.
+    // When determining the total cloud cover, all clouds or parts of clouds, regardless of height and genus,
+    // that are above his location will be added. Aircraft contrails are also counted as cloud cover if they remain
+    // in the sky for more than 15 minutes. On the other hand, fog is not counted as cloud cover.
+    //
+    // With a little practice, the observer can easily determine the total amount of cloud cover.
+    // Problems occur only with scattered clouds or many single clouds (cumulus).
+    // Their cloud cover is often overestimated. On the other hand,
+    // the coverage of thin ice clouds (cirrus) is often underestimated.[3]
+    //
+    // \par References:
+    // [1] ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
+    // [2] https://de.wikipedia.org/wiki/Bewölkung
+    // [3] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
+    //
+    enum CloudState
+    {
+        // Cloud State is unknown (must not be used in ground truth).
+        //
+        CLOUD_STATE_UNKNOWN = 0;
+
+        // Other (unspecified but known) CloudState.
+        //
+        CLOUD_STATE_OTHER = 1;
+
+        // Cloudless (0/8)
+        //
+        CLOUD_STATE_CLOUDLESS = 2;
+
+        // Sunny (1/8)
+        //
+        CLOUD_STATE_SUNNY = 3;
+
+        // Serene (2/8))
+        //
+        CLOUD_STATE_SERENE = 4;
+
+        // Slightly Cloudy (3/8)
+        //
+        CLOUD_STATE_SLIGHTLY_CLOUDY = 5;
+
+        // Light Cloudy (4/8)
+        //
+        CLOUD_STATE_LIGHT_CLOUDY = 6;
+
+        // Cloudy (5/8)
+        //
+        CLOUD_STATE_CLOUDY = 7;
+
+        // Heavy Cloudy (6/8)
+        //
+        CLOUD_STATE_HEAVY_CLOUDY = 8;
+
+        // Almost Covered (7/8)
+        //
+        CLOUD_STATE_ALMOST_COVERED = 9;
+
+        // Covered (8/8)
+        //
+        CLOUD_STATE_COVERED = 10;
+
+        // No Sky
+        //
+        CLOUD_STATE_NO_SKY = 11;
+    }
+
+    //
+    // \brief Specification of sun properties.
+    //
+    // \note Defines the specification of sun properties according to ASAM OpenSCENARIO
+    //
+    message Sun
+    {
+        // Azimuth of the sun, counted counterclockwise, 0=north, PI/2 = east, PI=south, 3/2 PI=west. Unit: radian; Range: [0..2PI].
+        //
+        optional double azimuth = 1;
+
+        // Solar elevation angle, 0=x/y plane, PI/2=zenith. Unit: rad; Range: [-PI..PI].
+        //
+        optional double elevation = 2;
+
+        // Illuminance of the sun, direct sunlight is around 100,00 lx. Unit: lux; Range: [0..inf[.
+        //
+        optional double intensity = 3;
     }
 }

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -338,9 +338,7 @@ message EnvironmentalConditions
     }
 
     //
-    // \brief Specification of the cloud layer.
-    //
-    // \note within this message there is the cloud state level.
+    // \brief Specification of a cloud layer.
     //
     message CloudLayer
     {
@@ -350,7 +348,7 @@ message EnvironmentalConditions
 
         // Defines the cloud state levels given by observation of total cloud amount in oktas.
         //
-        // For visual alignment please call the reference[1]
+        // For visual alignment please see reference[1].
         //
         // The total degree of coverage indicates how large the part of the sky vault is which is covered
         // with clouds altogether. It is given in eighths, because this division is easier to estimate
@@ -439,16 +437,16 @@ message EnvironmentalConditions
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi]
+        // The preferred angular range is [-pi, pi].
         //
         // \note The direction is the origin, not the target direction. \c
         // The range in openSCENARIO is Range [0...2 pi[. Mind the conversion.
         //
-        optional Vector3d origin_direction = 1;
+        optional double origin_direction = 1;
 
         // The wind speed.
         //
-        // Unit m/s
+        // Unit: m/s
         //
         // Range [0...inf[
         //
@@ -466,7 +464,7 @@ message EnvironmentalConditions
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi]
+        // The preferred angular range is [-pi, pi].
         //
         optional double azimuth = 1;
 
@@ -474,11 +472,11 @@ message EnvironmentalConditions
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi]
+        // The preferred angular range is [-pi, pi].
         //
         optional double elevation = 2;
 
-        // Illuminance of the sun, direct sunlight is around 100,00 lx.
+        // Illuminance of the sun, direct sunlight is around 100000 lx.
         //
         // Unit: lx
         //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -342,29 +342,29 @@ message EnvironmentalConditions
     //
     message CloudLayer
     {
-        // Properties of a cloud layer by discrete cloud layer levels.
+        // Properties of a cloud layer given by fractional cloud cover levels.
         //
-        optional FractionalCloudCover cloud_layer_level = 1;
+        optional FractionalCloudCover fractional_cloud_cover = 1;
 
-        // Defines the fractional cloud cover given by observation of total cloud amount in eights (oktas) of the sky.
+        // Defines the fractional cloud cover [1] given by observation of total cloud amount in eights (oktas) of the sky.
         //
-        // For visual alignment please see reference[1].
+        // For visual alignment please see reference[2].
         //
         // The total degree of coverage indicates how much of the sky is covered with clouds altogether.
         // 0 oktas means that there are no traces of clouds in the sky, \c
         // 8 oktas means that the sky is completely covered with clouds and no sky blue can be recognized.
         //
         // \par References:
-        // https://cie.co.at/eilvterm/17-29-116
-        // [1] https://www.eoas.ubc.ca/courses/atsc113/flying/met_concepts/01-met_concepts/01c-cloud_coverage/index.html
+        // [1] CIE engl. International Commission on Illumination. (2020). <em>CIE S017:2020 ILV: Intl. Lighitng Vocabulary, 2nd edn.</em>. Retrieved March 8, 2022, from https://cie.co.at/eilvterm/17-29-116
+        // [2] UBC The University of British Columbia. (2018). <em>ATSC 113 Weather for Sailing, Flying & Snow Sports</em>. Retrieved March 8, 2022, from https://www.eoas.ubc.ca/courses/atsc113/flying/met_concepts/01-met_concepts/01c-cloud_coverage/index.html
         //
         enum FractionalCloudCover
         {
-            // Cloud layer level is unknown (must not be used in ground truth).
+            // Fractional cloud cover level is unknown (must not be used in ground truth).
             //
             FRACTIONAL_CLOUD_COVER_UNKNOWN = 0;
 
-            // Other (unspecified but known) cloud layer level.
+            // Other (unspecified but known) fractional cloud cover level.
             //
             FRACTIONAL_CLOUD_COVER_OTHER = 1;
 
@@ -427,7 +427,7 @@ message EnvironmentalConditions
         // The preferred angular range is [0, 2pi].
         //
         // \par References:
-        // [1] https://proj.org/usage/projections.html#:~:text=E%20%20%20%200dN%200.000-,Axis%20orientation,%C2%B6,-Starting%20in%20PROJ
+        // [1] PROJ contributors. (2019). <em>PROJ coordinate transformation software library</em>. Open Source Geospatial Foundation. Retrieved January 25, 2019, from https://proj.org/usage/projections.html
         //
         optional double origin_direction = 1;
 
@@ -458,7 +458,7 @@ message EnvironmentalConditions
         // The preferred angular range is [0, 2pi].
         //
         // \par References:
-        // [1] https://proj.org/usage/projections.html
+        // [1] PROJ contributors. (2019). <em>PROJ coordinate transformation software library</em>. Open Source Geospatial Foundation. Retrieved January 25, 2019, from https://proj.org/usage/projections.html
         //
         optional double azimuth = 1;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -342,11 +342,11 @@ message EnvironmentalConditions
     //
     message CloudLayer
     {
-        // Definition of the cloud state level, i.e. cloud state and sky visualization settings.
+        // Definition of the cloud layer, i.e. cloud layer level and sky visualization settings.
         //
         optional CloudLayerLevel cloud_layer_level = 1;
 
-        // Defines the cloud state levels given by observation of total cloud amount in oktas.
+        // Defines the cloud layer levels given by observation of total cloud amount in oktas.
         //
         // For visual alignment please see reference[1].
         //
@@ -374,11 +374,11 @@ message EnvironmentalConditions
         //
         enum CloudLayerLevel
         {
-            // Cloud State is unknown (must not be used in ground truth).
+            // Cloud layer level is unknown (must not be used in ground truth).
             //
             CLOUD_LAYER_LEVEL_UNKNOWN = 0;
 
-            // Other (unspecified but known) CloudState.
+            // Other (unspecified but known) cloud layer level.
             //
             CLOUD_LAYER_LEVEL_OTHER = 1;
 
@@ -427,20 +427,21 @@ message EnvironmentalConditions
     //
     // \brief Defines wind properties.
     //
-    // \note Inspired by the wind speed and direction as defined in ASAM OpenSCENARIO.
-    //
     message Wind
     {
         // The origin direction of the wind (not the target direction) in the ground/xy-plane of the \c
-        // world coordinate system. Corresponds to the heading/yaw angle. \c
-        // x-axis-direction is 0 rad.
+        // world coordinate system. Corresponds to the heading/yaw angle, counted counterclockwise. \c
+        // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
+        // then north is pointing in y-axis direction. The default orientation (x, y, z) is easting, northing, up [1].
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi].
+        // The preferred angular range is [0, 2pi].
         //
-        // \note The direction is the origin, not the target direction. \c
-        // The range in openSCENARIO is Range [0...2 pi[. Mind the conversion.
+        // \note The direction is the origin, not the target direction.
+        //
+        // \par References:
+        // [1] https://proj.org/usage/projections.html#:~:text=E%20%20%20%200dN%200.000-,Axis%20orientation,%C2%B6,-Starting%20in%20PROJ
         //
         optional double origin_direction = 1;
 
@@ -456,23 +457,31 @@ message EnvironmentalConditions
     //
     // \brief Specification of sun properties.
     //
-    // \note Aligns with the specification of sun properties according to ASAM OpenSCENARIO.
-    //
     message Sun
     {
         // Azimuth of the sun, counted counterclockwise.
+        // 0 pointing north. If north not explicitly defined via proj4 reference in ground truth, \c
+        // then north is pointing in y-axis direction. The default orientation (x, y, z) is “easting, northing, up” [1].
+        //
+        // \note 0: north; +pi/2: west; pi: south, 3/2 pi: east.
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi].
+        // The preferred angular range is [0, 2pi].
+        //
+        // \par References:
+        // [1] https://proj.org/usage/projections.html#:~:text=E%20%20%20%200dN%200.000-,Axis%20orientation,%C2%B6,-Starting%20in%20PROJ
         //
         optional double azimuth = 1;
 
-        // Solar elevation angle.
+        // Solar elevation angle. Counted in positive direction around x-axis.
+        //
+        // \note This is different to ASAM OpenSCENARIO for an unique definition of azimuth and elevation.\c
+        // 0: xy-plane; +pi/2: zenith.
         //
         // Unit: rad
         //
-        // The preferred angular range is [-pi, pi].
+        // The preferred angular range is [-pi/2, +pi/2].
         //
         optional double elevation = 2;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -23,6 +23,9 @@ message EnvironmentalConditions
     //
     optional TimeOfDay time_of_day = 2;
 
+    // The unix timestamp describes the time and date at the host vehicle's
+    // location, referring to UTC.
+    //
     // The Unix epoch (or Unix time or POSIX time or Unix timestamp) is
     // the number of seconds that have elapsed since January 1, 1970
     // (midnight UTC/GMT [1]), not counting leap seconds [2].

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -105,7 +105,7 @@ message EnvironmentalConditions
     //
     optional Clouds clouds = 10;
 
-    // Definition of the wind properties
+    // Definition of the wind properties.
     //
     optional Wind wind = 11;
 
@@ -338,9 +338,9 @@ message EnvironmentalConditions
     }
 
     //
-    // \brief Specification of the cloud states
+    // \brief Specification of the cloud states.
     //
-    // \note within this message there is the cloud state level
+    // \note within this message there is the cloud state level.
     //
     message Clouds
     {
@@ -364,7 +364,7 @@ message EnvironmentalConditions
         // With a little practice, the observer can easily determine the total amount of cloud cover.
         // Problems occur only with scattered clouds or many single clouds (cumulus).
         // Their cloud cover is often overestimated. On the other hand,
-        // the coverage of thin ice clouds (cirrus) is often underestimated.[3]
+        // the coverage of thin ice clouds (cirrus) is often underestimated [3].
         //
         // \par References:
         // [1] ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
@@ -416,27 +416,33 @@ message EnvironmentalConditions
             // Covered (8/8)
             //
             CLOUD_STATE_LEVEL_COVERED = 10;
-
-            // No Sky
-            //
-            CLOUD_STATE_LEVEL_NO_SKY = 11;
         }
     }
 
     //
     // \brief Defines wind properties.
     //
-    // \note Aligns with the wind speed and direction as defined in ASAM OpenSCENARIO
+    // \note Aligns with the wind speed and direction as defined in ASAM OpenSCENARIO.
     //
     message Wind
     {
         // The target direction of the wind (not the origin direction) in the ground/xy-plane of the \c
         // world coordinate system. Corresponds to the heading/yaw angle. \c
-        // x-axis-direction is 0 rad. Unit [rad]. Range [0...2 pi[
+        // x-axis-direction is 0 rad.
+        //
+        // Unit: rad
+        //
+        // The preferred angular range is [-pi, pi]
+        //
+        // \note The range in openSCENARIO is Range [0...2 pi[. Mind the conversion.
         //
         optional Vector3d direction = 1;
 
-        // The wind speed. Unit [m/s]. Range [0...inf[
+        // The wind speed.
+        //
+        // Unit m/s
+        //
+        // Range [0...inf[
         //
         optional double speed = 2;
     }
@@ -444,29 +450,23 @@ message EnvironmentalConditions
     //
     // \brief Specification of sun properties.
     //
-    // \note Aligns with the specification of sun properties according to ASAM OpenSCENARIO
+    // \note Aligns with the specification of sun properties according to ASAM OpenSCENARIO.
     //
     message Sun
     {
-        // Azimuth of the sun, counted counterclockwise
+        // Azimuth of the sun, counted counterclockwise.
         //
         // Unit: rad
         //
-        // \rules
-        // is_greater_than_or_equal_to: -PI
-        // is_less_than_or_equal_to: 2PI
-        // \endrules
+        // The preferred angular range is [0, 2pi]
         //
         optional double azimuth = 1;
 
-        // Solar elevation angle
+        // Solar elevation angle.
         //
         // Unit: rad
         //
-        // \rules
-        // is_greater_than_or_equal_to: -PI
-        // is_less_than_or_equal_to: PI
-        // \endrules
+        // The preferred angular range is [-pi, pi]
         //
         optional double elevation = 2;
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -346,9 +346,11 @@ message EnvironmentalConditions
     {
         // Definition of the cloud state level, i.e. cloud state and sky visualization settings.
         //
-        optional CloudStateLevel cloud_state_level = 1;
+        optional CloudLayerLevel cloud_layer_level = 1;
 
         // Defines the cloud state levels given by observation of total cloud amount in oktas.
+        //
+        // For visual alignment please call the reference[1]
         //
         // The total degree of coverage indicates how large the part of the sky vault is which is covered
         // with clouds altogether. It is given in eighths, because this division is easier to estimate
@@ -364,58 +366,63 @@ message EnvironmentalConditions
         // With a little practice, the observer can easily determine the total amount of cloud cover.
         // Problems occur only with scattered clouds or many single clouds (cumulus).
         // Their cloud cover is often overestimated. On the other hand,
-        // the coverage of thin ice clouds (cirrus) is often underestimated [3].
+        // the coverage of thin ice clouds (cirrus) is often underestimated [2].
         //
         // \par References:
-        // [1] ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
-        // [2] https://en.wikipedia.org/wiki/Cloud_cover
-        // [3] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
+        // ISO 15469:2004(E) / CIE S 011/E:2003 : Spatial distribution of skylight
+        // https://en.wikipedia.org/wiki/Cloud_cover
+        // [1] https://www.eoas.ubc.ca/courses/atsc113/flying/met_concepts/01-met_concepts/01c-cloud_coverage/index.html
+        // [2] https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv2=100932&lv3=101016
         //
-        enum CloudStateLevel
+        enum CloudLayerLevel
         {
             // Cloud State is unknown (must not be used in ground truth).
             //
-            CLOUD_STATE_LEVEL_UNKNOWN = 0;
+            CLOUD_LAYER_LEVEL_UNKNOWN = 0;
 
             // Other (unspecified but known) CloudState.
             //
-            CLOUD_STATE_LEVEL_OTHER = 1;
+            CLOUD_LAYER_LEVEL_OTHER = 1;
 
             // Cloudless (0/8)
             //
-            CLOUD_STATE_LEVEL_CLOUDLESS = 2;
+            CLOUD_LAYER_LEVEL_0 = 2;
 
             // Sunny (1/8)
             //
-            CLOUD_STATE_LEVEL_SUNNY = 3;
+            CLOUD_LAYER_LEVEL_1 = 3;
 
             // Serene (2/8))
             //
-            CLOUD_STATE_LEVEL_SERENE = 4;
+            CLOUD_LAYER_LEVEL_2 = 4;
 
             // Slightly Cloudy (3/8)
             //
-            CLOUD_STATE_LEVEL_SLIGHTLY_CLOUDY = 5;
+            CLOUD_LAYER_LEVEL_3 = 5;
 
             // Light Cloudy (4/8)
             //
-            CLOUD_STATE_LEVEL_LIGHT_CLOUDY = 6;
+            CLOUD_LAYER_LEVEL_4 = 6;
 
             // Cloudy (5/8)
             //
-            CLOUD_STATE_LEVEL_CLOUDY = 7;
+            CLOUD_LAYER_LEVEL_5 = 7;
 
             // Heavy Cloudy (6/8)
             //
-            CLOUD_STATE_LEVEL_HEAVY_CLOUDY = 8;
+            CLOUD_LAYER_LEVEL_6 = 8;
 
             // Almost Covered (7/8)
             //
-            CLOUD_STATE_LEVEL_ALMOST_COVERED = 9;
+            CLOUD_LAYER_LEVEL_7 = 9;
 
             // Covered (8/8)
             //
-            CLOUD_STATE_LEVEL_COVERED = 10;
+            CLOUD_LAYER_LEVEL_8 = 10;
+
+            // Sky obscured, describes situations where the sky is not perceivable.
+            //
+            CLOUD_LAYER_LEVEL_SKY_OBSCURED = 11;
         }
     }
 

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -462,9 +462,11 @@ message EnvironmentalConditions
         //
         optional double azimuth = 1;
 
-        // Solar elevation angle. Counted in positive direction (clockwise) around xy-plane.
+        // Solar elevation angle.
+        // The elevation angle is positive when the sun is above the xy-plane, negative when
+        // the sun is below the xy-plane.
         //
-        // \note 0: xy-plane; +pi/2: zenith.
+        // \note 0: xy-plane; +pi/2: zenith; -pi/2: nadir.
         //
         // Unit: rad
         //

--- a/osi_environment.proto
+++ b/osi_environment.proto
@@ -384,43 +384,43 @@ message EnvironmentalConditions
             //
             CLOUD_LAYER_LEVEL_OTHER = 1;
 
-            // Cloudless (0/8)
+            // 0/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_0 = 2;
 
-            // Sunny (1/8)
+            // 1/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_1 = 3;
 
-            // Serene (2/8))
+            // 2/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_2 = 4;
 
-            // Slightly Cloudy (3/8)
+            // 3/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_3 = 5;
 
-            // Light Cloudy (4/8)
+            // 4/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_4 = 6;
 
-            // Cloudy (5/8)
+            // 5/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_5 = 7;
 
-            // Heavy Cloudy (6/8)
+            // 6/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_6 = 8;
 
-            // Almost Covered (7/8)
+            // 7/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_7 = 9;
 
-            // Covered (8/8)
+            // 8/8 of the sky is covered with clouds.
             //
             CLOUD_LAYER_LEVEL_8 = 10;
 
-            // Sky obscured, describes situations where the sky is not perceivable.
+            // Sky obscured, describes situations where the sky is not perceivable, e.g. in dense fog.
             //
             CLOUD_LAYER_LEVEL_SKY_OBSCURED = 11;
         }


### PR DESCRIPTION
With this PR we try to fulfill the needs of harmonization of the Issue #544, #577, #578 as well as Issue #255 and the PR #582 
The discussion has been over a year now and we try to merge with small steps.

So far we only added the `Sun`, `CloudState` as well as the `Wind` as messages.
This should help merging this PR in Version V3.5.0. more easily.

There is another PR #601 in order to get the Enum types and continues values for e.g. `Fog`, `Precipitation`, `Ambient Illumination` to V4.0.0. #577 #578 #255 

According to #544 the following data structures were created within this PR:
- Sun:
  - azimuth [rad]
  - elevation [rad]
  - intensity [lx]
- Wind:
   - direction [rad]
   - speed [m/s]
- CloudStates (__enum__):
   - Level 1 - 8 to tell how many clouds cover the blue sky

most of these requirements are form ASAM openSCENARIO