### PR TITLE
Dependebility: Bumb protobuf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install `pip3` and missing python packages:
 ```bash
 $ sudo apt-get install python3-pip python3-setuptools
 ```
-Install `protobuf` 3.0.0:
+Install `protobuf`:
 ```bash
 $ sudo apt-get install libprotobuf-dev protobuf-compiler
 ```


### PR DESCRIPTION
@pmai there is a security issue with protobuffer that created an automatic version bumb PR in [osi-validation](https://github.com/OpenSimulationInterface/osi-validation/pull/41). I am wondering three things here:
1) Why not bumb to the newest version [3.19.4](https://github.com/protocolbuffers/protobuf/releases)?
2) Where are the places we have defined the protobuffer version in this repository?
3) Do we need to create a new patch version for OSI?