### PR TITLE
Tweak Doxygen output

### DIFF
--- a/doxygen_config.cmake.in
+++ b/doxygen_config.cmake.in
@@ -15,15 +15,20 @@ RECURSIVE              = YES
 # There is no standard configuration for .proto files documentation.
 # A Doxygen filter for .proto files has to be added under the directory doc/.
 # proto2cpp.py is an external script. See README.md for more informations.
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
+REPEAT_BRIEF           = YES
+ALWAYS_DETAILED_SEC    = YES
 EXTENSION_MAPPING      = proto=C++
 FILE_PATTERNS          = *.proto
 INPUT_FILTER           = "python @FILTER_PROTO2CPP_PY_PATH@/proto2cpp.py"
 HAVE_DOT               = YES
 HIDE_UNDOC_RELATIONS   = NO
 MAX_DOT_GRAPH_DEPTH    = 2
-SORT_MEMBER_DOCS       = YES
+SORT_MEMBER_DOCS       = NO
 USE_MATHJAX            = YES
+
+# Translate \rules and \endrules to something more readable
+ALIASES = "rules=\par Rules\n\code{.unparsed}" "endrules=\endcode"
 
 # If someone wants UML diagrams in the documentation, the next parameter must 
 # be commented in.


### PR DESCRIPTION
- Automatically generate brief output, so the attribute list is more
  informative.
- Do not sort detailed description alphabetically. This means the detailed
  description is in the same order as the attribute list and the source
  file.
- Translate \rules and \endrules to something more readable. As a nice
  side effect, this removes a lot of warnings when building the
  documentation.

Signed-off-by: Thomas Bleher <thomas.tb.bleher@bmw.de>

- [X] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [X] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [X] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [X] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.