### PR TITLE
Clarifications on curbs and other boundaries with a height

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -440,6 +440,9 @@ message Lane
             // Since it is not intended to be used for normal automotive
             // driving, it should be used in combination with TYPE_NONDRIVING.
             //
+            // \note A typical lane boundary for this lane-subtype has the type
+            // TYPE_CURB_UPPER_EDGE.
+            //
             SUBTYPE_SIDEWALK = 4;
             
             // A lane with parking spaces.
@@ -723,7 +726,10 @@ message LaneBoundary
     // Example: If the points are deducted from a map format, the order of points 
     // is recommended to be in line with the road coordinate (e.g. s-coordinate in 
     // OpenDRIVE). 
-
+    //    
+    // \note For curbs, the boundary line represents the lower edge of the curb and 
+    // not the physical curb itself. 
+    //
     // \note For dashed lines, one \c BoundaryPoint has to be at the start and
     // another at the end of each dashed line segment. The first
     // \c BoundaryPoint defines the beginning of the first dashed lane marking.
@@ -799,6 +805,8 @@ message LaneBoundary
         // \c BoundaryPoint .
         // Used for lines forming lane markings.
         //
+        // \attention Shall not be used for curbs.                 
+        //
         // \image html OSI_LaneBoundaryWidth.svg "" width=600px
         //
         // \note Field need not be set if it is defined previous.
@@ -808,7 +816,10 @@ message LaneBoundary
 
         // The overall height of the lane boundary at the position of the
         // \c BoundaryPoint .
-        // Used for guard rails, curbstone, or similar.
+        // This field can be used for guard rails, curbs, barriers and sound 
+        // barriers and reflects the maximal physical hight of those items and thereby the height
+        // of the boundary line at this point. It does not specify the direction 
+        // in which the height points to; for this the concept of surface lines is used.
         //
         // \image html OSI_LaneBoundaryHeight.svg "" width=600px
         //
@@ -1023,25 +1034,45 @@ message LaneBoundary
             //
             TYPE_SOIL_EDGE = 10;
 
-            // A guard rail.
+            // The guard rail projected to the ground.
             //
             TYPE_GUARD_RAIL = 11;
 
-            // A curb.
+            // A curb. TODO: Suggestion to deprecate with this PR.
             //
             TYPE_CURB = 12;
 
-            // A structure (e.g. building or tunnel wall).
+            // The lower edge of a structure (e.g. building or tunnel wall).
             //
             TYPE_STRUCTURE = 13;
 
-            // A barrier to guide vehicles and to prevent them from entering other lanes (e.g. a concrete barrier on a highway).
+            // The lower edge of a barrier to guide vehicles and to prevent them from entering other lanes (e.g. a concrete barrier on a highway).
             //
             TYPE_BARRIER = 14;
 
-            // A sound barrier.
+            // The lower edge of a sound barrier.
             //
             TYPE_SOUND_BARRIER = 15;
+
+            // The lower edge of a curb.
+            //
+            // \note If a curb stands on its own (no sidewalk attached), it has 
+            // two lower edges.
+            //            
+            TYPE_CURB_LOWER_EDGE = 16;    
+
+            // The upper edge of a curb. 
+            //
+            // Note that the shape of the curb (e.g. a phase)
+            // is currently not supported by OSI. The upper edge reflects the
+            // first point of the curb's cross-section that has the maximum height
+            // (following the profile from the lower edge).
+            // More detailed hight profiles can be supported with surface lines.
+            //
+            // \note If a curb stands on its own (no sidewalk attached), it has 
+            // two upper edges.            
+            //            
+            TYPE_CURB_UPPER_EDGE = 17;                       
         }
 
         // The semantic color of the lane boundary in case of a lane markings.

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -441,7 +441,7 @@ message Lane
             // driving, it should be used in combination with TYPE_NONDRIVING.
             //
             // \note A typical lane boundary for this lane-subtype has the type
-            // TYPE_CURB_UPPER_EDGE.
+            // TYPE_CURB_TOP.
             //
             SUBTYPE_SIDEWALK = 4;
             
@@ -800,9 +800,7 @@ message LaneBoundary
 
         // The overall width of the lane boundary at the position of the
         // \c BoundaryPoint .
-        // Used for lines forming lane markings.
-        //
-        // \attention Shall not be used for curbs.                 
+        // Used for lines forming lane markings.               
         //
         // \image html OSI_LaneBoundaryWidth.svg "" width=600px
         //
@@ -814,9 +812,9 @@ message LaneBoundary
         // The overall height of the lane boundary at the position of the
         // \c BoundaryPoint .
         // This field can be used for guard rails, curbs, barriers and sound 
-        // barriers and reflects the maximal physical hight of those items and thereby the height
+        // barriers and reflects the maximal physical height of those items and thereby the height
         // of the boundary line at this point. It does not specify the direction 
-        // in which the height points to; for this the concept of surface lines is used.
+        // in which the height points to.
         //
         // \image html OSI_LaneBoundaryHeight.svg "" width=600px
         //
@@ -1035,7 +1033,9 @@ message LaneBoundary
             //
             TYPE_GUARD_RAIL = 11;
 
-            // A curb. TODO: Suggestion to deprecate with this PR.
+            // A curb.
+            // 
+            // \attention This field might be deprecated v4.0. 
             //
             TYPE_CURB = 12;
 
@@ -1051,25 +1051,13 @@ message LaneBoundary
             //
             TYPE_SOUND_BARRIER = 15;
 
-            // The lower edge of a curb.
-            //
-            // \note If a curb stands on its own (no sidewalk attached), it has 
-            // two lower edges.
+            // The bottom of a curb.
             //            
-            TYPE_CURB_LOWER_EDGE = 16;    
+            TYPE_CURB_BOTTOM = 16;    
 
-            // The upper edge of a curb. 
-            //
-            // Note that the shape of the curb (e.g. a phase)
-            // is currently not supported by OSI. The upper edge reflects the
-            // first point of the curb's cross-section that has the maximum height
-            // (following the profile from the lower edge).
-            // More detailed hight profiles can be supported with surface lines.
-            //
-            // \note If a curb stands on its own (no sidewalk attached), it has 
-            // two upper edges.            
+            // The top of a curb.          
             //            
-            TYPE_CURB_UPPER_EDGE = 17;                       
+            TYPE_CURB_TOP = 17;                       
         }
 
         // The semantic color of the lane boundary in case of a lane markings.

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -726,9 +726,6 @@ message LaneBoundary
     // Example: If the points are deducted from a map format, the order of points 
     // is recommended to be in line with the road coordinate (e.g. s-coordinate in 
     // OpenDRIVE). 
-    //    
-    // \note For curbs, the boundary line represents the lower edge of the curb and 
-    // not the physical curb itself. 
     //
     // \note For dashed lines, one \c BoundaryPoint has to be at the start and
     // another at the end of each dashed line segment. The first


### PR DESCRIPTION
modifications and clarifications for curbs and other lane boundaries having a 'height'

Signed-off-by: Habedank Clemens <qxs2704@europe.bmw.corp>

﻿#### Reference to a related issue in the repository
Add a reference to a related issue in the repository.

#### Add a description
This PR is a suggestion which was preceded by discussion in the Road Model WP. It is basically reasoned by certain unclarities in the current definition of curbs: 
- Do the boundary points describing a curb lie "inside" the curb on the level of the lower side of the curb? Because a lane boundary has a width going to the left/right from its middle...
- In wich direction points the height? Currently there is no surface definition (see https://github.com/OpenSimulationInterface/open-simulation-interface/pull/436) 
- Is it allowed to have a lane boundary of type curb referenced from the left and the right lane? Should this take the height of the curb into account (e.g. for sidewalk yes, for normal driving lane no)? 

This definition tries to fix those unclarities and needs to be seen in combination with https://github.com/OpenSimulationInterface/open-simulation-interface/pull/600

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [ ] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [ ] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [ ] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
