### PR TITLE
Update host vehicle data with kinematics data

### DIFF
--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -86,6 +86,11 @@ message HostVehicleData
     // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
+    
+    // Interface regarding the vehicle kinematics.
+    //
+    optional VehicleKinematics vehicle_kinematics = 13; 
+
 
     //
     // \brief Base parameters and overall states of the vehicle.
@@ -336,6 +341,31 @@ message HostVehicleData
         //
         optional GeodeticPosition geodetic_position = 3;
     }
+
+    //
+    // \brief Current calculated and estimated acceleration, velocity and orientation rate on Inertial Measurement Unit measurements and related sensors.
+    //
+    // This message contains the most accurate information the vehicle knows about its velocity, 
+    // acceleration and orientation rate available in the on-board network.
+    //   
+    message VehicleKinematics
+    {
+        // Most accurate velocity information of the vehicle, available in the on-board network.
+        // The velocity is represented in context to the coordinate system of the vehicle.
+        //
+        optional Vector3d velocity = 1;
+
+        // Most accurate acceleration information of the vehicle, available in the on-board network.
+        // The acceleration is represented in context to the coordinate system of the vehicle.
+        //
+        optional Vector3d acceleration = 2;
+
+        // Most accurate orientation rate of the vehicle, available in the on-board network.
+        // The orientation rate is represented in context to the coordinate system of the vehicle.
+        //
+        optional Orientation3d orientation_rate = 3;
+    }
+
 
     //
     // \brief State of one automated driving function on the host vehicle.

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -328,12 +328,12 @@ message HostVehicleData
     message VehicleLocalization
     {
         // Most accurate position information of the vehicle available in the on-board network
-        // in context to the global coordinate system.
+        // measured in context to the global coordinate system.
         //
         optional Vector3d position = 1;
 
         // Most accurate orientation information of the vehicle available in the on-board network
-        // in context to the global coordinate system.
+        // measured in context to the global coordinate system.
         //
         optional Orientation3d orientation = 2;
 

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -323,10 +323,11 @@ message HostVehicleData
     // Because of this the values can differ from the "true" values calculated out of
     // GroundTruth::proj_string, GroundTruth::MovingObject::BaseMoving::position, GroundTruth::host_vehicle_id.
     //
+    // This data uses the reference point coincident with the center (x,y,z) of the bounding box.
+    //
     message VehicleLocalization
     {
-        // Most accurate position information of the vehicle available in the on-board network.
-        // The reference point for position, that is, the center (x,y,z) of the bounding box
+        // Most accurate position information of the vehicle available in the on-board network
         // in context to the global coordinate system.
         //
         optional Vector3d position = 1;
@@ -349,10 +350,8 @@ message HostVehicleData
     // including vehicle dynamics and control related information available in the on-board network,
     // which can differ from the "true" values calculated out of the ground truth.
     //
-    // This data uses the reference point coincident with the midpoint of rear axle, defined by the following coordinates: 
-    // x: Position of rear axle 
-    // y: Vehicle longitudinal centerline
-    // z: Wheel center of rear axle
+    // This data uses the reference point coincident with the middle (in x, y and z) of rear axle 
+    // under neutral load conditions as defined in \c MovingObject::VehicleAttributes::bbcenter_to_rear.
     //
     message VehicleMotion
     {
@@ -365,28 +364,28 @@ message HostVehicleData
         // measured on the vehicle coordinate system in context of the global inertial system.
         //
         optional Orientation3d orientation = 2;
-        
-        // Most accurate curvature currently followed by vehicle and available in the on-board network
+
+        // Most accurate velocity information of the vehicle, available in the on-board network
+        // measured on the vehicle coordinate system in context of the global inertial system.
         //
-        // Unit: m^-1
-        //
-        optional double current_curvature = 3;
-                
+        optional Vector3d velocity = 3;
+
         // Most accurate orientation rate of the vehicle, available in the on-board network
         // measured on the vehicle coordinate system in context of the global inertial system.
         //
         optional Orientation3d orientation_rate = 4;
-        
-        // Most accurate velocity information of the vehicle, available in the on-board network
-        // measured on the vehicle coordinate system in context of the global inertial system.
-        //
-        optional Vector3d velocity = 5;
 
         // Most accurate acceleration information of the vehicle, available in the on-board network
         // measured on the vehicle coordinate system in context of the global inertial system.
         //
-        optional Vector3d acceleration = 6;
-
+        optional Vector3d acceleration = 5;
+                
+        // Most accurate curvature currently followed by vehicle and available in the on-board network
+        //
+        // Unit: m^-1
+        //
+        optional double current_curvature = 6;
+                
     }
 
     //

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -86,11 +86,6 @@ message HostVehicleData
     // \note OSI uses singular instead of plural for repeated field names.
     //
     repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
-    
-    // Interface regarding the vehicle kinematics.
-    //
-    optional VehicleKinematics vehicle_kinematics = 13; 
-
 
     //
     // \brief Base parameters and overall states of the vehicle.
@@ -316,10 +311,10 @@ message HostVehicleData
     }
 
     //
-    // \brief Current calculated and estimated location that can be based on GNSS and related navigation sensors.
+    // \brief Current calculated and estimated location, velocity and acceleration that can be based on GNSS, IMU and related navigation sensors.
     // This message does not contain the individual sensor values of the sensor technology.
     //
-    // This message contains the most accurate information the vehicle knows about its position
+    // This message contains the most accurate information the vehicle knows about its position, velocity and acceleration 
     // available in the on-board network.
     // Because of this the values can differ from the "true" values calculated out of
     // GroundTruth::proj_string, GroundTruth::MovingObject::BaseMoving::position, GroundTruth::host_vehicle_id.
@@ -340,32 +335,33 @@ message HostVehicleData
         // Most accurate geodetic information of the vehicle available in the on-board network.
         //
         optional GeodeticPosition geodetic_position = 3;
-    }
-
-    //
-    // \brief Current calculated and estimated acceleration, velocity and orientation rate on Inertial Measurement Unit measurements and related sensors.
-    //
-    // This message contains the most accurate information the vehicle knows about its velocity, 
-    // acceleration and orientation rate available in the on-board network.
-    //   
-    message VehicleKinematics
-    {
-        // Most accurate velocity information of the vehicle, available in the on-board network.
-        // The velocity is represented in context to the coordinate system of the vehicle.
+        
+        // Most accurate curvature currently followed by vehicle and available in the on-board network,
+        // measured from a localization system.
         //
-        optional Vector3d velocity = 1;
+        // Reference point: car body point coincident with the midpoint of rear axle in design configuration, defined by the following coordinates: 
+        // x: Position of rear axle 
+        // y: Vehicle longitudinal centerline
+        // z: Wheel center of rear axle
+        //
+        optional double current_curvature = 4;
+                
+        // Most accurate orientation rate of the vehicle, available in the on-board network.
+        // Measured along the vehicle orientation in context of the global inertial system.
+        //
+        optional Orientation3d orientation_rate = 5;
+        
+        // Most accurate velocity information of the vehicle, available in the on-board network.
+        // Measured along the vehicle orientation in context of the global inertial system.
+        //
+        optional Vector3d velocity = 6;
 
         // Most accurate acceleration information of the vehicle, available in the on-board network.
-        // The acceleration is represented in context to the coordinate system of the vehicle.
+        // Measured along the vehicle orientation in context of the global inertial system.
         //
-        optional Vector3d acceleration = 2;
+        optional Vector3d acceleration = 7;
 
-        // Most accurate orientation rate of the vehicle, available in the on-board network.
-        // The orientation rate is represented in context to the coordinate system of the vehicle.
-        //
-        optional Orientation3d orientation_rate = 3;
     }
-
 
     //
     // \brief State of one automated driving function on the host vehicle.

--- a/osi_hostvehicledata.proto
+++ b/osi_hostvehicledata.proto
@@ -87,6 +87,10 @@ message HostVehicleData
     //
     repeated VehicleAutomatedDrivingFunction vehicle_automated_driving_function = 12;
 
+    // Interface regarding the vehicle motion.
+    //
+    optional VehicleMotion vehicle_motion = 13;
+
     //
     // \brief Base parameters and overall states of the vehicle.
     //
@@ -311,10 +315,10 @@ message HostVehicleData
     }
 
     //
-    // \brief Current calculated and estimated location, velocity and acceleration that can be based on GNSS, IMU and related navigation sensors.
+    // \brief Current calculated and estimated location that can be based on GNSS and related navigation sensors.
     // This message does not contain the individual sensor values of the sensor technology.
     //
-    // This message contains the most accurate information the vehicle knows about its position, velocity and acceleration 
+    // This message contains the most accurate information the vehicle knows about its position
     // available in the on-board network.
     // Because of this the values can differ from the "true" values calculated out of
     // GroundTruth::proj_string, GroundTruth::MovingObject::BaseMoving::position, GroundTruth::host_vehicle_id.
@@ -335,31 +339,53 @@ message HostVehicleData
         // Most accurate geodetic information of the vehicle available in the on-board network.
         //
         optional GeodeticPosition geodetic_position = 3;
-        
-        // Most accurate curvature currently followed by vehicle and available in the on-board network,
-        // measured from a localization system.
-        //
-        // Reference point: car body point coincident with the midpoint of rear axle in design configuration, defined by the following coordinates: 
-        // x: Position of rear axle 
-        // y: Vehicle longitudinal centerline
-        // z: Wheel center of rear axle
-        //
-        optional double current_curvature = 4;
-                
-        // Most accurate orientation rate of the vehicle, available in the on-board network.
-        // Measured along the vehicle orientation in context of the global inertial system.
-        //
-        optional Orientation3d orientation_rate = 5;
-        
-        // Most accurate velocity information of the vehicle, available in the on-board network.
-        // Measured along the vehicle orientation in context of the global inertial system.
-        //
-        optional Vector3d velocity = 6;
 
-        // Most accurate acceleration information of the vehicle, available in the on-board network.
-        // Measured along the vehicle orientation in context of the global inertial system.
+    }
+
+    //
+    // \brief Current calculated and estimated motion related information.
+    //
+    // This message contains the most accurate information the vehicle knows about its motion
+    // including vehicle dynamics and control related information available in the on-board network,
+    // which can differ from the "true" values calculated out of the ground truth.
+    //
+    // This data uses the reference point coincident with the midpoint of rear axle, defined by the following coordinates: 
+    // x: Position of rear axle 
+    // y: Vehicle longitudinal centerline
+    // z: Wheel center of rear axle
+    //
+    message VehicleMotion
+    {
+        // Most accurate position of the vehicle available in the on-board network
+        // measured in the cartesian global coordinate system.
         //
-        optional Vector3d acceleration = 7;
+        optional Vector3d position = 1;
+
+        // Most accurate orientation information of the vehicle available in the on-board network
+        // measured on the vehicle coordinate system in context of the global inertial system.
+        //
+        optional Orientation3d orientation = 2;
+        
+        // Most accurate curvature currently followed by vehicle and available in the on-board network
+        //
+        // Unit: m^-1
+        //
+        optional double current_curvature = 3;
+                
+        // Most accurate orientation rate of the vehicle, available in the on-board network
+        // measured on the vehicle coordinate system in context of the global inertial system.
+        //
+        optional Orientation3d orientation_rate = 4;
+        
+        // Most accurate velocity information of the vehicle, available in the on-board network
+        // measured on the vehicle coordinate system in context of the global inertial system.
+        //
+        optional Vector3d velocity = 5;
+
+        // Most accurate acceleration information of the vehicle, available in the on-board network
+        // measured on the vehicle coordinate system in context of the global inertial system.
+        //
+        optional Vector3d acceleration = 6;
 
     }
 


### PR DESCRIPTION
Include velocity, acceleration and orientation rate data related to the vehicle coordinate system in the host_vehicle_data message

Signed-off-by: Maikol Drechsler <maikol.drechsler@carissma.eu>

﻿#### Reference to a related issue in the repository
Due to the deprecation of localization and localization_rmse attributes of host_vehicle_data the velocity, acceleration and yaw_rate of the vehicle cannot be described.
The issue had been discussed per e-mail with @ThomasNaderBMW

#### Add a description
Include a new attribute vehicle_kinametics which include the ego velocity, orientation rate and acceleration in the host_vehicle_data. 

**Some questions to ask**:
What is this change?
Include a new attribute, that enables the exchange of vehicle kinematics data.  
What does it fix?
The data lost by the deprecation of the attributes localization and localization_rmse.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
It is a new optional attribute, no update is forced. 
How has it been tested?
It has been tested locally with a C++ implementation. 


#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [X] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [X] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [X] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [X] My changes generate no errors when passing CI tests. 
- [X] I have successfully implemented and tested my fix/feature locally.
- [X] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
