### PR TITLE
(feat SensorModelling) add pixel_order field

### DIFF
--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -313,8 +313,10 @@ message CameraSensorView
 
     // Raw image data.
     //
-    // The raw image data in the memory layout and order specified by the
-    // camera sensor input configuration.
+    // The raw image data in the memory layout specified by the camera sensor
+    // input configuration. Default pixel order is left-to-right, top-to-bottom
+    ///(think of scan lines in a TV), but modifications can be 
+    // requested/indicated in CameraSensorViewConfiguration.pixel_order.
     //
     optional bytes image_data = 2;
 }

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -315,7 +315,7 @@ message CameraSensorView
     //
     // The raw image data in the memory layout specified by the camera sensor
     // input configuration. Default pixel order is left-to-right, top-to-bottom
-    ///(think of scan lines in a TV), but modifications can be 
+    // (think of scan lines in a TV), but modifications can be 
     // requested/indicated in CameraSensorViewConfiguration.pixel_order.
     //
     optional bytes image_data = 2;

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -314,9 +314,7 @@ message CameraSensorView
     // Raw image data.
     //
     // The raw image data in the memory layout specified by the camera sensor
-    // input configuration. Default pixel order is left-to-right, top-to-bottom
-    // (think of scan lines in a TV), but modifications can be 
-    // requested/indicated in CameraSensorViewConfiguration.pixel_order.
+    // input configuration. The pixel order is specified in CameraSensorViewConfiguration.pixel_order with the default value PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM.
     //
     optional bytes image_data = 2;
 }

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -313,8 +313,10 @@ message CameraSensorView
 
     // Raw image data.
     //
-    // The raw image data in the memory layout specified by the camera sensor
-    // input configuration. The pixel order is specified in CameraSensorViewConfiguration.pixel_order with the default value PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM.
+    // The raw image data in the memory layout specified by the camera    
+    // sensor input configuration. The pixel order is specified in 
+    // CameraSensorViewConfiguration.pixel_order with the 
+    // default value PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM.
     //
     optional bytes image_data = 2;
 }

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -316,7 +316,7 @@ message CameraSensorView
     // The raw image data in the memory layout specified by the camera    
     // sensor input configuration. The pixel order is specified in 
     // CameraSensorViewConfiguration.pixel_order with the 
-    // default value PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM.
+    // default value PIXEL_ORDER_DEFAULT (i.e. left-to-right, top-to-bottom).
     //
     optional bytes image_data = 2;
 }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -733,7 +733,7 @@ message CameraSensorViewConfiguration
     //
     // By default, the pixel data is is left-to-right, top-to-bottom. 
     // 
-    // \note for rotations of the pixel data, use the camera coordinate system
+    // \note for rotations of the pixel data, use the camera coordinate system.
     //
     optional PixelOrder pixel_order = 12;
 
@@ -743,8 +743,9 @@ message CameraSensorViewConfiguration
     // in CameraSensorView. 
     //
     // \note this enum does not contain an entry to do mirroring upside down
-    // and left-to-right at the same time, because this is equivalent to a 180°
-    // rotation, which should be indicated in the sensor coordinate system 
+    // and left-to-right at the same time, because this is equivalent to a
+    // 180-degree rotation, which should be indicated in the sensor coordinate
+    // system.
     //
     enum PixelOrder
     {
@@ -752,7 +753,7 @@ message CameraSensorViewConfiguration
         //
         PIXEL_ORDER_UNKNOWN = 0;
 
-        // Unspecified but unknown pixel order.
+        // Known pixel order that is not supported by OSI.
         // Consider proposing an additional format if using
         // \c #PIXEL_ORDER_OTHER.
         //

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -742,32 +742,34 @@ message CameraSensorViewConfiguration
     // Pixel layout documents the order of pixels in the \c image_data
     // in CameraSensorView. 
     //
-    // \note this enum does not contain an entry for right-to-left and bottom-to-top, because this is equivalent to a
-    // 180-degree rotation of the default, which should be indicated in the sensor coordinate
+    // \note this enum does not contain an entry to do mirroring upside down
+    // and left-to-right at the same time, because this is equivalent to a
+    // 180-degree rotation, which should be indicated in the sensor coordinate
     // system.
     //
     enum PixelOrder
     {
-        // Pixel order is unknown (must not be used).
+        // Pixel data is not mirrored (Default).
+        // Pixels are ordered left-to-right, top-to-bottom.
         //
-        PIXEL_ORDER_UNKNOWN = 0;
+        PIXEL_ORDER_DEFAULT = 0;
 
         // Known pixel order that is not supported by OSI.
         // Consider proposing an additional format if using
         // \c #PIXEL_ORDER_OTHER.
         //
         PIXEL_ORDER_OTHER = 1;
-        
-        // Pixels are ordered left-to-right, top-to-bottom (default)
-        //
-        PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM = 2;
-        
-        // Pixels are ordered right-to-left, top-to-bottom
+                
+        // Pixels are ordered right-to-left, top-to-bottom.
+        // Pixel data is mirrored along the vertical axis.
+        // The image is mirrored left-to-right.
         //
         PIXEL_ORDER_RIGHT_LEFT_TOP_BOTTOM = 3;
         
-        // Pixels are ordered left-to-right, bottom-to-top
-        //
+        // Pixels are ordered left-to-right, bottom-to-top.
+        // Pixel data is mirrored along the horizontal axis.
+        // The image is mirrored top-to-bottom.
+        // 
         PIXEL_ORDER_LEFT_RIGHT_BOTTOM_TOP = 4;
     }
 

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -731,9 +731,9 @@ message CameraSensorViewConfiguration
 
     // Indicates if and how the the pixel data is ordered
     //
-    // By default, the pixel data is is left-to-right, top-to-bottom. 
+    // The default value is PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM. 
     // 
-    // \note for rotations of the pixel data, use the camera coordinate system.
+    // \note For rotations of the pixel data, use the camera coordinate system.
     //
     optional PixelOrder pixel_order = 12;
 
@@ -742,9 +742,8 @@ message CameraSensorViewConfiguration
     // Pixel layout documents the order of pixels in the \c image_data
     // in CameraSensorView. 
     //
-    // \note this enum does not contain an entry to do mirroring upside down
-    // and left-to-right at the same time, because this is equivalent to a
-    // 180-degree rotation, which should be indicated in the sensor coordinate
+    // \note this enum does not contain an entry for right-to-left and bottom-to-top, because this is equivalent to a
+    // 180-degree rotation of the default, which should be indicated in the sensor coordinate
     // system.
     //
     enum PixelOrder
@@ -759,20 +758,17 @@ message CameraSensorViewConfiguration
         //
         PIXEL_ORDER_OTHER = 1;
         
-        // Pixel data is not mirrored (Default).
-        // Pixels are ordered left-to-right, top-to-bottom
+        // Pixels are ordered left-to-right, top-to-bottom (default)
         //
-        PIXEL_ORDER_DEFAULT = 2;
-
-        // Pixel data is mirrored along the vertical axis.
-        // The image is mirrored left-to-right.
+        PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM = 2;
+        
+        // Pixels are ordered right-to-left, top-to-bottom
         //
-        PIXEL_ORDER_MIRRORED_LEFT_RIGHT = 3;
-
-        // Pixel data is mirrored along the horizontal axis.
-        // The image is mirrored top-to-bottom.
-        //      
-        PIXEL_ORDER_MIRRORED_UP_DOWN = 4;
+        PIXEL_ORDER_RIGHT_LEFT_TOP_BOTTOM = 3;
+        
+        // Pixels are ordered left-to-right, bottom-to-top
+        //
+        PIXEL_ORDER_LEFT_RIGHT_BOTTOM_TOP = 4;
     }
 
 

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -729,6 +729,52 @@ message CameraSensorViewConfiguration
     //
     repeated WavelengthData wavelength_data = 11;
 
+    // Indicates if and how the the pixel data is ordered
+    //
+    // By default, the pixel data is is left-to-right, top-to-bottom. 
+    // 
+    // \note for rotations of the pixel data, use the camera coordinate system
+    //
+    optional PixelOrder pixel_order = 12;
+
+    // Pixel layout 
+    //
+    // Pixel layout documents the order of pixels in the \c image_data
+    // in CameraSensorView. 
+    //
+    // \note this enum does not contain an entry to do mirroring upside down
+    // and left-to-right at the same time, because this is equivalent to a 180°
+    // rotation, which should be indicated in the sensor coordinate system 
+    //
+    enum PixelOrder
+    {
+        // Pixel order is unknown (must not be used).
+        //
+        PIXEL_ORDER_UNKNOWN = 0;
+
+        // Unspecified but unknown pixel order.
+        // Consider proposing an additional format if using
+        // \c #PIXEL_ORDER_OTHER.
+        //
+        PIXEL_ORDER_OTHER = 1;
+        
+        // Pixel data is not mirrored (Default).
+        // Pixels are ordered left-to-right, top-to-bottom
+        //
+        PIXEL_ORDER_DEFAULT = 2;
+
+        // Pixel data is mirrored along the vertical axis.
+        // The image is mirrored left-to-right.
+        //
+        PIXEL_ORDER_MIRRORED_LEFT_RIGHT = 3;
+
+        // Pixel data is mirrored along the horizontal axis.
+        // The image is mirrored top-to-bottom.
+        //      
+        PIXEL_ORDER_MIRRORED_UP_DOWN = 4;
+    }
+
+
     // Channel format.
     //
     enum ChannelFormat

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -766,13 +766,13 @@ message CameraSensorViewConfiguration
         // Pixel data is mirrored along the vertical axis.
         // The image is mirrored left-to-right.
         //
-        PIXEL_ORDER_RIGHT_LEFT_TOP_BOTTOM = 3;
+        PIXEL_ORDER_RIGHT_LEFT_TOP_BOTTOM = 2;
         
         // Pixels are ordered left-to-right, bottom-to-top.
         // Pixel data is mirrored along the horizontal axis.
         // The image is mirrored top-to-bottom.
         // 
-        PIXEL_ORDER_LEFT_RIGHT_BOTTOM_TOP = 4;
+        PIXEL_ORDER_LEFT_RIGHT_BOTTOM_TOP = 3;
     }
 
 

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -731,7 +731,9 @@ message CameraSensorViewConfiguration
 
     // Indicates if and how the the pixel data is ordered
     //
-    // The default value is PIXEL_ORDER_LEFT_RIGHT_TOP_BOTTOM. 
+    // The default value (PIXEL_ORDER_DEFAULT) indicates standard image
+    // pixel order (left-to-right, top-to-bottom). The other values can
+    // be used to indicate/request mirroring (right to left or bottom to top).
     // 
     // \note For rotations of the pixel data, use the camera coordinate system.
     //


### PR DESCRIPTION
Signed-off-by: RIFJo <jochmann@rt.rif-ev.de>

﻿#### Reference to a related issue in the repository
refers to #620

#### Add a description
Adds a "pixel_order" field and enum to allow mirrored versions of the pixel layouts.  This is the result of the discussions with the participants in the sensor modelling workgroup meetings.

This pull request also includes the changes from Thomas Sedlmayer in https://github.com/OpenSimulationInterface/open-simulation-interface/pull/684


#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
