### PR TITLE
Introducing Operating States

### DIFF
--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -101,35 +101,35 @@ message HostVehicleData
         //
         optional double curb_weight = 1;
 
-        // The operating status of the vehicle.
+        // The operating state of the vehicle.
         //
-        optional OperatingStatus operating_status = 2;
+        optional OperatingState operating_state = 2;
 
-        // Possible operating stati of the vehicle.
+        // Possible operating states of the vehicle.
         //
         enum OperatingStatus
         {
-            // The operating status is unknown.
+            // The operating state is unknown.
             //
-            OPERATING_STATUS_UNKNOWN = 0;
+            OPERATING_STATE_UNKNOWN = 0;
 
-            // The operating status is another one.
+            // The operating state is another one.
             //
-            OPERATING_STATUS_OTHER = 1;
+            OPERATING_STATE_OTHER = 1;
 
             // The minimum electrical state the vehicle reaches after a while.
             // Usually the driver has left the car a few hours ago.
             //
-            OPERATING_STATUS_OFF = 2;
+            OPERATING_STATE_OFF = 2;
 
             // Some electrical consumers are operating e.g. interior lights or radio.
             // Usually the driver sits in the car before or after a drive.
             //
-            OPERATING_STATUS_READY = 3;
+            OPERATING_STATE_READY = 3;
 
             // The electrical state that is necessary to drive the vehicle.
             //
-            OPERATING_STATUS_ON = 4;
+            OPERATING_STATE_ON = 4;
         }
     }
 

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -106,6 +106,7 @@ message HostVehicleData
         optional OperatingState operating_state = 2;
 
         // Possible operating states of the vehicle.
+        // It is user specific which states are used and how their transitions work.
         //
         enum OperatingState
         {
@@ -124,9 +125,9 @@ message HostVehicleData
 
             // Cabin lights and entertainment are off. The vehicle can not be driven.
             // Some ECUs are still operating and not in their minimum electrical sate.
-            // Usually the driver has left the vehicle recently.
+            // Usually the driver has left (and closed) the vehicle recently.
             //
-            OPERATING_STATE_OFF = 3;
+            OPERATING_STATE_STANDBY = 3;
 
             // Some features of the vehicle are available e.g. cabin lights.
             // Entertainment is off and the vehicle can not be driven.

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -51,7 +51,7 @@ message HostVehicleData
     //
     optional BaseMoving location_rmse = 2;
 
-    // The basic parameters of the vehicle.
+    // The basic parameters and overall states of the vehicle.
     //
     optional VehicleBasics vehicle_basics = 3;
 
@@ -88,7 +88,7 @@ message HostVehicleData
     repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
 
     //
-    // \brief The absolute base parameters of the vehicle.
+    // \brief Base parameters and overall states of the vehicle.
     //
     message VehicleBasics
     {
@@ -100,6 +100,37 @@ message HostVehicleData
         // Paragraph 42 of the German Road Traffic Admission Regulations (StVZO).
         //
         optional double curb_weight = 1;
+
+        // The operating status of the vehicle.
+        //
+        optional OperatingStatus operating_status = 2;
+
+        // Possible operating stati of the vehicle.
+        //
+        enum OperatingStatus
+        {
+            // The operating status is unknown.
+            //
+            OPERATING_STATUS_UNKNOWN = 0;
+
+            // The operating status is another one.
+            //
+            OPERATING_STATUS_OTHER = 1;
+
+            // The minimum electrical state the vehicle reaches after a while.
+            // Usually the driver has left the car a few hours ago.
+            //
+            OPERATING_STATUS_OFF = 2;
+
+            // Some electrical consumers are operating e.g. interior lights or radio.
+            // Usually the driver sits in the car before or after a drive.
+            //
+            OPERATING_STATUS_READY = 3;
+
+            // The electrical state that is necessary to drive the vehicle.
+            //
+            OPERATING_STATUS_ON = 4;
+        }
     }
 
     //

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -101,11 +101,11 @@ message HostVehicleData
         //
         optional double curb_weight = 1;
 
-        // The operating state of the vehicle.
+        // The operating state of the vehicle from an user's perspective.
         //
         optional OperatingState operating_state = 2;
 
-        // Possible operating states of the vehicle.
+        // Possible operating states of the vehicle from an user's perspective.
         //
         enum OperatingState
         {
@@ -117,19 +117,36 @@ message HostVehicleData
             //
             OPERATING_STATE_OTHER = 1;
 
-            // The minimum electrical state the vehicle reaches after a while.
-            // Usually the driver has left the car a few hours ago.
+            // The minimum electrical state of the vehicle (and its ECUs).
+            // Usually the driver has left the car a while ago.
             //
-            OPERATING_STATE_OFF = 2;
+            OPERATING_STATE_SLEEP = 2;
 
-            // Some electrical consumers are operating e.g. interior lights or radio.
+            // Cabin lights and entertainment are off. The vehicle can not be driven.
+            // Some ECUs are still operating and not in their minimum electrical sate.
+            // Usually the driver has left the car recently.
+            //
+            OPERATING_STATE_OFF = 3;
+
+            // Some features of the vehicle are available e.g. cabin lights.
+            // Entertainment is off and the vehicle can not be driven.
+            // Usually the driver wants to enter or leave the car.
+            //
+            OPERATING_STATE_BOARDING = 4;
+
+            // Entertainment, navigation or similiar systems can be used by the driver.
+            // The vehicle can not be driven.
             // Usually the driver sits in the car before or after a drive.
             //
-            OPERATING_STATE_READY = 3;
+            OPERATING_STATE_ENTERTAINMENT = 5;
 
             // The electrical state that is necessary to drive the vehicle.
             //
-            OPERATING_STATE_ON = 4;
+            OPERATING_STATE_DRIVING = 6;
+
+            // The electrical state that is necessary for analysis and diagnostics.
+            //
+            OPERATING_STATE_DIAGNOSTIC = 7;
         }
     }
 

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -101,11 +101,11 @@ message HostVehicleData
         //
         optional double curb_weight = 1;
 
-        // The operating state of the vehicle from an user's perspective.
+        // The operating state of the vehicle.
         //
         optional OperatingState operating_state = 2;
 
-        // Possible operating states of the vehicle from an user's perspective.
+        // Possible operating states of the vehicle.
         //
         enum OperatingState
         {
@@ -118,25 +118,25 @@ message HostVehicleData
             OPERATING_STATE_OTHER = 1;
 
             // The minimum electrical state of the vehicle (and its ECUs).
-            // Usually the driver has left the car a while ago.
+            // Usually the driver has left the vehicle a while ago.
             //
             OPERATING_STATE_SLEEP = 2;
 
             // Cabin lights and entertainment are off. The vehicle can not be driven.
             // Some ECUs are still operating and not in their minimum electrical sate.
-            // Usually the driver has left the car recently.
+            // Usually the driver has left the vehicle recently.
             //
             OPERATING_STATE_OFF = 3;
 
             // Some features of the vehicle are available e.g. cabin lights.
             // Entertainment is off and the vehicle can not be driven.
-            // Usually the driver wants to enter or leave the car.
+            // Usually the driver wants to enter or leave the vehicle.
             //
             OPERATING_STATE_BOARDING = 4;
 
             // Entertainment, navigation or similiar systems can be used by the driver.
             // The vehicle can not be driven.
-            // Usually the driver sits in the car before or after a drive.
+            // Usually the driver sits in the vehicle before or after a drive.
             //
             OPERATING_STATE_ENTERTAINMENT = 5;
 

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -107,7 +107,7 @@ message HostVehicleData
 
         // Possible operating states of the vehicle.
         //
-        enum OperatingStatus
+        enum OperatingState
         {
             // The operating state is unknown.
             //


### PR DESCRIPTION
The operating state of the vehicle.

Signed-off-by: Thomas Nader <Thomas.Nader@bmw.de>

#### Add a description
Beyond sheer driving use cases, this extension is needed to show if a vehicle is actually operating or not.
It is an overall state that may turn off or on the electrical consumers in the vehicle.

**Some questions to ask**:
What is this change?
An improvement.
What does it fix?
No bug fix.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
It is a feature, no break.
How has it been tested?
With a similar signal on a HiL(dynamic+RBS) and a mockup.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [ ] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [ ] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [ ] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
