### PR TITLE
Fix image_data comment on pixel order

### DIFF
--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -313,8 +313,9 @@ message CameraSensorView
 
     // Raw image data.
     //
-    // The raw image data in the memory layout and order specified by the
-    // camera sensor input configuration.
+    // The raw image data in the memory layout specified by the camera sensor
+    // input configuration. Pixel order is left-to-right, top-to-bottom (think
+    // of scan lines in a TV).
     //
     optional bytes image_data = 2;
 }


### PR DESCRIPTION
#### Description
We noticed that the pixel order of the image_data field in CameraSensorView was not specified by CameraSensorViewConfiguration as the description of image_data says:
> The raw image data in the memory layout and order specified by the camera sensor input configuration.

Since both radar and lidar reflections are currently defined to be ordered left-to-right, top-to-bottom (see following quote), it could be the case that this was accidently omitted for image_data. ([RadarSensorView](https://opensimulationinterface.github.io/open-simulation-interface/structosi3_1_1RadarSensorView.html), [LidarSensorView](https://opensimulationinterface.github.io/open-simulation-interface/structosi3_1_1LidarSensorView.html))
> This field includes one entry for each ray, in left-to-right, top-to-bottom order (think of scan lines in a TV). 

Therefore, the default pixel order should probably align with the definitions of radar and lider reflections. If further pixel orders are desired a enum could be added to CameraSensorViewConfiguration but I think this small change would already clarify enough to be able to reliably exchange image data with OSI.

This change can be seen as a bug fix. The description of image_data that a pixel order can be specified in CameraSensorViewConfiguration is definitely misleading.

#### Checklist
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

﻿#### References
#681 
