### PR TITLE
Add DAY to TrafficSign-Value-Unit and change DAY to WEEKDAY

### DIFF
--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -103,7 +103,7 @@ message TrafficSignValue
         UNIT_SHORT_TON = 11;
 
         // Time of day.
-        // Hour since midnight.
+        // Minutes since last hour.
         //
         // Unit: min
         //

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -124,6 +124,13 @@ message TrafficSignValue
         // Day of the month.
         //
         UNIT_DAY = 15;
+
+        // Time of day.
+        // Hour since midnight.
+        //
+        // Unit: h
+        //
+        UNIT_HOUR = 15;
     }
 
     // Text associated with a sign, e.g. the name of a location whose distance

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -112,7 +112,7 @@ message TrafficSignValue
         // Day of the week.
         // Days since Monday. Monday = 0; Tuesday = 1; ...
         //
-        UNIT_DAY = 13;
+        UNIT_WEEKDAY = 13;
 
         // Percentage.
         // Value.
@@ -120,6 +120,10 @@ message TrafficSignValue
         // Unit: %
         //
         UNIT_PERCENTAGE = 14;
+
+        // Day of the month.
+        //
+        UNIT_DAY = 15;
     }
 
     // Text associated with a sign, e.g. the name of a location whose distance

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -101,18 +101,32 @@ message TrafficSignValue
         // Unit: tn. sh.
         //
         UNIT_SHORT_TON = 11;
+        
+        // Time of day.
+        // Hours since midnight. Starting with 0.
+        //
+        // Unit: h
+        //
+        UNIT_HOUR = 15;
 
         // Time of day.
-        // Minutes since last hour.
+        // Minutes since last hour. Starting with 0.
         //
         // Unit: min
         //
         UNIT_MINUTES = 12;
+        
+        // Day of the month.
+        // Starting with 1.
+        //
+        UNIT_DAY_OF_MONTH = 16;
 
         // Day of the week.
         // Days since Monday. Monday = 0; Tuesday = 1; ...
         //
-        UNIT_WEEKDAY = 13;
+        // \note For consistency this field will be renamed to UNIT_DAY_OF_WEEK in v4.0.0 .
+        //
+        UNIT_DAY = 13;
 
         // Percentage.
         // Value.
@@ -120,17 +134,24 @@ message TrafficSignValue
         // Unit: %
         //
         UNIT_PERCENTAGE = 14;
-
-        // Day of the month.
+        
+        // Duration in days.
         //
-        UNIT_DAY = 15;
-
-        // Time of day.
-        // Hour since midnight.
+        // Unit: day
+        //
+        UNIT_DURATION_DAY = 17;
+        
+        // Duration in hours.
         //
         // Unit: h
         //
-        UNIT_HOUR = 16;
+        UNIT_DURATION_HOUR = 18;
+        
+        // Duration in minutes.
+        //
+        // Unit: min
+        //
+        UNIT_DURATION_MINUTE = 19;
     }
 
     // Text associated with a sign, e.g. the name of a location whose distance

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -130,7 +130,7 @@ message TrafficSignValue
         //
         // Unit: h
         //
-        UNIT_HOUR = 15;
+        UNIT_HOUR = 16;
     }
 
     // Text associated with a sign, e.g. the name of a location whose distance


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository

Issue: #635

#### Add a description
ASAM OSI and ISO 23150 or AUTOSAR ADI have a common history. Unfortunately, the inner structure, the naming and the definitions of the standards are differentiated from each other. This makes the work of developers unnecessary complicated for mostly no technical reasons. All sides should strive to reduce inequality.

osi_trafficsign.proto message TrafficSignValue { enum Unit } need an entry which describes the day of the month.

Furthermore, the type need a entry kHour which describe the hour of the day.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html).
- [x] I have taken care about the [documentation](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/commenting.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

The checks will follow.

#### Additional context

ISO23150:2021A.2.67 Sign value unit:

@ThomasNaderBMW @jdsika @schmidtlorenz
