### PR TITLE
620 orientation indicator for camerasensorviewconfiguration

### DIFF
--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -746,7 +746,6 @@ message CameraSensorViewConfiguration
     // Orientation hint for to interpred the image pixel data (EXIF orientation tag)
     //
     // Indicates how this image pixels are to be interpreted
-    // Reference https://web.archive.org/web/20180921145139if_/http://www.cipa.jp:80/std/documents/e/DC-010-2017_E.pdf
     //
     // value    operation to perform on image
     // 1        correct orientation, no adjustment is required
@@ -757,7 +756,10 @@ message CameraSensorViewConfiguration
     // 6        rotate 90 degrees (counterclockwise)
     // 7        rotate 270 degrees (counterclockwise), then flip upside-down
     // 8        rotate 270 degrees (counterclockwise)
-
+    //
+    // \par References
+    // [1] Camera and Imaging Products Association. <em>CIPA DC-010-2017 Exif 2.31 metadata for XMP</em>. Retrieved 04 28, 2022, from https://web.archive.org/web/20180921145139if_/http://www.cipa.jp:80/std/documents/e/DC-010-2017_E.pdf .
+    //
     // \rules
     // is_greater_than_or_equal_to: 1
     // is_less_than_or_equal_to: 8

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -743,6 +743,29 @@ message CameraSensorViewConfiguration
     //
     repeated WavelengthData wavelength_data = 11;
 
+    // Orientation hint for to interpred the image pixel data (EXIF orientation tag)
+    //
+    // Indicates how this image pixels are to be interpreted
+    // Reference https://web.archive.org/web/20180921145139if_/http://www.cipa.jp:80/std/documents/e/DC-010-2017_E.pdf
+    //
+    // value    operation to perform on image
+    // 1        correct orientation, no adjustment is required
+    // 2        horizontal flip: image is mirrored left-right
+    // 3        rotate 180 degrees: image is upside down
+    // 4        vertical flip: image is mirrored top/down
+    // 5        transpose
+    // 6        rotate 90 degrees (counterclockwise)
+    // 7        rotate 270 degrees (counterclockwise), then flip upside-down
+    // 8        rotate 270 degrees (counterclockwise)
+
+    // \rules
+    // is_greater_than_or_equal_to: 1
+    // is_less_than_or_equal_to: 8
+    // \endrules
+    //
+    optional uint32 orientation = 12;
+
+
     // Channel format.
     //
     enum ChannelFormat


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#620 

#### Add a description
add new integer field "orientation" to CameraSensorViewConfiguration, and document the field
I have tested the change locally by compiling the modified .proto file to cpp and python.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.


If you can’t check all of them, please explain why.
=> I am unsure how to perform the CI tests.

If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
