### PR TITLE
Docu/remove note on singular plural

### DIFF
--- a/doc/architecture/architecture_overview.adoc
+++ b/doc/architecture/architecture_overview.adoc
@@ -29,13 +29,16 @@ The `HostVehicleData` interface describes the measured internal states of a traf
 OSI currently provides only limited support for data structures that describe measured internal states of traffic participants.
 Actuator intentions are currently not covered by OSI and must be handled using a different data description format.
 
-All fields in an interface are set to `optional`.
+NOTE: OSI uses singular instead of plural for `repeated` field names.
+
+NOTE: All fields in an interface are set to `optional`.
 `required` is not used.
+
 This has been done to allow backward-compatible changes in the field.
 Additionally, this is the default behavior in Protocol Buffer version 3 that no longer has the `required` type.
 Setting all fields to `optional` thus ensures update compatibility.
 However, this does not mean that it is optional to fill the field.
 For the purpose of providing a complete interface, all existing fields should be set, unless not setting a field carries a specific meaning, as indicated in the accompanying comment.
 
-All field numbers equal to or greater than 10000 are available for user-specific extensions via custom fields.
+NOTE: All field numbers equal to or greater than 10000 are available for user-specific extensions via custom fields.
 No future evolution of OSI will therefore use field numbers equal to or greater than 10000.

--- a/osi_datarecording.proto
+++ b/osi_datarecording.proto
@@ -14,8 +14,6 @@ message SensorDataSeries
 {
     // List of sensor data messages for subsequent time steps.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated SensorData sensor_data = 1;
 }
 
@@ -26,8 +24,6 @@ message SensorDataSeries
 message SensorDataSeriesList
 {
     // List of sensor data for multiple sensors at subsequent time steps.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated SensorDataSeries sensor = 1;
 }

--- a/osi_detectedlane.proto
+++ b/osi_detectedlane.proto
@@ -19,8 +19,6 @@ message DetectedLane
 
     // A list of candidates for this lane as estimated by the sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CandidateLane candidate = 2;
 
     //
@@ -64,8 +62,6 @@ message DetectedLaneBoundary
 
     // A list of candidates for this lane boundary as estimated by the
     // sensor.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CandidateLaneBoundary candidate = 2;
 

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -21,8 +21,6 @@ message DetectedItemHeader
 
     // The ID of the original detected item in the ground truth.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated Identifier ground_truth_id = 2;
 
     // The estimated probability that this detected item really exists, not
@@ -62,8 +60,6 @@ message DetectedItemHeader
     // \note This information can be determined via the detected entities'
     // detections ( \c ...Detection::object_id = 'this detected item' ) and
     // the sensors (their IDs) to which these detections belong.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated Identifier sensor_id = 6;
 
@@ -115,8 +111,6 @@ message DetectedStationaryObject
 
     // A list of candidates for this stationary object as estimated by the
     // sensor.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CandidateStationaryObject candidate = 4;
 
@@ -220,8 +214,6 @@ message DetectedMovingObject
 
     // A list of candidates for this moving object as estimated by the
     // sensor (e.g. pedestrian, car).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CandidateMovingObject candidate = 8;
 

--- a/osi_detectedoccupant.proto
+++ b/osi_detectedoccupant.proto
@@ -19,8 +19,6 @@ message DetectedOccupant
     // A list of candidates for this occupant as estimated by the
     // sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CandidateOccupant candidate = 2;
 
     //

--- a/osi_detectedroadmarking.proto
+++ b/osi_detectedroadmarking.proto
@@ -55,8 +55,6 @@ message DetectedRoadMarking
     // A list of candidates for this road marking as estimated by the
     // sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CandidateRoadMarking candidate = 4;
 
     // The visual color of the material of the road marking.

--- a/osi_detectedtrafficlight.proto
+++ b/osi_detectedtrafficlight.proto
@@ -39,8 +39,6 @@ message DetectedTrafficLight
     // A list of candidates for this traffic light as estimated by the
     // sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CandidateTrafficLight candidate = 4;
 
     // The visual color of the traffic light.

--- a/osi_detectedtrafficsign.proto
+++ b/osi_detectedtrafficsign.proto
@@ -25,8 +25,6 @@ message DetectedTrafficSign
 
     // A list of additional supplementary sign(s) as detected by the sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated DetectedSupplementarySign supplementary_sign = 3;
 
     //

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -26,19 +26,13 @@ message FeatureData
 
     // Radar detections for multiple radar sensors (sensor fusion).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated RadarDetectionData radar_sensor = 2;
 
     // Lidar detections for multiple lidar sensors (sensor fusion).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated LidarDetectionData lidar_sensor = 3;
 
     // Ultrasonic detections for multiple ultrasonic sensors (sensor fusion).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     // \note Required for ultrasonic sensors: Detections will be send by the
     // emitting ultrasonic sensor, including all indirect detections received
@@ -47,8 +41,6 @@ message FeatureData
     repeated UltrasonicDetectionData ultrasonic_sensor = 4;
 
     // Camera detections for multiple camera sensors (sensor fusion).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CameraDetectionData camera_sensor = 5;
 }
@@ -249,8 +241,6 @@ message RadarDetectionData
 
     // List of radar detections constituting the radar detection list.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated RadarDetection detection = 2;
 }
 
@@ -357,8 +347,6 @@ message LidarDetectionData
     optional SensorDetectionHeader header = 1;
 
     // List of lidar detections.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated LidarDetection detection = 2;
 }
@@ -519,14 +507,10 @@ message UltrasonicDetectionData
 
     // List of ultrasonic detections.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated UltrasonicDetection detection = 2;
 
     // List of ultrasonic indirect detections (sender and receiver sensors are
     // not the same).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated UltrasonicIndirectDetection indirect_detection = 4;
 }
@@ -676,13 +660,9 @@ message CameraDetectionData
 
     // List of camera detections.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CameraDetection detection = 2;
 
     // List of points which are used by detections.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated CameraPoint point = 4;
 }

--- a/osi_groundtruth.proto
+++ b/osi_groundtruth.proto
@@ -75,50 +75,34 @@ message GroundTruth
     // The list of stationary objects (excluding traffic signs and traffic
     // lights).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated StationaryObject stationary_object = 4;
 
     // The list of all other moving objects including all (host) vehicles.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated MovingObject moving_object = 5;
 
     // The list of traffic signs.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated TrafficSign traffic_sign = 6;
 
     // The list of traffic lights.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated TrafficLight traffic_light = 7;
 
     // The list of road surface markings (lane markings are excluded and
     // defined as \c LaneBoundary).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated RoadMarking road_marking = 8;
 
     // The list of lane boundaries.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated LaneBoundary lane_boundary = 9;
 
     // The list of lanes forming a road network.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated Lane lane = 10;
 
     // The list of passengers in the (host) vehicle(s).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated Occupant occupant = 11;
 

--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -29,8 +29,6 @@ message LogicalDetectionData
     // Logical detections are given with respect to the reference frame of the logical/virtual sensor
     // \c SensorView::mounting_position (e.g. center of rear axle of the ego car)
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated LogicalDetection logical_detection = 3;
 }
 

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -408,8 +408,6 @@ message MovingObject
     // \note Might be multiple if the object is switching lanes or moving from
     // one lane into another following lane.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     // \note DEPRECATED: Use assigned_lane_id in MovingObjectClassification
     // instead.
     //

--- a/osi_sensordata.proto
+++ b/osi_sensordata.proto
@@ -198,8 +198,6 @@ message SensorData
     // for reference purposes.  For complex sensors or logic models this
     // can be multiple copies.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated SensorView sensor_view = 8;
 
     // The timestamp of the last real-world measurement (e.g. GT input) that
@@ -226,8 +224,6 @@ message SensorData
     // The list of moving objects detected by the sensor as perceived by
     // the sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated DetectedMovingObject moving_object = 13;
 
     // General information about the \c DetectedTrafficSign .
@@ -236,8 +232,6 @@ message SensorData
 
     // The list of traffic signs detected by the sensor.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated DetectedTrafficSign traffic_sign = 15;
 
     // General information about the \c DetectedTrafficLight .
@@ -245,8 +239,6 @@ message SensorData
     optional DetectedEntityHeader traffic_light_header = 16;
 
     // The list of traffic lights detected by the sensor.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated DetectedTrafficLight traffic_light = 17;
 
@@ -257,8 +249,6 @@ message SensorData
     // The list of road markings detected by the sensor.
     // This excludes lane boundary markings.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated DetectedRoadMarking road_marking = 19;
 
     // General information about the \c DetectedLaneBoundary .
@@ -266,8 +256,6 @@ message SensorData
     optional DetectedEntityHeader lane_boundary_header = 20;
 
     // The list of lane boundary markings detected by the sensor.
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated DetectedLaneBoundary lane_boundary = 21;
 
@@ -277,8 +265,6 @@ message SensorData
 
     // The list of lanes detected by the sensor
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated DetectedLane lane = 23;
 
     // General information about the \c DetectedOccupant .
@@ -286,8 +272,6 @@ message SensorData
     optional DetectedEntityHeader occupant_header = 24;
 
     // The list of occupants of the host vehicle
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated DetectedOccupant occupant = 25;
 

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -131,31 +131,21 @@ message SensorView
 
     // Generic SensorView(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated GenericSensorView generic_sensor_view = 1000;
 
     // Radar-specific SensorView(s).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated RadarSensorView radar_sensor_view = 1001;
 
     // Lidar-specific SensorView(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated LidarSensorView lidar_sensor_view = 1002;
 
     // Camera-specific SensorView(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CameraSensorView camera_sensor_view = 1003;
 
     // Ultrasonic-specific SensorView(s).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated UltrasonicSensorView ultrasonic_sensor_view = 1004;
 }
@@ -187,8 +177,6 @@ message RadarSensorView
     //
     // This field includes one entry for each ray, in left-to-right,
     // top-to-bottom order (think of scan lines in a TV).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated Reflection reflection = 2;
 
@@ -260,8 +248,6 @@ message LidarSensorView
     //
     // This field includes one entry for each ray, in left-to-right,
     // top-to-bottom order (think of scan lines in a TV).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated Reflection reflection = 2;
 

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -201,35 +201,25 @@ message SensorViewConfiguration
 
     // Generic Sensor View Configuration(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated GenericSensorViewConfiguration generic_sensor_view_configuration =
         1000;
 
     // Radar-specific Sensor View Configuration(s).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated RadarSensorViewConfiguration radar_sensor_view_configuration =
         1001;
 
     // Lidar-specific Sensor View Configuration(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated LidarSensorViewConfiguration lidar_sensor_view_configuration =
         1002;
 
     // Camera-specific Sensor View Configuration(s).
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated CameraSensorViewConfiguration camera_sensor_view_configuration =
         1003;
 
     // Ultrasonic-specific Sensor View Configuration(s).
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated UltrasonicSensorViewConfiguration
         ultrasonic_sensor_view_configuration = 1004;
@@ -426,13 +416,9 @@ message RadarSensorViewConfiguration
 
     // This represents the TX antenna diagram
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated AntennaDiagramEntry tx_antenna_diagram = 10;
 
     // This represents the RX antenna diagram
-    //
-    // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated AntennaDiagramEntry rx_antenna_diagram = 11;
 

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -152,8 +152,6 @@ message TrafficSign
     // Additional supplementary signs, e.g. time limits, modifying the traffic
     // sign.
     //
-    // \note OSI uses singular instead of plural for repeated field names.
-    //
     repeated SupplementarySign supplementary_sign = 3;
 
 


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
This PR solves #556.

#### Add a description
It cleans up the docu a lot, as it deletes this common note in a lot of fields on naming convention for repeated fields:
`\note OSI uses singular instead of plural for repeated field names.`

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
