### PR TITLE
feat(SensorModelling) add pixelcoordinates to CameraPoint

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -1048,6 +1048,14 @@ message CameraPoint
     // Root mean squared error of the measured point.
     //
     optional Spherical3d point_rmse = 3;
+    
+    // pixel-coordinate [x] in corresponding image
+    //
+    optional uint32 pixel_x = 4;
+    
+    // pixel-coordinate [y] in corresponding image
+    //
+    optional uint32 pixel_y = 5;    
 }
 
 // Definition of a basic detection classifications.


### PR DESCRIPTION
refers to #627

Signed-off-by: RIFJo <jochmann@rt.rif-ev.de>

﻿#### Reference to a related issue in the repository
 #627

#### Add a description
add two integer-fields (pixel_x and pixel_y) to CameraPoint message to allow image-coordinate specification for CameraDetectionData. I chose this solution over using Vector2d (because it uses doubles) or creating a custom type "ImageCoordinates" with two integer fields - which would be another good alternative, but i was unsure where (as in "which file") such a type should be placed.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
