### PR TITLE
Add new traffic sign variability types

### DIFF
--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -9571,23 +9571,35 @@ message TrafficSign
         //
         VARIABILITY_OTHER = 1;
 
-        // Sign that can change neither semantically nor positionally, e.g.
-        // fixed immutable traffic sign.
+        // Sign that can change neither semantically nor positionally, e.g. a
+        // fixed, immutable, non-temporary traffic sign.
         //
         VARIABILITY_FIXED = 2;
 
-        // Sign that can change semantically and positionally.
+        // Sign that can change semantically and/or positionally, i.e. it is
+        // left unspecified in which way the sign may change.
+        //
+        // \note This value represents a legacy definition. If possible, please
+        // use the more specific values below to indicate the exact nature of
+        // variability.
         //
         VARIABILITY_VARIABLE = 3;
 
-        // Sign that can change positionally but not semantically, e.g.
-        // temporary immutable traffic sign at construction site.
+        // Sign that can change positionally but not semantically, e.g. a
+        // temporary, immutable traffic sign at construction site.
         //
-        VARIABILITY_VARIABLE_MOVABLE = 4;
+        VARIABILITY_MOVABLE = 4;
 
-        // Sign that can change semantically but not positionally, e.g. digital
-        // traffic sign on traffic sign gantry or analog prism signs.
+        // Sign that can change semantically but not positionally, e.g. a
+        // digital traffic sign on traffic sign gantry, or an analog prism
+        // sign.
         //
-        VARIABILITY_VARIABLE_MUTABLE = 5;
+        VARIABILITY_MUTABLE = 5;
+
+        // Sign that can change both semantically and positionally, e.g. a
+        // temporary, digital traffic sign at a construction site, or a digital
+        // traffic sign attached to a road works vehicle.
+        //
+        VARIABILITY_MOVABLE_AND_MUTABLE = 6;
     }
 }

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -9571,12 +9571,23 @@ message TrafficSign
         //
         VARIABILITY_OTHER = 1;
 
-        // Fixed sign, i.e. always present.
+        // Sign that can change neither semantically nor positionally, e.g.
+        // fixed immutable traffic sign.
         //
         VARIABILITY_FIXED = 2;
 
-        // Temporary or variable sign, e.g. on a sign bridge.
+        // Sign that can change semantically and positionally.
         //
         VARIABILITY_VARIABLE = 3;
+
+        // Sign that can change positionally but not semantically, e.g.
+        // temporary immutable traffic sign at construction site.
+        //
+        VARIABILITY_VARIABLE_MOVABLE = 4;
+
+        // Sign that can change semantically but not positionally, e.g. digital
+        // traffic sign on traffic sign gantry or analog prism signs.
+        //
+        VARIABILITY_VARIABLE_MUTABLE = 5;
     }
 }


### PR DESCRIPTION
#### Description
- Clarify definition of VARIABILITY_FIXED and VARIABILITY_VARIABLE to differentiate from new types
- Add new types VARIABILITY_VARIABLE_MOVABLE and VARIABILITY_VARIABLE_MUTABLE

As already mentioned by @jdsika in #623, the differentiation between mutable content (e.g. traffic sign type) and changes in position of traffic signs is not given yet.
To maintain backwards compatibility the existing type VARIABILITY_VARIABLE is essentially kept as it is. It still describes traffic signs that CAN BE semantically and positionally variable. This means that it has to be expected that the traffic sign's type and position could change over time (exactly as it is with the current OSI version). If further differentiation in terms of semantics and position is desired, the new types VARIABILITY_VARIABLE_MOVABLE and VARIABILITY_VARIABLE_MUTABLE can be used.

#### Examples
VARIABILITY_VARIABLE:
> Pickup truck at the Autobahn carries a semantically mutable (e.g. digital) sign for a construction site which moves on the car.

VARIABILITY_VARIABLE_MUTABLE:
> Digital or analog mutable traffic signs like signs on a traffic sign gantry.

VARIABILITY_VARIABLE_MOVABLE:
> Temporary (but semantically immutable) signs at construction sites.

#### Checklist
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

﻿#### References
resolves #623 
#671 