### PR TITLE
Adapt ReferenceLine ST definition to avoid transformation ambiguity and discontinuities

### DIFF
--- a/doc/images/OSI_ReferenceLine1.svg
+++ b/doc/images/OSI_ReferenceLine1.svg
@@ -2,63 +2,36 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="175.60274mm"
-   height="188.71796mm"
-   viewBox="0 0 175.60274 188.71796"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="173.05109mm"
+   height="65.034073mm"
+   viewBox="0 0 173.05108 65.034073"
    version="1.1"
    id="svg8"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   sodipodi:docname="s-t-calculation.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="OSI_ReferenceLine1.svg">
   <defs
      id="defs2">
     <marker
-       style="overflow:visible"
-       id="marker1267"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="DotL"
-       inkscape:isstock="true">
-      <path
-         transform="matrix(0.8,0,0,0.8,5.92,0.8)"
-         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         id="path1067" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5074"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="DotM">
-      <path
-         transform="matrix(0.4,0,0,0.4,2.96,0.4)"
-         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         id="path5072" />
-    </marker>
-    <marker
-       inkscape:stockid="DotL"
+       inkscape:stockid="Arrow1Lend"
        orient="auto"
        refY="0"
        refX="0"
-       id="marker4940"
+       id="Arrow1Lend"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path4938"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+         id="path820"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
     </marker>
     <marker
        inkscape:stockid="DotL"
@@ -69,53 +42,26 @@
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path4595"
+         id="path878"
          d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#000f88;fill-opacity:1;fill-rule:evenodd;stroke:#000f88;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)"
+         inkscape:connector-curvature="0" />
     </marker>
     <marker
-       inkscape:stockid="DotM"
+       inkscape:stockid="Arrow1Lend"
        orient="auto"
        refY="0"
        refX="0"
-       id="marker4852"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
-      <path
-         id="path4850"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
-    </marker>
-    <marker
-       inkscape:stockid="DotM"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="marker4818"
+       id="Arrow1Lend-9"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path4816"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
-    </marker>
-    <marker
-       inkscape:stockid="DotM"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="DotM"
-       style="overflow:visible"
-       inkscape:isstock="true">
-      <path
-         id="path4598"
-         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+         id="path820-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
     </marker>
   </defs>
   <sodipodi:namedview
@@ -125,64 +71,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="383.60542"
-     inkscape:cy="348.60363"
+     inkscape:zoom="2.4218407"
+     inkscape:cx="378.71849"
+     inkscape:cy="77.598184"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:object-paths="true"
-     inkscape:snap-intersection-paths="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1171"
-     inkscape:window-x="1920"
+     inkscape:window-width="1916"
+     inkscape:window-height="842"
+     inkscape:window-x="0"
      inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="0"
-     inkscape:snap-global="true"
-     showguides="false"
-     fit-margin-top="5"
-     fit-margin-left="5"
-     fit-margin-right="5"
-     fit-margin-bottom="5"
-     inkscape:snap-text-baseline="false">
-    <sodipodi:guide
-       position="111.73027,20.097646"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label="Measure"
-       orientation="-0.845257,-0.53436"
-       id="guide20214" />
-    <sodipodi:guide
-       position="111.73027,20.097646"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label=""
-       orientation="-0,1"
-       id="guide20216" />
-    <sodipodi:guide
-       position="111.73027,20.097646"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label="Start"
-       orientation="1,0"
-       id="guide20218" />
-    <sodipodi:guide
-       position="98.225272,41.460648"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label="End"
-       orientation="-0,1"
-       id="guide20220" />
-    <sodipodi:guide
-       position="98.225272,41.460648"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label=""
-       orientation="1,0"
-       id="guide20222" />
-    <sodipodi:guide
-       position="111.29327,20.790246"
-       inkscape:color="rgb(167,0,255)"
-       inkscape:label="Crossing 1"
-       orientation="-0.53436,0.845257"
-       id="guide20224" />
-  </sodipodi:namedview>
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -191,6 +90,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -198,177 +98,159 @@
      inkscape:label="Ebene 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-8.60074,-63.836733)">
+     transform="translate(4.3233347,-69.350064)">
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotM);marker-mid:url(#marker4818);marker-end:url(#marker4852)"
-       d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565"
-       id="path3721"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc"
-       inkscape:original-d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-mid:url(#marker1267)"
-       d="m 36.359671,226.9366 -0.04503,-152.161435 0.04503,-5.937429"
-       id="path3723"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.548;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#DotL);marker-mid:url(#DotL);marker-end:url(#DotL);paint-order:normal"
+       d="M -1.2683682,102.1846 93.981632,102.75157 138.72127,84.017084"
+       id="path815"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc" />
+    <circle
+       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path3247"
+       cx="98.289581"
+       cy="130.44498"
+       r="2.4054258" />
+    <circle
+       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path3247-3"
+       cx="88.667885"
+       cy="75.521088"
+       r="2.4054258" />
+    <circle
+       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path3247-6"
+       cx="31.939932"
+       cy="78.728325"
+       r="2.4054258" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 132.54847,226.9366 33.44512,70.237989"
-       id="path3725"
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39687496;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 98.49004,130.44497 -4.508408,-27.6934"
+       id="path3290"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39687496;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 31.939933,78.728321 0.200458,22.851539"
+       id="path3292"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;stroke:#000f88;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotL);marker-end:url(#DotL)"
-       d="M 70.377189,246.33251 66.529644,226.9366"
-       id="path4896"
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499995, 0.79499995;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 88.667885,102.58213 -10e-7,-27.061044"
+       id="path3294"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;stroke:#005621;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4940);marker-end:url(#marker4940)"
-       d="M 102.80288,226.9366 94.595262,208.14915"
-       id="path4936"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.795, 0.795;stroke-dashoffset:0;stroke-opacity:0.38709675"
+       d="M 99.893207,100.57759 88.667884,75.521086"
+       id="path3296"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="94.481003"
+       y="77.926521"
+       id="text3662"><tspan
+         sodipodi:role="line"
+         id="tspan3660"
+         x="94.481003"
+         y="77.926521"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="86.2771"
+       y="133.75755"
+       id="text3666"><tspan
+         sodipodi:role="line"
+         id="tspan3664"
+         x="86.2771"
+         y="133.75755"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="36.349869"
+       y="81.133736"
+       id="text3670"><tspan
+         sodipodi:role="line"
+         id="tspan3668"
+         x="36.349869"
+         y="81.133736"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P1</tspan></text>
+    <circle
+       style="fill:#000000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#808083;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.29838712;paint-order:normal"
+       id="path3247-7"
+       cx="100.04005"
+       cy="129.91692"
+       r="2.4054258" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79500001, 0.79500001;stroke-dashoffset:0;stroke-opacity:0.38709675"
+       d="M 100.2718,129.99515 93.981632,102.75157"
+       id="path3296-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="103.64107"
+       y="129.40108"
+       id="text3666-8"><tspan
+         sodipodi:role="line"
+         id="tspan3664-1"
+         x="103.64107"
+         y="129.40108"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P4</tspan></text>
+    <circle
+       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path3247-3-5"
+       cx="158.56671"
+       cy="94.836052"
+       r="2.4054258" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="146.51065"
+       y="97.780518"
+       id="text3666-8-6"><tspan
+         sodipodi:role="line"
+         id="tspan3664-1-5"
+         x="146.51065"
+         y="97.780518"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P5</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499996, 0.79499996;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 151.13779,78.760134 7.21043,16.092253"
+       id="path3294-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;stroke:#005622;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.265, 0.795;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 36.359671,74.846371 102.80288,226.9366"
-       id="path5044"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 29.079503,102.45616 h 16.38733"
+       id="path8045"
+       inkscape:connector-curvature="0" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot8069"
+       style="fill:black;stroke:none;stroke-opacity:1;stroke-width:1px;stroke-linejoin:miter;stroke-linecap:butt;fill-opacity:1;font-family:'Courier 10 Pitch';font-style:normal;font-weight:normal;font-size:20px;line-height:125%;letter-spacing:0px;word-spacing:0px;-inkscape-font-specification:'Courier 10 Pitch, Normal';font-stretch:normal;font-variant:normal;text-anchor:start;text-align:start;writing-mode:lr"><flowRegion
+         id="flowRegion8071"><rect
+           id="rect8073"
+           width="87.123817"
+           height="33.858559"
+           x="50.787815"
+           y="159.50006" /></flowRegion><flowPara
+         id="flowPara8075"></flowPara></flowRoot>    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-9)"
+       d="M 99.838583,100.11328 115.18304,93.855983"
+       id="path8045-8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;stroke:#001088;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.264583, 0.79375;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 66.529644,226.9366 36.359671,74.846371"
-       id="path5046"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.98790324;stroke-miterlimit:4;stroke-dasharray:0.26499999,1.05999995;stroke-dashoffset:0"
+       d="M 166.58553,72.248139 97.00532,101.4604"
+       id="path12238"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="73.119087"
-       y="246.23586"
-       id="text5180"><tspan
-         sodipodi:role="line"
-         id="tspan5178"
-         x="73.119087"
-         y="246.23586"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P1</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="97.160507"
-       y="209.23372"
-       id="text5184"><tspan
-         sodipodi:role="line"
-         id="tspan5182"
-         x="97.160507"
-         y="209.23372"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="38.95602"
-       y="75.694221"
-       id="text5206"><tspan
-         sodipodi:role="line"
-         id="tspan5204"
-         x="38.95602"
-         y="75.694221"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">I</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="67.295532"
-       y="222.46956"
-       id="text5210"><tspan
-         sodipodi:role="line"
-         id="tspan5208"
-         x="67.295532"
-         y="222.46956"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">P1<tspan
-   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub"
-   id="tspan5212">proj</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="99.530411"
-       y="234.05304"
-       id="text5210-1"><tspan
-         sodipodi:role="line"
-         id="tspan5208-5"
-         x="99.530411"
-         y="234.05304"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2<tspan
-   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub;stroke-width:0.264583"
-   id="tspan5212-1">proj</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="37.249924"
-       y="233.90164"
-       id="text7745"><tspan
-         sodipodi:role="line"
-         id="tspan7743"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="37.249924"
-         y="233.90164">R0</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="134.53453"
-       y="233.85275"
-       id="text7745-6"><tspan
-         sodipodi:role="line"
-         id="tspan7743-4"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="134.53453"
-         y="233.85275">R1</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="167.26143"
-       y="200.1812"
-       id="text7745-3"><tspan
-         sodipodi:role="line"
-         id="tspan7743-3"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="167.26143"
-         y="200.1812">R2</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="149.12575"
-       y="217.43385"
-       id="text21757"><tspan
-         sodipodi:role="line"
-         id="tspan21755"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="149.12575"
-         y="217.43385"
-         rotate="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">Reference line</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="90.009979"
-       y="153.74646"
-       id="text21757-3"><tspan
-         sodipodi:role="line"
-         id="tspan21755-6"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="90.009979"
-         y="153.74646"
-         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R1)</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="13.487052"
-       y="153.64305"
-       id="text21757-3-7"><tspan
-         sodipodi:role="line"
-         id="tspan21755-6-5"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="13.487052"
-         y="153.64305"
-         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R0)</tspan></text>
   </g>
 </svg>

--- a/doc/images/OSI_ReferenceLine1.svg
+++ b/doc/images/OSI_ReferenceLine1.svg
@@ -2,36 +2,63 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="173.05109mm"
-   height="65.034073mm"
-   viewBox="0 0 173.05108 65.034073"
+   width="175.60274mm"
+   height="188.71796mm"
+   viewBox="0 0 175.60274 188.71796"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="OSI_ReferenceLine1.svg">
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="s-t-calculation.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2">
     <marker
-       inkscape:stockid="Arrow1Lend"
+       style="overflow:visible"
+       id="marker1267"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotL"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path1067" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5074"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotM">
+      <path
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path5072" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
        orient="auto"
        refY="0"
        refX="0"
-       id="Arrow1Lend"
+       id="marker4940"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path820"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         inkscape:connector-curvature="0" />
+         id="path4938"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
     </marker>
     <marker
        inkscape:stockid="DotL"
@@ -42,26 +69,53 @@
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path878"
+         id="path4595"
          d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         transform="matrix(0.8,0,0,0.8,5.92,0.8)"
-         inkscape:connector-curvature="0" />
+         style="fill:#000f88;fill-opacity:1;fill-rule:evenodd;stroke:#000f88;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Lend"
+       inkscape:stockid="DotM"
        orient="auto"
        refY="0"
        refX="0"
-       id="Arrow1Lend-9"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4850"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4818"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path820-8"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         inkscape:connector-curvature="0" />
+         id="path4816"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="DotM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4598"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
     </marker>
   </defs>
   <sodipodi:namedview
@@ -71,17 +125,64 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.4218407"
-     inkscape:cx="378.71849"
-     inkscape:cy="77.598184"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="383.60542"
+     inkscape:cy="348.60363"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1916"
-     inkscape:window-height="842"
-     inkscape:window-x="0"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1171"
+     inkscape:window-x="1920"
      inkscape:window-y="0"
-     inkscape:window-maximized="1" />
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:snap-global="true"
+     showguides="false"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     inkscape:snap-text-baseline="false">
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Measure"
+       orientation="-0.845257,-0.53436"
+       id="guide20214" />
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label=""
+       orientation="-0,1"
+       id="guide20216" />
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Start"
+       orientation="1,0"
+       id="guide20218" />
+    <sodipodi:guide
+       position="98.225272,41.460648"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="End"
+       orientation="-0,1"
+       id="guide20220" />
+    <sodipodi:guide
+       position="98.225272,41.460648"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label=""
+       orientation="1,0"
+       id="guide20222" />
+    <sodipodi:guide
+       position="111.29327,20.790246"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Crossing 1"
+       orientation="-0.53436,0.845257"
+       id="guide20224" />
+  </sodipodi:namedview>
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -90,7 +191,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -98,159 +198,177 @@
      inkscape:label="Ebene 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(4.3233347,-69.350064)">
+     transform="translate(-8.60074,-63.836733)">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.548;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#DotL);marker-mid:url(#DotL);marker-end:url(#DotL);paint-order:normal"
-       d="M -1.2683682,102.1846 93.981632,102.75157 138.72127,84.017084"
-       id="path815"
+       style="fill:none;stroke:#000000;stroke-width:0.865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotM);marker-mid:url(#marker4818);marker-end:url(#marker4852)"
+       d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565"
+       id="path3721"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc"
+       inkscape:original-d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-mid:url(#marker1267)"
+       d="m 36.359671,226.9366 -0.04503,-152.161435 0.04503,-5.937429"
+       id="path3723"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc" />
-    <circle
-       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="path3247"
-       cx="98.289581"
-       cy="130.44498"
-       r="2.4054258" />
-    <circle
-       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="path3247-3"
-       cx="88.667885"
-       cy="75.521088"
-       r="2.4054258" />
-    <circle
-       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="path3247-6"
-       cx="31.939932"
-       cy="78.728325"
-       r="2.4054258" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39687496;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 98.49004,130.44497 -4.508408,-27.6934"
-       id="path3290"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39687496;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 31.939933,78.728321 0.200458,22.851539"
-       id="path3292"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 132.54847,226.9366 33.44512,70.237989"
+       id="path3725"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499995, 0.79499995;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 88.667885,102.58213 -10e-7,-27.061044"
-       id="path3294"
+       style="fill:none;stroke:#000f88;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotL);marker-end:url(#DotL)"
+       d="M 70.377189,246.33251 66.529644,226.9366"
+       id="path4896"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.795, 0.795;stroke-dashoffset:0;stroke-opacity:0.38709675"
-       d="M 99.893207,100.57759 88.667884,75.521086"
-       id="path3296"
+       style="fill:none;stroke:#005621;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4940);marker-end:url(#marker4940)"
+       d="M 102.80288,226.9366 94.595262,208.14915"
+       id="path4936"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#005622;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.265, 0.795;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 36.359671,74.846371 102.80288,226.9366"
+       id="path5044"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#001088;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.264583, 0.79375;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 66.529644,226.9366 36.359671,74.846371"
+       id="path5046"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="94.481003"
-       y="77.926521"
-       id="text3662"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="73.119087"
+       y="246.23586"
+       id="text5180"><tspan
          sodipodi:role="line"
-         id="tspan3660"
-         x="94.481003"
-         y="77.926521"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P2</tspan></text>
+         id="tspan5178"
+         x="73.119087"
+         y="246.23586"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P1</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="86.2771"
-       y="133.75755"
-       id="text3666"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="97.160507"
+       y="209.23372"
+       id="text5184"><tspan
          sodipodi:role="line"
-         id="tspan3664"
-         x="86.2771"
-         y="133.75755"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P3</tspan></text>
+         id="tspan5182"
+         x="97.160507"
+         y="209.23372"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="36.349869"
-       y="81.133736"
-       id="text3670"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="38.95602"
+       y="75.694221"
+       id="text5206"><tspan
          sodipodi:role="line"
-         id="tspan3668"
-         x="36.349869"
-         y="81.133736"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P1</tspan></text>
-    <circle
-       style="fill:#000000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#808083;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.29838712;paint-order:normal"
-       id="path3247-7"
-       cx="100.04005"
-       cy="129.91692"
-       r="2.4054258" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79500001, 0.79500001;stroke-dashoffset:0;stroke-opacity:0.38709675"
-       d="M 100.2718,129.99515 93.981632,102.75157"
-       id="path3296-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+         id="tspan5204"
+         x="38.95602"
+         y="75.694221"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">I</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="103.64107"
-       y="129.40108"
-       id="text3666-8"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="67.295532"
+       y="222.46956"
+       id="text5210"><tspan
          sodipodi:role="line"
-         id="tspan3664-1"
-         x="103.64107"
-         y="129.40108"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P4</tspan></text>
-    <circle
-       style="fill:#ff0000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:#8080ff;stroke-width:0.54750001;stroke-miterlimit:15;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="path3247-3-5"
-       cx="158.56671"
-       cy="94.836052"
-       r="2.4054258" />
+         id="tspan5208"
+         x="67.295532"
+         y="222.46956"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">P1<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub"
+   id="tspan5212">proj</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.9375px;line-height:125%;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="146.51065"
-       y="97.780518"
-       id="text3666-8-6"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="99.530411"
+       y="234.05304"
+       id="text5210-1"><tspan
          sodipodi:role="line"
-         id="tspan3664-1-5"
-         x="146.51065"
-         y="97.780518"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.8791666px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.39687496px">P5</tspan></text>
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.39749998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499996, 0.79499996;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 151.13779,78.760134 7.21043,16.092253"
-       id="path3294-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 29.079503,102.45616 h 16.38733"
-       id="path8045"
-       inkscape:connector-curvature="0" />
-    <flowRoot
+         id="tspan5208-5"
+         x="99.530411"
+         y="234.05304"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub;stroke-width:0.264583"
+   id="tspan5212-1">proj</tspan></tspan></text>
+    <text
        xml:space="preserve"
-       id="flowRoot8069"
-       style="fill:black;stroke:none;stroke-opacity:1;stroke-width:1px;stroke-linejoin:miter;stroke-linecap:butt;fill-opacity:1;font-family:'Courier 10 Pitch';font-style:normal;font-weight:normal;font-size:20px;line-height:125%;letter-spacing:0px;word-spacing:0px;-inkscape-font-specification:'Courier 10 Pitch, Normal';font-stretch:normal;font-variant:normal;text-anchor:start;text-align:start;writing-mode:lr"><flowRegion
-         id="flowRegion8071"><rect
-           id="rect8073"
-           width="87.123817"
-           height="33.858559"
-           x="50.787815"
-           y="159.50006" /></flowRegion><flowPara
-         id="flowPara8075"></flowPara></flowRoot>    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-9)"
-       d="M 99.838583,100.11328 115.18304,93.855983"
-       id="path8045-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.98790324;stroke-miterlimit:4;stroke-dasharray:0.26499999,1.05999995;stroke-dashoffset:0"
-       d="M 166.58553,72.248139 97.00532,101.4604"
-       id="path12238"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="37.249924"
+       y="233.90164"
+       id="text7745"><tspan
+         sodipodi:role="line"
+         id="tspan7743"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="37.249924"
+         y="233.90164">R0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="134.53453"
+       y="233.85275"
+       id="text7745-6"><tspan
+         sodipodi:role="line"
+         id="tspan7743-4"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="134.53453"
+         y="233.85275">R1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="167.26143"
+       y="200.1812"
+       id="text7745-3"><tspan
+         sodipodi:role="line"
+         id="tspan7743-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="167.26143"
+         y="200.1812">R2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="149.12575"
+       y="217.43385"
+       id="text21757"><tspan
+         sodipodi:role="line"
+         id="tspan21755"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="149.12575"
+         y="217.43385"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">Reference line</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="90.009979"
+       y="153.74646"
+       id="text21757-3"><tspan
+         sodipodi:role="line"
+         id="tspan21755-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="90.009979"
+         y="153.74646"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R1)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="13.487052"
+       y="153.64305"
+       id="text21757-3-7"><tspan
+         sodipodi:role="line"
+         id="tspan21755-6-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="13.487052"
+         y="153.64305"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R0)</tspan></text>
   </g>
 </svg>

--- a/doc/images/OSI_ReferenceLine2.svg
+++ b/doc/images/OSI_ReferenceLine2.svg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="175.60274mm"
+   height="188.71796mm"
+   viewBox="0 0 175.60274 188.71796"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="s-t-calculation.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="marker1267"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotL"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path1067" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5074"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotM">
+      <path
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path5072" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4940"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4938"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#005621;fill-opacity:1;fill-rule:evenodd;stroke:#005621;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="DotL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4595"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000f88;fill-opacity:1;fill-rule:evenodd;stroke:#000f88;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4850"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4818"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4816"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="DotM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4598"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="383.60542"
+     inkscape:cy="348.60363"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1171"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:snap-global="true"
+     showguides="false"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     inkscape:snap-text-baseline="false">
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Measure"
+       orientation="-0.845257,-0.53436"
+       id="guide20214" />
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label=""
+       orientation="-0,1"
+       id="guide20216" />
+    <sodipodi:guide
+       position="111.73027,20.097646"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Start"
+       orientation="1,0"
+       id="guide20218" />
+    <sodipodi:guide
+       position="98.225272,41.460648"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="End"
+       orientation="-0,1"
+       id="guide20220" />
+    <sodipodi:guide
+       position="98.225272,41.460648"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label=""
+       orientation="1,0"
+       id="guide20222" />
+    <sodipodi:guide
+       position="111.29327,20.790246"
+       inkscape:color="rgb(167,0,255)"
+       inkscape:label="Crossing 1"
+       orientation="-0.53436,0.845257"
+       id="guide20224" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-8.60074,-63.836733)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotM);marker-mid:url(#marker4818);marker-end:url(#marker4852)"
+       d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565"
+       id="path3721"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc"
+       inkscape:original-d="m 36.359671,226.9366 h 96.188799 l 33.16808,-33.48565" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-mid:url(#marker1267)"
+       d="m 36.359671,226.9366 -0.04503,-152.161435 0.04503,-5.937429"
+       id="path3723"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 132.54847,226.9366 33.44512,70.237989"
+       id="path3725"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000f88;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotL);marker-end:url(#DotL)"
+       d="M 70.377189,246.33251 66.529644,226.9366"
+       id="path4896"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#005621;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4940);marker-end:url(#marker4940)"
+       d="M 102.80288,226.9366 94.595262,208.14915"
+       id="path4936"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#005622;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.265, 0.795;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 36.359671,74.846371 102.80288,226.9366"
+       id="path5044"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#001088;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.264583, 0.79375;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 66.529644,226.9366 36.359671,74.846371"
+       id="path5046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="73.119087"
+       y="246.23586"
+       id="text5180"><tspan
+         sodipodi:role="line"
+         id="tspan5178"
+         x="73.119087"
+         y="246.23586"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="97.160507"
+       y="209.23372"
+       id="text5184"><tspan
+         sodipodi:role="line"
+         id="tspan5182"
+         x="97.160507"
+         y="209.23372"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="38.95602"
+       y="75.694221"
+       id="text5206"><tspan
+         sodipodi:role="line"
+         id="tspan5204"
+         x="38.95602"
+         y="75.694221"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">I</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="67.295532"
+       y="222.46956"
+       id="text5210"><tspan
+         sodipodi:role="line"
+         id="tspan5208"
+         x="67.295532"
+         y="222.46956"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">P1<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub"
+   id="tspan5212">proj</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="99.530411"
+       y="234.05304"
+       id="text5210-1"><tspan
+         sodipodi:role="line"
+         id="tspan5208-5"
+         x="99.530411"
+         y="234.05304"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">P2<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;baseline-shift:sub;stroke-width:0.264583"
+   id="tspan5212-1">proj</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="37.249924"
+       y="233.90164"
+       id="text7745"><tspan
+         sodipodi:role="line"
+         id="tspan7743"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="37.249924"
+         y="233.90164">R0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="134.53453"
+       y="233.85275"
+       id="text7745-6"><tspan
+         sodipodi:role="line"
+         id="tspan7743-4"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="134.53453"
+         y="233.85275">R1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="167.26143"
+       y="200.1812"
+       id="text7745-3"><tspan
+         sodipodi:role="line"
+         id="tspan7743-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="167.26143"
+         y="200.1812">R2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="149.12575"
+       y="217.43385"
+       id="text21757"><tspan
+         sodipodi:role="line"
+         id="tspan21755"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="149.12575"
+         y="217.43385"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">Reference line</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="90.009979"
+       y="153.74646"
+       id="text21757-3"><tspan
+         sodipodi:role="line"
+         id="tspan21755-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="90.009979"
+         y="153.74646"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R1)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="13.487052"
+       y="153.64305"
+       id="text21757-3-7"><tspan
+         sodipodi:role="line"
+         id="tspan21755-6-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="13.487052"
+         y="153.64305"
+         rotate="0 0 0 0 0 0 0 0 0 0 0 0">t axis (R0)</tspan></text>
+  </g>
+</svg>

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -91,8 +91,11 @@ message ReferenceLine
     // and a projected point (P_proj) on the polyline. The T axis (projecting
     // axis) is the line going through P and the intersection point (I). I is
     // defined as the intersection of both T axes of two consecutive
-    // ReferenceLinePoints (see example and image below for illustration). The T
-    // coordinate of the point in question is then defined as
+    // ReferenceLinePoints (see example and image below for illustration). If
+    // both T axes of the neighboring ReferenceLinePoint are parallel (so no
+    // intersection point exists), the resulting T axis direction is equal to
+    // the T axis of these ReferenceLinePoints.
+    // The T coordinate of the point in question is then defined as
     // <code>hypot(P.X-P_proj.X,P.Y-P_proj.Y)</code>. The projected point P_proj
     // might either be on a line segment or at an edge between two line segments.
     // The distance is positive if the point is left of the polyline (in
@@ -129,13 +132,14 @@ message ReferenceLine
     // and two points (P1 and P2) not part of the reference line.
     //
     // Calculation of ST for P1:
-    // - Calculate the instersection point I of the T axes of R0 and R1.
+    // - Calculate the intersection point I of the T axes of R0 and R1.
     // - As P1 lies in the sector defined by these T axes it is considered part
     //   of the reference line section between R0 and R1.
     // - The point P1 is projected onto the line segment [R0, R1] via the
     //   straight line through I (by calculating the intersection of the line
     //   segment and the projection axis), resulting in point P1_proj.
-    //   If the T axes are parallel, a simple orthogonal projection is used.
+    //   If the T axes are parallel, projection is applied in the direction of
+    //   these axes.
     // - The S coordinate of P1 is the S coordinate of P1_proj
     // - The T coordinate of P1 is the signed Euclidean distance to P1_proj.
     //

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -37,7 +37,7 @@ message ReferenceLine
 
     // ReferenceLine types
     //
-    // ReferenceLinePoints might be interpreted diffrently depending on the type
+    // ReferenceLinePoints might be interpreted differently depending on the type
     // of the ReferenceLine.
     //
     // See also: "Adding T coordinates"
@@ -47,19 +47,25 @@ message ReferenceLine
         // ReferenceLine is a polyline, where the coordinates of points are
         // calculated by projection onto the nearest point on the line.
         //
+        // \attention DEPRECATED: Due to the shortcomings documenten below, this
+        //            type will be removed in 4.0.0.
+        //
         TYPE_POLYLINE = 0;
 
         // ReferenceLine is a polyline, where the coordinates of points are
-        // calculated using the t axis definition.
+        // calculated using the T axis definition.
+        //
+        // \note If this type is used, ReferenceLinePoint::t_axis_yaw must be set.
         //
         TYPE_POLYLINE_WITH_T_AXIS = 1;
     }
 
     // Points comprising the polyline.
     //
-    // At least 2 points must be given.
+    // At least two points must be given.
     // The polyline is defined as the lines between consecutive points.
-    // Each point has an S coordinate.
+    // Each point has an S coordinate. Other attributes might be set, depending
+    // on the type of the polyline (see Type).
     //
     // ## Rules on the S position
     //
@@ -113,34 +119,68 @@ message ReferenceLine
     // To describe points that are not directly on the polyline, a T coordinate
     // is added. T is the signed 2D distance between the point to describe (P)
     // and a projected point (P_proj) on the polyline. There are two ways of
-    // defining this point, depending on the ReferenceLine type.
+    // defining this point, depending on the ReferenceLine::Type (see below).
     //
-    // ## Nearest point (TYPE_POLYLINE)
-    //
-    // The projection point is the nearest point on the polyline (this point might
-    // either be on a line segment or at an edge between two line segments).
-    //
-    // ## T axis definition (TYPE_POLYLINE_WITH_T_AXIS)
-    //
-    // The T axis (projecting axis) is the line going through P and the
-    // intersection point (I). I is defined as the intersection of both
-    // T axes of two consecutive ReferenceLinePoints (see example and
-    // image below for illustration). If both T axes of the neighboring
-    // ReferenceLinePoint are parallel (so no intersection point exists), the
-    // resulting T axis direction is equal to the T axis of these ReferenceLinePoints.
     // The T coordinate of the point in question is then defined as
     // <code>hypot(P.X-P_proj.X,P.Y-P_proj.Y)</code>. The projected point P_proj
     // might either be on a line segment or at an edge between two line segments.
     // The distance is positive if the point is left of the polyline (in
     // definition direction), negative if it is right of it. The S position of
     // such a point outside the reference line is the same as the S value of the
-    // projected point on the polyline, resulting in all points on a single T
-    // axis having the same S coordinate.
+    // projected point on the polyline.
     //
-    // \note The ST coordinate system shall be defined in 2D only. When
-    // referencing any points (including the reference line), their projection
-    // onto the XY plane shall be considered (but notes on OpenDRIVE compatibility
-    // below should be considered).
+    // ## Nearest point (TYPE_POLYLINE)
+    //
+    // The projection point is the nearest point on the polyline (this point might
+    // either be on a line segment or at an edge between two line segments).
+    //
+    // Notes:
+    // - The "nearest point on the polyline" is determined in 3D (even if the
+    //   resulting T value is only the 2D distance), in order to choose the
+    //   correct point for 3D curves (think reference lines for roads in parking
+    //   decks).
+    // - If there are several "nearest points", the one with the smallest S
+    //   coordinate on the polyline is chosen.
+    //
+    // Example:
+    // \image html OSI_ReferenceLine1.svg "S, T calculation using nearest point"
+    //
+    // This shows a reference line (consisting of three points), and five points
+    // not on the reference line.
+    //
+    // - For \c P1, the situation is clear, since there is exactly one nearest
+    //   point on the polyline. The resulting ST coordinate uniquely maps back
+    //   to \c P1.
+    // - \c P2 has multiple points "nearest points" on the polyline.
+    //   As can be seen here, two  ST coordinates map to \c P2 (red and grey
+    //   dotted line).  Following the rules above, the one with the smallest S
+    //   value is chosen (the red dotted line).
+    // - \c P3 has a unique "nearest point" on the polyline. However, multiple
+    //   points map to the same ST coordinate as that of \c P3, e.g. \c P4
+    //   (drawn in grey).
+    // - Finally, \c P5 shows how the reference line is extended infinitely for
+    //   points that are "outside" the reference line.
+    //
+    // ## T axis definition (TYPE_POLYLINE_WITH_T_AXIS)
+    //
+    // The T axes of the two ReferenceLinePoints of each ReferenceLine segment
+    // define a sector (or strip if parallel) of the plane. A point is associated
+    // with the segment if it lies within this sector. For points being
+    // associated with multiple segments, the actual segment to consider is
+    // determined by the shortest 3D Euclidean distance between the point and the
+    // segments in question.
+    //
+    // The T axis (projecting axis) is the line going through P and the
+    // intersection point (I). I is defined as the intersection of both
+    // T axes of two consecutive ReferenceLinePoints (see example and
+    // image below for illustration).
+    //
+    // Special cases:
+    // 1. If both T axes of the consecutive ReferenceLinePoint are parallel (so
+    //    no intersection point exists), the resulting T axis orientation is equal
+    //    to the T axis of these ReferenceLinePoints.
+    // 2. For the extended lines outside the defined range the projection axis is
+    //    parallel to the T axis of the respective end point.
     //
     // ## Rules on the T axis
     //
@@ -153,25 +193,12 @@ message ReferenceLine
     // - The T axis must be located inside the sectors spanned by rotating the
     //   normal of one neighboring ReferenceLine segment into the normal of the
     //   other ReferenceLine segment on the shortest way.
-    //
-    // ## Defining angles
-    //
-    // Sometimes an angle to a reference line is needed. This shall be defined
-    // as follows:
-    // First the projected point on the polyline is determined, as described
-    // below. If this point is on a line segment, then the angle is calculated
-    // relative to the line segment on which the reference point lays.
-    // If the projected point is at the edge between line segments, then the
-    // angle of the following line shall be chosen.
-    //
-    // ## Converting between world coordinates and ST coordinates
-    //
-    // The above rules define an ST coordinate system across the whole XY plane.
-    // Every XY position has a ST coordinate, but not necessarily a unique ST
-    // coordinate.
+    // - The T axis in the first and the last point of a ReferenceLine has to be
+    //   perpendicular to the first and last segment of the ReferenceLine,
+    //   respectively.
     //
     // Example:
-    // \image html OSI_ReferenceLine1.svg "S, T calculation"
+    // \image html OSI_ReferenceLine2.svg "S, T calculation using T axis"
     //
     // This shows a reference line (consisting of three points \c R0, \c R1 and
     // \c R2) and two points (\c P1 and \c P2) not part of the reference line.
@@ -189,6 +216,22 @@ message ReferenceLine
     // - The T coordinate of \c P1 is the signed Euclidean distance to \c P1_proj.
     //
     // Calculation of \c P2 follows the same pattern.
+    //
+    // ## Defining angles
+    //
+    // Sometimes an angle to a reference line is needed. This shall be defined
+    // as follows:
+    // First the projected point on the polyline is determined, as described
+    // below. If this point is on a line segment, then the angle is calculated
+    // relative to the line segment on which the reference point lays.
+    // If the projected point is at the edge between line segments, then the
+    // angle of the following line shall be chosen.
+    //
+    // ## Converting between world coordinates and ST coordinates
+    //
+    // The above rules define an ST coordinate system across the whole XY plane.
+    // Every XY position has an ST coordinate, but not necessarily a unique ST
+    // coordinate.
     //
     // The sampling of the polyline must be chosen such that the error
     // when converting coordinates is "small enough". The exact needed
@@ -261,7 +304,8 @@ message ReferenceLine
         //
         // Also see image "S, T coordinates" at #poly_line for reference.
         //
-        // \note This field is only set if the type of the reference line is TYPE_POLYLINE_WITH_T_AXIS.
+        // \note This field is only set if the type of the reference line is
+        //       TYPE_POLYLINE_WITH_T_AXIS.
         //
         optional double t_axis_yaw = 3;
     }

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -38,12 +38,12 @@ message ReferenceLine
         // ReferenceLine is a polyline, where the coordinates of points are
         // calculated by projection onto the nearest point on the line.
         //
-        POLYLINE = 0;
+        TYPE_POLYLINE = 0;
 
         // ReferenceLine is a polyline, where the coordinates of points are
         // calculated using the t axis definition.
         //
-        POLYLINE_WITH_T_AXIS = 1;
+        TYPE_POLYLINE_WITH_T_AXIS = 1;
     }
 
     // Points comprising the polyline.
@@ -106,12 +106,12 @@ message ReferenceLine
     // and a projected point (P_proj) on the polyline. There are two ways of
     // defining this point, depending on the ReferenceLine type.
     //
-    // ## Nearest point (Type POLYLINE)
+    // ## Nearest point (TYPE_POLYLINE)
     //
     // The projection point is the nearest point on the polyline (this point might
     // either be on a line segment or at an edge between two line segments).
     //
-    // ## T axis definition (Type POLYLINE_WITH_T_AXIS)
+    // ## T axis definition (TYPE_POLYLINE_WITH_T_AXIS)
     //
     // The T axis (projecting axis) is the line going through P and the
     // intersection point (I). I is defined as the intersection of both
@@ -252,7 +252,7 @@ message ReferenceLine
         //
         // Also see image "S, T coordinates" at #poly_line for reference.
         //
-        // \note This field is only set if the type of the reference line is POLYLINE_WITH_T_AXIS.
+        // \note This field is only set if the type of the reference line is TYPE_POLYLINE_WITH_T_AXIS.
         //
         optional double t_axis_yaw = 3;
     }

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -128,22 +128,22 @@ message ReferenceLine
     // Example:
     // \image html OSI_ReferenceLine1.svg "S, T calculation"
     //
-    // This shows a reference line (consisting of three points R0, R1 and R2)
-    // and two points (P1 and P2) not part of the reference line.
+    // This shows a reference line (consisting of three points \c R0, \c R1 and
+    // \c R2) and two points (\c P1 and \c P2) not part of the reference line.
     //
-    // Calculation of ST for P1:
-    // - Calculate the intersection point I of the T axes of R0 and R1.
-    // - As P1 lies in the sector defined by these T axes it is considered part
-    //   of the reference line section between R0 and R1.
-    // - The point P1 is projected onto the line segment [R0, R1] via the
-    //   straight line through I (by calculating the intersection of the line
-    //   segment and the projection axis), resulting in point P1_proj.
+    // Calculation of ST for \c P1:
+    // - Calculate the intersection point \c I of the T axes of \c R0 and \c R1.
+    // - As \c P1 lies in the sector defined by these T axes it is considered part
+    //   of the reference line section between \c R0 and \c R1.
+    // - The point \c P1 is projected onto the line segment [\c R0, \c R1] via the
+    //   straight line through \c I (by calculating the intersection of the line
+    //   segment and the projection axis), resulting in point \c P1_proj.
     //   If the T axes are parallel, projection is applied in the direction of
     //   these axes.
-    // - The S coordinate of P1 is the S coordinate of P1_proj
-    // - The T coordinate of P1 is the signed Euclidean distance to P1_proj.
+    // - The S coordinate of \c P1 is the S coordinate of \c P1_proj
+    // - The T coordinate of \c P1 is the signed Euclidean distance to \c P1_proj.
     //
-    // Calculation of P2 follows the same pattern.
+    // Calculation of \c P2 follows the same pattern.
     //
     // The sampling of the polyline must be chosen such that the error
     // when converting coordinates is "small enough". The exact needed

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -7,9 +7,9 @@ import "osi_common.proto";
 package osi3;
 
 //
-// \brief A reference line for defining a non-euclidean ST coordinate system
+// \brief A reference line for defining a non-Euclidean ST coordinate system
 //
-// A reference line is a 3D polyline, used for generating a non-euclidean
+// A reference line is a 3D polyline, used for generating a non-Euclidean
 // ST coordinate system.
 //
 // Notes on design decisions:
@@ -43,10 +43,10 @@ message ReferenceLine
     // - Later points in the list must have strictly larger S coordinates than
     //   earlier points.
     // - For consecutive points, the S difference between them  must be at
-    //   least as large as the 2D euclidean distance between the points (2D
-    //   distance == euclidean distance between the points taking only X and Y
+    //   least as large as the 2D Euclidean distance between the points (2D
+    //   distance == Euclidean distance between the points taking only X and Y
     //   into account).
-    // - The S distance between two points may be larger than the 2D euclidean
+    // - The S distance between two points may be larger than the 2D Euclidean
     //   distance, but should be not much larger. It is allowed to be larger if
     //   the underlying reference line (e.g. in an OpenDRIVE map) is a curve,
     //   and thus the sampled reference line has a smaller length than the original
@@ -76,9 +76,9 @@ message ReferenceLine
     // first line of the polyline is infinitely extended in negative S
     // direction.  Similarly, the last line of the polyline is infinitely
     // extended beyond the last point. The S value of points outside [\c
-    // sStart,\c sEnd] is defined by the euclidean 2D distance from the start
+    // sStart,\c sEnd] is defined by the Euclidean 2D distance from the start
     // or end point, respectively.  So if <code>sStart = 15</code>, and a point
-    // is on the line extended from the start position, with a 2D euclidean
+    // is on the line extended from the start position, with a 2D Euclidean
     // distance of 10 from the first point, then it has an S position of 5.
     //
     // A point is "before" the reference line, if its s coordinate is < \c sStart.
@@ -87,31 +87,33 @@ message ReferenceLine
     // ## Adding T coordinates
     //
     // To describe points that are not directly on the polyline, a T coordinate
-    // is added. T is the signed 2D distance (i.e. <code>hypot(A.X-B.X,
-    // A.Y-B.Y)</code>, if A and B are the two points) between the point to
-    // describe and the nearest point on the polyline (this point might either
-    // be on a line segment or at an edge between two line segments). The
-    // distance is positive if the point is left of the polyline (in definition
-    // direction), negative if it is right of it.
-    // The S position of such a point outside the reference line is the same as
-    // the S value of the nearest point on the polyline.
+    // is added. T is the signed 2D distance between the point to describe (P)
+    // and a projected point (P_proj) on the polyline. The T axis (projecting
+    // axis) is the line going through P and the intersection point (I). I is
+    // defined as the intersection of both T axes of two consecutive
+    // ReferenceLinePoints (see example and image below for illustration). The T
+    // coordinate of the point in question is then defined as
+    // <code>hypot(P.X-P_proj.X,P.Y-P_proj.Y)</code>. The projected point P_proj
+    // might either be on a line segment or at an edge between two line segments.
+    // The distance is positive if the point is left of the polyline (in
+    // definition direction), negative if it is right of it. The S position of
+    // such a point outside the reference line is the same as the S value of the
+    // projected point on the polyline, resulting in all points on a single T
+    // axis having the same S coordinate.
     //
-    // Notes:
-    // - The "nearest point on the polyline" is determined in 3D (even if the
-    //   resulting T value is only the 2D distance), in order to choose the
-    //   correct point for 3D curves (think reference lines for roads in parking
-    //   decks).
-    // - If there are several "nearest points", the one with the smallest S
-    //   coordinate on the polyline is chosen.
+    // \note The ST coordinate system shall be defined in 2D only. When
+    // referencing any points (including the reference line), their projection
+    // onto the XY plane shall be considered (but notes on OpenDRIVE compatibility
+    // below should be considered).
     //
     // ## Defining angles
     //
     // Sometimes an angle to a reference line is needed. This shall be defined
     // as follows:
-    // First the nearest point on the polyline is determined, as described
-    // above. If this point is on a line segment, then the angle is calculated
+    // First the projected point on the polyline is determined, as described
+    // below. If this point is on a line segment, then the angle is calculated
     // relative to the line segment on which the reference point lays.
-    // If the nearest point is at the edge between line segments, then the
+    // If the projected point is at the edge between line segments, then the
     // angle of the following line shall be chosen.
     //
     // ## Converting between world coordinates and ST coordinates
@@ -121,23 +123,23 @@ message ReferenceLine
     // coordinate.
     //
     // Example:
-    // \image html OSI_ReferenceLine1.svg
+    // \image html OSI_ReferenceLine1.svg "S, T calculation"
     //
-    // This shows a reference line (consisting of three points), and five points
-    // not on the reference line.
+    // This shows a reference line (consisting of three points R0, R1 and R2)
+    // and two points (P1 and P2) not part of the reference line.
     //
-    // - For \c P1, the situation is clear, since there is exactly one nearest
-    //   point on the polyline. The resulting ST coordinate uniquely maps back
-    //   to \c P1.
-    // - \c P2 has multiple points "nearest points" on the polyline.
-    //   As can be seen here, two  ST coordinates map to \c P2 (red and grey
-    //   dotted line).  Following the rules above, the one with the smallest S
-    //   value is chosen (the red dotted line).
-    // - \c P3 has a unique "nearest point" on the polyline. However, multiple
-    //   points map to the same ST coordinate as that of \c P3, e.g. \c P4
-    //   (drawn in grey).
-    // - Finally, \c P5 shows how the reference line is extended infinitely for
-    //   points that are "outside" the reference line.
+    // Calculation of ST for P1:
+    // - Calculate the instersection point I of the T axes of R0 and R1.
+    // - As P1 lies in the sector defined by these T axes it is considered part
+    //   of the reference line section between R0 and R1.
+    // - The point P1 is projected onto the line segment [R0, R1] via the
+    //   straight line through I (by calculating the intersection of the line
+    //   segment and the projection axis), resulting in point P1_proj.
+    //   If the T axes are parallel, a simple orthogonal projection is used.
+    // - The S coordinate of P1 is the S coordinate of P1_proj
+    // - The T coordinate of P1 is the signed Euclidean distance to P1_proj.
+    //
+    // Calculation of P2 follows the same pattern.
     //
     // The sampling of the polyline must be chosen such that the error
     // when converting coordinates is "small enough". The exact needed
@@ -158,7 +160,7 @@ message ReferenceLine
     // - It is preferable to have the reference line in the center of the road
     //   (e.g. on a highway, it should be in the middle between the two driving
     //   directions). Rationale: this makes S differences better approximate
-    //   euclidean distances, compared to having the reference line at one side
+    //   Euclidean distances, compared to having the reference line at one side
     //   of a curvy road.
     //
     // ## Various notes
@@ -202,6 +204,14 @@ message ReferenceLine
         // S position on the reference line
         //
         optional double s_position = 2;
+
+        // Yaw angle of the T axis in the world coordinate system
+        //
+        // When converting from formats like OpenDRIVE, the yaw angle is equal to
+        // the angle of the normal to the reference line in the sampled point.
+        //
+        // Also see image "S, T coordinates" at #poly_line for reference.
+        //
+        optional double t_axis_yaw = 3;
     }
 }
-

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -31,8 +31,17 @@ message ReferenceLine
     //
     optional Identifier id = 1;
 
+    // The type of the reference line.
+    //
     optional Type type = 3;
 
+    // ReferenceLine types
+    //
+    // ReferenceLinePoints might be interpreted diffrently depending on the type
+    // of the ReferenceLine.
+    //
+    // See also: "Adding T coordinates"
+    //
     enum Type
     {
         // ReferenceLine is a polyline, where the coordinates of points are

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -31,6 +31,21 @@ message ReferenceLine
     //
     optional Identifier id = 1;
 
+    optional Type type = 3;
+
+    enum Type
+    {
+        // ReferenceLine is a polyline, where the coordinates of points are
+        // calculated by projection onto the nearest point on the line.
+        //
+        POLYLINE = 0;
+
+        // ReferenceLine is a polyline, where the coordinates of points are
+        // calculated using the t axis definition.
+        //
+        POLYLINE_WITH_T_AXIS = 1;
+    }
+
     // Points comprising the polyline.
     //
     // At least 2 points must be given.
@@ -88,13 +103,22 @@ message ReferenceLine
     //
     // To describe points that are not directly on the polyline, a T coordinate
     // is added. T is the signed 2D distance between the point to describe (P)
-    // and a projected point (P_proj) on the polyline. The T axis (projecting
-    // axis) is the line going through P and the intersection point (I). I is
-    // defined as the intersection of both T axes of two consecutive
-    // ReferenceLinePoints (see example and image below for illustration). If
-    // both T axes of the neighboring ReferenceLinePoint are parallel (so no
-    // intersection point exists), the resulting T axis direction is equal to
-    // the T axis of these ReferenceLinePoints.
+    // and a projected point (P_proj) on the polyline. There are two ways of
+    // defining this point, depending on the ReferenceLine type.
+    //
+    // ## Nearest point (Type POLYLINE)
+    //
+    // The projection point is the nearest point on the polyline (this point might
+    // either be on a line segment or at an edge between two line segments).
+    //
+    // ## T axis definition (Type POLYLINE_WITH_T_AXIS)
+    //
+    // The T axis (projecting axis) is the line going through P and the
+    // intersection point (I). I is defined as the intersection of both
+    // T axes of two consecutive ReferenceLinePoints (see example and
+    // image below for illustration). If both T axes of the neighboring
+    // ReferenceLinePoint are parallel (so no intersection point exists), the
+    // resulting T axis direction is equal to the T axis of these ReferenceLinePoints.
     // The T coordinate of the point in question is then defined as
     // <code>hypot(P.X-P_proj.X,P.Y-P_proj.Y)</code>. The projected point P_proj
     // might either be on a line segment or at an edge between two line segments.
@@ -227,6 +251,8 @@ message ReferenceLine
         // the angle of the normal to the reference line in the sampled point.
         //
         // Also see image "S, T coordinates" at #poly_line for reference.
+        //
+        // \note This field is only set if the type of the reference line is POLYLINE_WITH_T_AXIS.
         //
         optional double t_axis_yaw = 3;
     }

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -12,6 +12,11 @@ package osi3;
 // A reference line is a 3D polyline, used for generating a non-Euclidean
 // ST coordinate system.
 //
+// \note This ST coordinate system is specific to OSI and not to be confused with
+//       similar definitions in other standards like OpenDRIVE or OpenSCENARIO 1.x.
+//       Nevertheless the goal of this definition is to approximate the source
+//       coordinates (e.g. OpenDRIVE).
+//
 // Notes on design decisions:
 // - This is a polyline, and not some more complex curve. The advantage of a
 //   polyline is that it is very simple to generate from various map formats,

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -109,6 +109,18 @@ message ReferenceLine
     // onto the XY plane shall be considered (but notes on OpenDRIVE compatibility
     // below should be considered).
     //
+    // ## Rules on the T axis
+    //
+    // For the T axis at a specific ReferenceLinePoint the following rules apply:
+    // - The T axis shall be close to the angle bisector (to the left in S
+    //   direction) of the neighboring ReferenceLine segments.
+    // - Small deviations from the angle bisector are allowed (e.g. to represent
+    //   the T axis of OpenDRIVE, which is perpendicular to the OpenDRIVE
+    //   reference line).
+    // - The T axis must be located inside the sectors spanned by rotating the
+    //   normal of one neighboring ReferenceLine segment into the normal of the
+    //   other ReferenceLine segment on the shortest way.
+    //
     // ## Defining angles
     //
     // Sometimes an angle to a reference line is needed. This shall be defined


### PR DESCRIPTION
This addresses #645 

Current definition of s,t coordinates has some (well documented) downsides, which we would like to mitigate with this proposed change. With the updated s,t definition, x,y <-> s,t associations are unique inside the lane geometries and there are no gaps in the s coordinate anymore.

This approach is used and tested by [openPASS ](https://gitlab.eclipse.org/eclipse/simopenpass/simopenpass).

Checks will follow (but the links to `howtocontribute.html` seem to be dead... where to get this information?)

- [ ] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.


