### PR TITLE
Correct documentation of Identifier of ReferenceLine

### DIFF
--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -21,7 +21,7 @@ package osi3;
 //
 message ReferenceLine
 {
-    // The ID of the logical lane.
+    // The ID of the reference line.
     //
     // \note Note ID is global unique.
     //


### PR DESCRIPTION
Fixes a copy-paste error in the documentation.