### PR TITLE
Traffic Command Update

### DIFF
--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -65,8 +65,9 @@ message TrafficCommand
 // model that certain actions must or shall be terminated, there are 
 // explicit actions nested inside this message (AbortActionsAction, 
 // EndActionsAction), which hold a reference to the respective actions.
-// It is highly recommended for the scenario engine to handle the state 
-// machine of traffic actions and to use AbortActionsActions / 
+//
+// It is highly recommended that the scenario engine handles the state 
+// machine of traffic actions and uses AbortActionsActions / 
 // EndActionsAction to transfer information to the traffic participant. 
 // Furthermore, the scenario engine shall listen to DismissedActions of 
 // \c TrafficCommandUpdate to reflect this in the evaluation of the 

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -59,12 +59,18 @@ message TrafficCommand
 // regarding that are not part of this message, yet are seen as a task of the 
 // scenario description, for example, OpenSCENARIO. 
 //
-// \note All traffic actions are sent only once just before they are about 
+// \attention All traffic actions are sent only once just before they are about 
 // to start. This is also true, if their execution is expected to 
 // take simulation time. To inform the traffic participant 
 // model that certain actions must or shall be terminated, there are 
 // explicit actions nested inside this message (AbortActionsAction, 
 // EndActionsAction), which hold a reference to the respective actions.
+// It is highly recommended for the scenario engine to handle the state 
+// machine of traffic actions and to use AbortActionsActions / 
+// EndActionsAction to transfer information to the traffic participant. 
+// Furthermore, the scenario engine shall listen to DismissedActions of 
+// \c TrafficCommandUpdate to reflect this in the evaluation of the 
+// scenario run. 
 //
 message TrafficAction
 {

--- a/osi_trafficcommand.proto
+++ b/osi_trafficcommand.proto
@@ -59,19 +59,14 @@ message TrafficCommand
 // regarding that are not part of this message, yet are seen as a task of the 
 // scenario description, for example, OpenSCENARIO. 
 //
-// \attention All traffic actions are sent only once just before they are about 
+// \note All traffic actions are sent only once just before they are about 
 // to start. This is also true, if their execution is expected to 
 // take simulation time. To inform the traffic participant 
 // model that certain actions must or shall be terminated, there are 
 // explicit actions nested inside this message (AbortActionsAction, 
 // EndActionsAction), which hold a reference to the respective actions.
-//
-// It is highly recommended that the scenario engine handles the state 
-// machine of traffic actions and uses AbortActionsActions / 
-// EndActionsAction to transfer information to the traffic participant. 
-// Furthermore, the scenario engine shall listen to DismissedActions of 
-// \c TrafficCommandUpdate to reflect this in the evaluation of the 
-// scenario run. 
+// Futhermore, there exists a \c TrafficCommandUpdate message for the 
+// traffic participant to report back on potentially dismissed actions. 
 //
 message TrafficAction
 {

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -17,11 +17,9 @@ package osi3;
 // This message allows a traffic participant to send feedback if an action 
 // cannot happen as requested by the \c TrafficCommand. Currently, it is out of
 // scope to standardize the exact reason for non-executability or failed execution 
-// because the reason can have multiple explantions. The point in time 
-// for this message to be sent is only restricted to be after (or at the same time) 
-// the \c TrafficCommand with the corresponding traffic action(s) has been sent. The 
-// responsibility for deciding about successful or unsuccessful scenario execution
-// lies fully on the side of the scenario engine.  
+// because the reason can have multiple explanations. The responsibility for deciding 
+// about successful or unsuccessful scenario execution lies fully on the side of the 
+// scenario engine.  
 //
 // \note This interface is currently just a placeholder and could be
 // changed in experimental ways to support semantics of upcoming OpenSCENARIO 
@@ -45,7 +43,17 @@ message TrafficCommandUpdate
     //
     optional Identifier traffic_participant_id = 3;
 
-    // Actions which a traffic participant dismisses.
+    // Actions which a traffic participant dismisses and which are not yet ended or 
+    // aborted by the scenario engine (via a \c TrafficCommand::action.end_actions_action or a 
+    // \c TrafficCommand::action.abort_actions_action). 
+    // Thus, the valid time interval for this action is after the \c TrafficCommand::timestamp
+    // for the respective action, which tells a traffic participant to perform an action, has 
+    // been sent, but must not be after a \c TrafficCommand::timestamp of the respective End-Actions-Action 
+    // or Abort-Actions-Action, which tells a traffic participant to end or abort that action. 
+    //
+    // Furthermore, a \c TrafficCommand::action.end_actions_action or a 
+    // \c TrafficCommand::action.abort_actions_action must not be sent after this action 
+    // (the \c TrafficCommandUpdate::dismissed_action) for a respective action has been sent.
     //
     // \note If more than one dismissed action is supplied it means that
     // multiple actions are regarded as dismissed.
@@ -59,9 +67,9 @@ message TrafficCommandUpdate
     {
         // Dismissed traffic action id from the perspective of this traffic participant, if any.
         //
-        // \note A dismissed traffic action id identifies a \c TrafficAction which cannot be executed or 
-        // completed by the traffic participant. This field must have the same value as 
-        // \c TrafficAction::ActionHeader::action_id of a prior sent \c TrafficCommand and must correspond
+        // \note A dismissed traffic action id identifies a \c TrafficCommand::action which cannot be executed or 
+        // completed by the traffic participant. This field must have the same value as the 
+        // \c ActionHeader::action_id of a prior sent \c TrafficCommand and must correspond
         // to the same traffic participant.
         //
         optional Identifier dismissed_action_id = 1;

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -49,7 +49,7 @@ message TrafficCommandUpdate
     // \note If more than one action id is supplied it means that
     // multiple actions are regarded as dismissed.
     //
-    repeated DismissedAction dismissed_action;
+    repeated DismissedAction dismissed_action = 4;
     
     // 
     // \brief Action which a traffic participant dismisses.
@@ -63,12 +63,12 @@ message TrafficCommandUpdate
         // \c TrafficAction::ActionHeader::action_id of a prior sent \c TrafficCommand and must correspond
         // to the same traffic participant.
         //
-        optional Identifier dismissed_action_id = 4;
+        optional Identifier dismissed_action_id = 1;
 
         // Information about the reason of failure.
         // 
         // \note This is just a custom, informal string without a standardized meaning. 
         //
-        optional string failure_reason = 5;
+        optional string failure_reason = 2;
     }
 }

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -1,0 +1,67 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_version.proto";
+import "osi_common.proto";
+
+package osi3;
+
+//
+// \brief This message enables the traffic participant model to send updates 
+// to the scenario engine about the execution of its received \c TrafficCommand input. While traffic 
+// actions are usually executed successfully by the traffic participant 
+// there may be actions which the traffic participant is not able to execute
+// either for capability or situation-specific reasons. This message gives
+// the traffic participant the basic possiblity to send feedback if an action 
+// cannot happen as requested by the \c TrafficCommand. Currently, it is out of
+// scope to standardize the exact reason for non-executability or failed execution 
+// because the reason can have multiple explantions. The point in time 
+// for this message to be sent is only restricted to be after the \c TrafficCommand  
+// with the corresponding traffic action(s) has been sent. The 
+// responsibility for deciding about successful or unsuccessful scenario execution
+// lies fully on the side of the scenario engine.  
+//
+// \note This interface is currently just a placeholder and could be
+// changed in experimental ways to support semantics of upcoming OpenSCENARIO 
+// versions. 
+//
+message TrafficCommandUpdate
+{
+    // The interface version used by the sender (traffic participant model).
+    //
+    optional InterfaceVersion version = 1;
+
+    // The data timestamp of the simulation environment. Zero time is arbitrary
+    // but must be identical for all messages. Zero time does not need to
+    // coincide with the UNIX epoch. It is recommended to use zero timestamp as 
+    // the starting time point of the simulation.
+    //
+    optional Timestamp timestamp = 2;
+
+    // The ID of this traffic participant which must coincide with a prior sent ID, cf.
+    // \c TrafficCommand::traffic_participant_id.
+    //
+    optional Identifier traffic_participant_id = 3;
+
+    // Dismissed traffic action id(s) from the perspective of a traffic participant, if any.
+    //
+    // \note Dismissed traffic action id(s) identify actions which cannot be executed or 
+    // completed by the traffic participant. If more than one action id is supplied it means that
+    // multiple actions are regarded as dismissed. This field must have the same value(s) as 
+    // \c TrafficAction::ActionHeader::action_id of the prior sent \c TrafficCommand and must correspond
+    // to the same traffic participant.
+    //
+    // \Attention If an action is not dismissed, abortet by the scenario engine with a 
+    // \c TrafficAction::AbortActionsAction or ended by the scenario engine with a
+    // \c TrafficAction::EndActionsAction it is assumed that the traffic participant is 
+    // in the process of executing this action.
+    //
+    repeated Identifier dismissed_action_id = 4;
+
+    // Information about the reason of failure.
+    // 
+    // \note This is just a custom, informal string without a standardized meaning. 
+    //
+    optional string failure_reason = 5; 
+}

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -12,8 +12,9 @@ package osi3;
 // to the scenario engine about the execution of its received \c TrafficCommand input. 
 // While traffic actions are usually executed successfully by the traffic participant,
 // there may be actions which the traffic participant is not able to execute
-// either for capability or situation-specific reasons. This message gives
-// the traffic participant the basic possiblity to send feedback if an action 
+// either for capability or situation-specific reasons. 
+// 
+// This message allows a traffic participant to send feedback if an action 
 // cannot happen as requested by the \c TrafficCommand. Currently, it is out of
 // scope to standardize the exact reason for non-executability or failed execution 
 // because the reason can have multiple explantions. The point in time 
@@ -46,7 +47,7 @@ message TrafficCommandUpdate
 
     // Actions which a traffic participant dismisses.
     //
-    // \note If more than one action id is supplied it means that
+    // \note If more than one dismissed action is supplied it means that
     // multiple actions are regarded as dismissed.
     //
     repeated DismissedAction dismissed_action = 4;
@@ -56,7 +57,7 @@ message TrafficCommandUpdate
     //
     message DismissedAction 
     {
-        // Dismissed traffic action id from the perspective of a traffic participant, if any.
+        // Dismissed traffic action id from the perspective of this traffic participant, if any.
         //
         // \note A dismissed traffic action id identifies a \c TrafficAction which cannot be executed or 
         // completed by the traffic participant. This field must have the same value as 

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -9,16 +9,16 @@ package osi3;
 
 //
 // \brief This message enables the traffic participant model to send updates 
-// to the scenario engine about the execution of its received \c TrafficCommand input. While traffic 
-// actions are usually executed successfully by the traffic participant 
+// to the scenario engine about the execution of its received \c TrafficCommand input. 
+// While traffic actions are usually executed successfully by the traffic participant 
 // there may be actions which the traffic participant is not able to execute
 // either for capability or situation-specific reasons. This message gives
 // the traffic participant the basic possiblity to send feedback if an action 
 // cannot happen as requested by the \c TrafficCommand. Currently, it is out of
 // scope to standardize the exact reason for non-executability or failed execution 
 // because the reason can have multiple explantions. The point in time 
-// for this message to be sent is only restricted to be after the \c TrafficCommand  
-// with the corresponding traffic action(s) has been sent. The 
+// for this message to be sent is only restricted to be after (or at the same time) 
+// the \c TrafficCommand with the corresponding traffic action(s) has been sent. The 
 // responsibility for deciding about successful or unsuccessful scenario execution
 // lies fully on the side of the scenario engine.  
 //
@@ -44,24 +44,31 @@ message TrafficCommandUpdate
     //
     optional Identifier traffic_participant_id = 3;
 
-    // Dismissed traffic action id(s) from the perspective of a traffic participant, if any.
+    // Actions which a traffic participant dismisses.
     //
-    // \note Dismissed traffic action id(s) identify actions which cannot be executed or 
-    // completed by the traffic participant. If more than one action id is supplied it means that
-    // multiple actions are regarded as dismissed. This field must have the same value(s) as 
-    // \c TrafficAction::ActionHeader::action_id of the prior sent \c TrafficCommand and must correspond
-    // to the same traffic participant.
+    // \note If more than one action id is supplied it means that
+    // multiple actions are regarded as dismissed.
     //
-    // \Attention If an action is not dismissed, abortet by the scenario engine with a 
-    // \c TrafficAction::AbortActionsAction or ended by the scenario engine with a
-    // \c TrafficAction::EndActionsAction it is assumed that the traffic participant is 
-    // in the process of executing this action.
-    //
-    repeated Identifier dismissed_action_id = 4;
-
-    // Information about the reason of failure.
+    repeated DismissedAction dismissed_action;
+    
     // 
-    // \note This is just a custom, informal string without a standardized meaning. 
+    // \brief Action which a traffic participant dismisses.
     //
-    optional string failure_reason = 5; 
+    message DismissedAction 
+    {
+        // Dismissed traffic action id from the perspective of a traffic participant, if any.
+        //
+        // \note A dismissed traffic action id identifies a \c TrafficAction which cannot be executed or 
+        // completed by the traffic participant. This field must have the same value as 
+        // \c TrafficAction::ActionHeader::action_id of a prior sent \c TrafficCommand and must correspond
+        // to the same traffic participant.
+        //
+        optional Identifier dismissed_action_id = 4;
+
+        // Information about the reason of failure.
+        // 
+        // \note This is just a custom, informal string without a standardized meaning. 
+        //
+        optional string failure_reason = 5;
+    }
 }

--- a/osi_trafficcommandupdate.proto
+++ b/osi_trafficcommandupdate.proto
@@ -10,7 +10,7 @@ package osi3;
 //
 // \brief This message enables the traffic participant model to send updates 
 // to the scenario engine about the execution of its received \c TrafficCommand input. 
-// While traffic actions are usually executed successfully by the traffic participant 
+// While traffic actions are usually executed successfully by the traffic participant,
 // there may be actions which the traffic participant is not able to execute
 // either for capability or situation-specific reasons. This message gives
 // the traffic participant the basic possiblity to send feedback if an action 
@@ -67,7 +67,7 @@ message TrafficCommandUpdate
 
         // Information about the reason of failure.
         // 
-        // \note This is just a custom, informal string without a standardized meaning. 
+        // \note This is a custom, informal string without a standardized meaning. 
         //
         optional string failure_reason = 2;
     }


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
This PR comes from the SET Level project.

#### Add a description
Offers a basic backchannel for traffic participant models regarding successful/unsuccessful execution of TrafficCommands. Interpretation is then up to the scenario engine. 

**Some questions to ask**:
What is this change?
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
