### PR TITLE
Add new enum Type in vehicle classification for stand-up scooters

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -865,8 +865,9 @@ message MovingObject
             // Vehicle is a wheelchair.
             //
             TYPE_WHEELCHAIR = 15;
-			
-            // Vehicle is a stand-up or kickboard scooter, including motorized versions.
+
+            // Vehicle is a stand-up or kickboard scooter, including
+            // motorized versions.
             //
             TYPE_STANDUP_SCOOTER = 17;
         }

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -865,6 +865,10 @@ message MovingObject
             // Vehicle is a wheelchair.
             //
             TYPE_WHEELCHAIR = 15;
+			
+            // Vehicle is a stand-up or kickboard scooter, including motorized versions.
+            //
+            TYPE_STANDUP_SCOOTER = 17;
         }
 
         //


### PR DESCRIPTION
feat(vehicle classifications): add classification for stand-up scooters, motivated by possible NCAP target type

﻿#### Reference to a related issue in the repository
refers to issue #673

#### Add a description
This adds a new enum Type in vehicle classification for stand-up or kickboard scooters.


#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [/] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [/] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [/] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

