### PR TITLE
Fix path to asciidoc-resources

### DIFF
--- a/doc/_config.adoc
+++ b/doc/_config.adoc
@@ -6,7 +6,7 @@
 ifndef::root-path[:root-path: ./]
 
 :partials-path: {root-path}../_additional_content
-:asciidoc-resources: ../asciidoc-resources
+:asciidoc-resources: ../../asciidoc-resources
 :appendix-caption: Annex
 :page-feedbackurl: https://github.com/OpenSimulationInterface/open-simulation-interface/issues/new
 


### PR DESCRIPTION
Quick Fix for Asciidoctor build