### PR TITLE
Never trigger antora builds for PRs from forks

### DIFF
--- a/.github/workflows/antora-generator.yml
+++ b/.github/workflows/antora-generator.yml
@@ -13,12 +13,15 @@ jobs:
 
     runs-on: Ubuntu-latest
 
+    env:
+      MUP_KEY: ${{ secrets.MACHINE_USER_PAT }}
+
     steps:
     - name: Trigger generator
+      if: ${{ env.MUP_KEY != '' }}
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.MACHINE_USER_PAT }}
         event-type: antora-build-trigger
         repository: OpenSimulationInterface/osi-antora-generator
         client-payload: '{"src": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "head_ref": "${{ github.head_ref }}"}'
-        


### PR DESCRIPTION
Since no secrets will be available for security reasons, do not try to trigger antora builds when those secrets are not available.