### PR TITLE
689 add raytracerview config

### DIFF
--- a/.github/spelling_custom_words_en_US.txt
+++ b/.github/spelling_custom_words_en_US.txt
@@ -40,10 +40,12 @@ bggr
 Biblio
 bicyclesback
 bildgebendes
+bmatrix
 bool
 boolean
 Botts
 bp
+Brem
 br
 britannica
 candela
@@ -95,6 +97,7 @@ ECE
 edn
 edu
 egm
+Eibert
 eilvterm
 ein
 Einheiten
@@ -105,6 +108,7 @@ Encyclopaedia
 endcode
 Ende
 Endeninch
+endian
 endlink
 endrules
 engl
@@ -161,7 +165,10 @@ haben
 Hafengebiet
 Hagen
 halten
+hh
 hier
+Hitpoint
+hitpoint
 Hochwasser
 hoverboards
 href
@@ -170,6 +177,7 @@ htm
 html
 http
 https
+hv
 hypot
 ietf
 illuminance
@@ -187,6 +195,7 @@ io
 IRI
 iso
 itu
+jones
 jpg
 Karamihas
 Karlsruhe
@@ -225,6 +234,7 @@ Nebenstrecke
 neuer
 nicht
 Nicolaus
+nm
 noao
 NONDRIVING
 Normung
@@ -260,6 +270,7 @@ Parkstände
 Paulat
 pdf
 png
+polarisation
 Polizeikontrolle
 polyline
 positionally
@@ -295,6 +306,7 @@ Sa
 SAE
 sae
 samstags
+SBR
 Schienenfahrzeuge
 Schleudergefahr
 Schlupf
@@ -362,9 +374,11 @@ Verkehrsführung
 Verkehrstechnik
 verkehrszeichen
 Verschmutzte
+vh
 Vorfahrt
 Vorschriftzeichen
 Vorweg
+vv
 vz
 VzKat
 vzkat

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -163,6 +163,10 @@ message SensorView
     // Ultrasonic-specific SensorView(s).
     //
     repeated UltrasonicSensorView ultrasonic_sensor_view = 1004;
+    
+    // Raytracer-specific View(s).
+    //
+    repeated RaytracerView raytracer_view = 1005;
 }
 
 //
@@ -346,4 +350,45 @@ message UltrasonicSensorView
     // Ultrasonic view configuration valid at the time the data was created.
     //
     optional UltrasonicSensorViewConfiguration view_configuration = 1;
+}
+
+//
+// \brief Definition of the raytracer view.
+//
+// Raytracer specific view data.
+//
+message RaytracerView
+{
+    // Raytracer view configuration valid at the time the data was created.
+    //
+    optional RaytracerViewConfiguration view_configuration = 1;
+
+    // Raw raytracer data.
+    //
+    // The raw raytracer data in the memory layout and order specified by the
+    // raytracer input configuration.
+    //
+    optional bytes raytracer_data = 2;
+    
+    // Device type defines the device where the data is located.
+    //
+    optional DeviceType device_type = 3;
+    
+    // Enum consits of different predefined device types.
+    // 
+    enum DeviceType
+    {
+        // Type of device type is unknown (must not be used).
+        //
+        DEVICE_TYPE_UNKNOWN = 0;
+        
+        // The data is located on the GPU.
+        //
+        DEVICE_TYPE_GPU = 1;
+        
+        // The data is located on the CPU.
+        //
+        DEVICE_TYPE_CPU = 2;
+        
+    }
 }

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -163,10 +163,6 @@ message SensorView
     // Ultrasonic-specific SensorView(s).
     //
     repeated UltrasonicSensorView ultrasonic_sensor_view = 1004;
-    
-    // Raytracer-specific View(s).
-    //
-    repeated RaytracerView raytracer_view = 1005;
 }
 
 //
@@ -350,45 +346,4 @@ message UltrasonicSensorView
     // Ultrasonic view configuration valid at the time the data was created.
     //
     optional UltrasonicSensorViewConfiguration view_configuration = 1;
-}
-
-//
-// \brief Definition of the raytracer view.
-//
-// Raytracer specific view data.
-//
-message RaytracerView
-{
-    // Raytracer view configuration valid at the time the data was created.
-    //
-    optional RaytracerViewConfiguration view_configuration = 1;
-
-    // Raw raytracer data.
-    //
-    // The raw raytracer data in the memory layout and order specified by the
-    // raytracer input configuration.
-    //
-    optional bytes raytracer_data = 2;
-    
-    // Device type defines the device where the data is located.
-    //
-    optional DeviceType device_type = 3;
-    
-    // Enum consits of different predefined device types.
-    // 
-    enum DeviceType
-    {
-        // Type of device type is unknown (must not be used).
-        //
-        DEVICE_TYPE_UNKNOWN = 0;
-        
-        // The data is located on the GPU.
-        //
-        DEVICE_TYPE_GPU = 1;
-        
-        // The data is located on the CPU.
-        //
-        DEVICE_TYPE_CPU = 2;
-        
-    }
 }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1050,7 +1050,7 @@ message RayTracerViewConfiguration
     //
     optional double maximum_signal_loss = 6;
     
-    // The maximum path length desribes the ray's maximum overall distance. If
+    // The maximum path length describes the ray's maximum overall distance. If
     // the maximum path length is reached during simulation no further
     // interaction is calculated.
     //
@@ -1058,7 +1058,7 @@ message RayTracerViewConfiguration
     //
     optional double max_path_length = 7;
     
-    // The maximum number of interaction desribes the ray's maximum hits with
+    // The maximum number of interaction describes the ray's maximum hits with
     // surfaces. If the maximum number of interaction is reached during
     // simulation no further interaction is calculated.
     //

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1088,33 +1088,19 @@ message RaytracerViewConfiguration
         // Consider proposing an additional format if using
         // \c #RAYTRACER_FORMAT_OTHER.
         //
-        RAYTRACER_FORMAT_OTHER = 1;
+        RAYTRACER_FORMAT_OTHER = 1;        
 
-        // Radar raytracer format used in the Japanese DIVP project.
-        //
-        // The message consists of the following fields in the described order.
-        // In brackets the data type, the unit and a short description is given. 
-        // distance (float; in m; path length of the ray)
-        // relative_speed (float; in m/s; summed relative speed due to interaction points with moved surfaces)
-        // propagation_attenuation_h_pol (float; in W; attenuation of signal strength of horizontal polarisation)
-        // propagation_attenuation_v_pol (float; in W; attenuation of signal strength of vertical polarisation)
-        // direction_of_arrival_azimuth (float; in rad; direction of arrival of the ray in the configured raytracer coordinate system in azimuth direction)
-        // direction_of_arrival_elevation (float; in rad; direction of arrival of the ray in the configured raytracer coordinate system in elevation direction)
-        // direction_of_departure_azimuth (float; in rad; direction of departure of the ray in the configured raytracer coordinate system in azimuth direction)
-        // direction_of_departure_elevation (float; in rad; direction of departure of the ray in the configured raytracer coordinate system in elevation direction)
-        //
-        RAYTRACER_FORMAT_DIVP_RADAR = 2;
-        
-        // Radar raytracer format used in the German VIVALDI project.
+        // Raytracer format for Shoot and Bounce Approach
+        // Adapted for electromagnetic wave propagation
         //
         // The message consists of the following fields in the described order.
         // In brackets the data type, the unit and a short description is given. 
         // intersection_path_length (float; in m; path length of the ray between the First_Hitpoint and the Last_Hitpoint)
         // relative_speed (float; in m/s; summed relative speed due to interaction points with moved surfaces)
-        // jones_vector (float4; in V/m; jones vector of the ray with information of the electromagnetic wave`s phase, signal strength and polarisation)
-        // last_hitpoint (float3; in m; coordinates of the last hitpoint in the raytracer's coordinate system defined by the mounting position)
-        // first_hitpoint (float3; in m; coordinates of the first hitpoint in the raytracer's coordinate system defined by the mounting position)
+        // jones_matrices (float8; in V/m; jones matrix of the ray with information of the electromagnetic wave`s phase, signal strength and polarisation, which gives you additonaly the projection to the subset of the jones vectors )
+        // direction_of_arrival_hitpoint (float3; in m; coordinates of the DoA (last hitpoint) in the raytracer's coordinate system defined by the mounting position)
+        // direction_of_departure_hitpoint (float3; in m; coordinates of the DoD (first hitpoint) in the raytracer's coordinate system defined by the mounting position)
         //
-        RAYTRACER_FORMAT_VIVALDI_RADAR = 3;
+        RAYTRACER_FORMAT_SBR = 3;
         }
 }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -236,6 +236,11 @@ message SensorViewConfiguration
     //
     repeated UltrasonicSensorViewConfiguration
         ultrasonic_sensor_view_configuration = 1004;
+        
+    // Raytracer-specific View Configuration(s).
+    //
+    repeated RaytracerViewConfiguration
+        raytracer_view_configuration = 1005;
 }
 
 //
@@ -972,4 +977,144 @@ message UltrasonicSensorViewConfiguration
 
     // TBD: Ultrasonic Sensor specific configuration.
     //
+}
+
+
+//
+// \brief The configuration settings for the Raytracer View to be
+// provided by the environment simulation.
+//
+message RaytracerViewConfiguration
+{
+    // The ID of the sensor origin at host vehicle's mounting_position.
+    //
+    // This is the ID of the simulated sensor, to be used in its detected
+    // features output.
+    //
+    // The ID is to be provided by the environment simulation, the sensor
+    // model is not in a position to provide a useful default value.
+    //
+    optional Identifier sensor_id = 1;
+
+    // The physical mounting position of the sensor (origin and orientation
+    // of the sensor coordinate system) given in vehicle coordinates [1].
+    // The physical position pertains to this detector individually, and
+    // governs the sensor-relative coordinates in features detected by this
+    // detector.
+    //
+    // \arg \b x-direction of sensor coordinate system: sensor viewing direction
+    // \arg \b z-direction of sensor coordinate system: sensor (up)
+    // \arg \b y-direction of sensor coordinate system: perpendicular to x and z
+    // right hand system
+    //
+    // \par Reference:
+    // [1] DIN Deutsches Institut fuer Normung e. V. (2013). <em>DIN ISO 8855 Strassenfahrzeuge - Fahrzeugdynamik und Fahrverhalten - Begriffe</em>. (DIN ISO 8855:2013-11). Berlin, Germany.
+    //
+    // \note The origin of vehicle's coordinate system in world frame is
+    // ( \c MovingObject::base . \c BaseMoving::position +
+    // Inverse_Rotation_yaw_pitch_roll( \c MovingObject::base . \c
+    // BaseMoving::orientation) * \c
+    // MovingObject::VehicleAttributes::bbcenter_to_rear) . The orientation of
+    // the vehicle's coordinate system is equal to the orientation of the
+    // vehicle's bounding box \c MovingObject::base . \c
+    // BaseMoving::orientation. \note A default position can be provided by the
+    // sensor model (e.g. to indicate the position the model was validated for),
+    // but this is optional; the environment simulation must provide a valid
+    // mounting position (based on the vehicle configuration) when setting the
+    // view configuration.
+    //
+    // All raytracing results e.g. Hitpoint positions are given in this
+    // sensor coordinate system.
+    //
+    optional MountingPosition mounting_position = 2;
+    
+    // Position of the raytracer`s receiver in the sensor coordinate system.
+    // 
+    repeated MountingPosition receiver_position = 3;
+    
+    // Position of the raytracer`s transmitter in the sensor coordinate system.
+    //
+    repeated MountingPosition transmitter_position = 4;
+    
+    // The wavelength of the transmitted ray in the simulation.
+    //
+    // Unit: nm
+    optional double emitter_wavelength = 5;
+    
+    // When reaching the maximmum signal loss during raytracing further raytracing is aborted.
+    // The maximum signal loss is the relation between current calculated signal strength and the emitted signal
+    // strength at the ray generation.
+    // 
+    // Unit: dB
+    optional double maximum_signal_loss = 6;
+    
+    // The maximum path length desribes the ray's maximum overall distance.
+    // If the maximum path length is reached during simulation no further interaction is calculated.
+    //
+    // Unit: m
+    optional double max_path_length = 7;
+    
+    // The maximum number of interaction desribes the ray's maximum hits with surfaces.
+    // If the maximum number of interaction is reached during simulation no further interaction is calculated.
+    //
+    // Unit: -
+    optional uint32 max_number_of_interactions = 8;
+    
+    // Format of raytracer data (includes number, kind and format of channels).
+    //
+    // In the message provided by the sensor model, this field can
+    // be repeated and all values are acceptable to the model, with
+    // the most acceptable value being listed first, and the remaining
+    // values indicating alternatives in descending order of preference.
+    //
+    // In the message provided to the sensor model, this field must
+    // contain exactly one value, indicating the format of the image
+    // data being provided by the simulation environment - which must
+    // be one of the values the sensor model requested - or there
+    // must be no value, indicating that the simulation environment
+    // cannot provide raytracer data in one of the requested formats.
+    //
+    repeated RaytracerFormat raytracer_format = 9;
+
+    // Different predefined raytracer formats
+    // 
+    enum RaytracerFormat
+    {
+        // Type of channel format is unknown (must not be used).
+        //
+        RAYTRACER_FORMAT_UNKNOWN = 0;
+
+        // Unspecified but known channel format.
+        // Consider proposing an additional format if using
+        // \c #RAYTRACER_FORMAT_OTHER.
+        //
+        RAYTRACER_FORMAT_OTHER = 1;
+
+        // Radar raytracer format used in the Japanese DIVP project.
+        //
+        // The message consists of the following fields in the described order.
+        // In brackets the data type, the unit and a short description is given. 
+        // distance (float; in m; path length of the ray)
+        // relative_speed (float; in m/s; summed relative speed due to interaction points with moved surfaces)
+        // propagation_attenuation_h_pol (float; in W; attenuation of signal strength of horizontal polarisation)
+        // propagation_attenuation_v_pol (float; in W; attenuation of signal strength of vertical polarisation)
+        // direction_of_arrival_azimuth (float; in rad; direction of arrival of the ray in the configured raytracer coordinate system in azimuth direction)
+        // direction_of_arrival_elevation (float; in rad; direction of arrival of the ray in the configured raytracer coordinate system in elevation direction)
+        // direction_of_departure_azimuth (float; in rad; direction of departure of the ray in the configured raytracer coordinate system in azimuth direction)
+        // direction_of_departure_elevation (float; in rad; direction of departure of the ray in the configured raytracer coordinate system in elevation direction)
+        //
+        RAYTRACER_FORMAT_DIVP_RADAR = 2;
+        
+        // Radar raytracer format used in the German VIVALDI project.
+        //
+        // The message consists of the following fields in the described order.
+        // In brackets the data type, the unit and a short description is given. 
+        // intersection_path_length (float; in m; path length of the ray between the First_Hitpoint and the Last_Hitpoint)
+        // relative_speed (float; in m/s; summed relative speed due to interaction points with moved surfaces)
+        // jones_vector (float4; in V/m; jones vector of the ray with information of the electromagnetic wave`s phase, signal strength and polarisation)
+        // last_hitpoint (float3; in m; coordinates of the last hitpoint in the raytracer's coordinate system defined by the mounting position)
+        // first_hitpoint (float3; in m; coordinates of the first hitpoint in the raytracer's coordinate system defined by the mounting position)
+        //
+        RAYTRACER_FORMAT_VIVALDI_RADAR = 3;
+        }
 }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1090,16 +1090,66 @@ message RaytracerViewConfiguration
         //
         RAYTRACER_FORMAT_OTHER = 1;        
 
-        // Raytracer format for Shoot and Bounce Approach
-        // Adapted for electromagnetic wave propagation
+        // Raytracer format for Shoot and Bounce Approach (adapted for
+        // electromagnetic wave propagation)
         //
-        // The message consists of the following fields in the described order.
-        // In brackets the data type, the unit and a short description is given. 
-        // intersection_path_length (float; in m; path length of the ray between the First_Hitpoint and the Last_Hitpoint)
-        // relative_speed (float; in m/s; summed relative speed due to interaction points with moved surfaces)
-        // jones_matrices (float8; in V/m; jones matrix of the ray with information of the electromagnetic wave`s phase, signal strength and polarisation, which gives you additonaly the projection to the subset of the jones vectors )
-        // direction_of_arrival_hitpoint (float3; in m; coordinates of the DoA (last hitpoint) in the raytracer's coordinate system defined by the mounting position)
-        // direction_of_departure_hitpoint (float3; in m; coordinates of the DoD (first hitpoint) in the raytracer's coordinate system defined by the mounting position)
+        // The 64-byte message consists of the fields in the described order,
+        // with all values as 32-bit IEEE-754 floats (float32) stored in
+        // little-endian (least-significant byte first).
+        //
+        // * \c intersection_path_length - float32 (meters)
+        //
+        //   Path length of the ray between First_Hitpoint and Last_Hitpoint.
+        //
+        //   Offset: 0 (4 bytes)
+        //
+        // * \c relative_speed - float32 (meters/second)
+        //
+        //   Summed relative speed due to interaction points with moving
+        //   surfaces.
+        //
+        //   Offset: 4 (4 bytes)
+        //
+        // * \c jones_matrices - float32[8] (V/m complex components)
+        //
+        //   Contains the 2x2 Jones matrix (complex entries) of the ray with
+        //   information of the electromagnetic wave's phase, signal strength
+        //   and polarisation, which gives you additonaly the projection to the
+        //   subset of the jones vectors.
+        //
+        //   Layout (in this order):
+        //   vv[re], vv[im], vh[re], vh[im], hv[re], hv[im], hh[re], hh[im]
+        //
+        //   \f[
+        //   J = \begin{bmatrix}
+        //   vv & vh \\
+        //   hv & hh
+        //   \end{bmatrix}
+        //   \f]
+        //
+        //   Offset: 8 (32 bytes)
+        //
+        // * \c direction_of_arrival_hitpoint - float32[3] (meters):
+        //
+        //   Coordinates of the DoA (last hitpoint) in the raytracer's
+        //   coordinate system defined by the mounting position.
+        //
+        //   Order: x, y, z
+        //
+        //   Coordinate system: right-handed ([see OSI coordinate system definition](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html))
+        //
+        //   Offset: 40 (12 bytes)
+        //
+        // * \c direction_of_departure_hitpoint - float32[3] (meters):
+        //
+        //   Coordinates of the DoD (first hitpoint) in the raytracer's
+        //   coordinate system defined by the mounting position.
+        //
+        //   Order: x, y, z
+        //
+        //   Coordinate system: right-handed ([see OSI coordinate system definition](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html))
+        //
+        //   Offset: 52 (12 bytes)
         //
         RAYTRACER_FORMAT_SBR = 2;
         }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1096,7 +1096,7 @@ message RaytracerViewConfiguration
         RAYTRACER_FORMAT_OTHER = 1;        
 
         // Raytracer format for Shoot and Bounce Approach (adapted for
-        // electromagnetic wave propagation)
+        // electromagnetic wave propagation) [1]
         //
         // The 64-byte message consists of the fields in the described order,
         // with all values as 32-bit IEEE-754 floats (float32) stored in
@@ -1155,6 +1155,9 @@ message RaytracerViewConfiguration
         //   Coordinate system: right-handed ([see OSI coordinate system definition](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html))
         //
         //   Offset: 52 (12 bytes)
+        //
+        // /par Reference
+        // [1] Brem, R., & Eibert, T. F. (2015, August). A Shooting and Bouncing Ray (SBR) Modeling Framework Involving Dielectrics and Perfect Conductors. IEEE Transactions on Antennas and Propagation, 63(8), 3599-3609. https://doi.org/10.1109/TAP.2015.2438318
         //
         RAYTRACER_FORMAT_SBR = 2;
         }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1101,6 +1101,6 @@ message RaytracerViewConfiguration
         // direction_of_arrival_hitpoint (float3; in m; coordinates of the DoA (last hitpoint) in the raytracer's coordinate system defined by the mounting position)
         // direction_of_departure_hitpoint (float3; in m; coordinates of the DoD (first hitpoint) in the raytracer's coordinate system defined by the mounting position)
         //
-        RAYTRACER_FORMAT_SBR = 3;
+        RAYTRACER_FORMAT_SBR = 2;
         }
 }

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1067,6 +1067,15 @@ message RaytracerViewConfiguration
     
     // Format of raytracer data (includes number, kind and format of channels).
     //
+    // The \c RayTracerFormat is used to facilitate information exchange between
+    // different modules within a shared context. The ray tracing provider
+    // communicates the location of the data on the GPU to the consumer.
+    // Additionally, the \c RayTracerFormat defines how this data should be
+    // interpreted, enabling the consumer to correctly process it during
+    // GPU-based post-processing. This configuration ensures that the consumer
+    // understands the structure and semantics of the data, allowing for
+    // efficient and accurate interpretation in the post-processing.
+    //
     // In the message provided by the sensor model, this field can
     // be repeated and all values are acceptable to the model, with
     // the most acceptable value being listed first, and the remaining

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -1039,25 +1039,30 @@ message RaytracerViewConfiguration
     // The wavelength of the transmitted ray in the simulation.
     //
     // Unit: nm
+    //
     optional double emitter_wavelength = 5;
     
-    // When reaching the maximmum signal loss during raytracing further raytracing is aborted.
-    // The maximum signal loss is the relation between current calculated signal strength and the emitted signal
-    // strength at the ray generation.
+    // When reaching the maximmum signal loss during raytracing further
+    // raytracing is aborted. The maximum signal loss is the relation between
+    // current calculated signal strength and the emitted signal strength at the
+    // ray generation.
     // 
     // Unit: dB
+    //
     optional double maximum_signal_loss = 6;
     
-    // The maximum path length desribes the ray's maximum overall distance.
-    // If the maximum path length is reached during simulation no further interaction is calculated.
+    // The maximum path length desribes the ray's maximum overall distance. If
+    // the maximum path length is reached during simulation no further
+    // interaction is calculated.
     //
     // Unit: m
+    //
     optional double max_path_length = 7;
     
-    // The maximum number of interaction desribes the ray's maximum hits with surfaces.
-    // If the maximum number of interaction is reached during simulation no further interaction is calculated.
+    // The maximum number of interaction desribes the ray's maximum hits with
+    // surfaces. If the maximum number of interaction is reached during
+    // simulation no further interaction is calculated.
     //
-    // Unit: -
     optional uint32 max_number_of_interactions = 8;
     
     // Format of raytracer data (includes number, kind and format of channels).
@@ -1114,8 +1119,8 @@ message RaytracerViewConfiguration
         //
         //   Contains the 2x2 Jones matrix (complex entries) of the ray with
         //   information of the electromagnetic wave's phase, signal strength
-        //   and polarisation, which gives you additonaly the projection to the
-        //   subset of the jones vectors.
+        //   and polarisation, which additionally provides the projection to the
+        //   subset of the Jones vectors.
         //
         //   Layout (in this order):
         //   vv[re], vv[im], vh[re], vh[im], hv[re], hv[im], hh[re], hh[im]

--- a/osi_sensorviewconfiguration.proto
+++ b/osi_sensorviewconfiguration.proto
@@ -237,10 +237,9 @@ message SensorViewConfiguration
     repeated UltrasonicSensorViewConfiguration
         ultrasonic_sensor_view_configuration = 1004;
         
-    // Raytracer-specific View Configuration(s).
+    // Ray tracer-specific View Configuration(s).
     //
-    repeated RaytracerViewConfiguration
-        raytracer_view_configuration = 1005;
+    repeated RayTracerViewConfiguration ray_tracer_view_configuration = 1005;
 }
 
 //
@@ -981,10 +980,10 @@ message UltrasonicSensorViewConfiguration
 
 
 //
-// \brief The configuration settings for the Raytracer View to be
+// \brief The configuration settings for the \c RayTracerView to be
 // provided by the environment simulation.
 //
-message RaytracerViewConfiguration
+message RayTracerViewConfiguration
 {
     // The ID of the sensor origin at host vehicle's mounting_position.
     //
@@ -1023,16 +1022,16 @@ message RaytracerViewConfiguration
     // mounting position (based on the vehicle configuration) when setting the
     // view configuration.
     //
-    // All raytracing results e.g. Hitpoint positions are given in this
+    // All ray tracing results e.g. Hitpoint positions are given in this
     // sensor coordinate system.
     //
     optional MountingPosition mounting_position = 2;
     
-    // Position of the raytracer`s receiver in the sensor coordinate system.
+    // Position of the ray tracer's receiver in the sensor coordinate system.
     // 
     repeated MountingPosition receiver_position = 3;
     
-    // Position of the raytracer`s transmitter in the sensor coordinate system.
+    // Position of the ray tracer's transmitter in the sensor coordinate system.
     //
     repeated MountingPosition transmitter_position = 4;
     
@@ -1042,8 +1041,8 @@ message RaytracerViewConfiguration
     //
     optional double emitter_wavelength = 5;
     
-    // When reaching the maximmum signal loss during raytracing further
-    // raytracing is aborted. The maximum signal loss is the relation between
+    // When reaching the maximum signal loss during ray tracing further
+    // ray tracing is aborted. The maximum signal loss is the relation between
     // current calculated signal strength and the emitted signal strength at the
     // ray generation.
     // 
@@ -1065,7 +1064,7 @@ message RaytracerViewConfiguration
     //
     optional uint32 max_number_of_interactions = 8;
     
-    // Format of raytracer data (includes number, kind and format of channels).
+    // Format of ray tracer data (includes number, kind and format of channels).
     //
     // The \c RayTracerFormat is used to facilitate information exchange between
     // different modules within a shared context. The ray tracing provider
@@ -1086,25 +1085,25 @@ message RaytracerViewConfiguration
     // data being provided by the simulation environment - which must
     // be one of the values the sensor model requested - or there
     // must be no value, indicating that the simulation environment
-    // cannot provide raytracer data in one of the requested formats.
+    // cannot provide ray tracer data in one of the requested formats.
     //
-    repeated RaytracerFormat raytracer_format = 9;
+    repeated RayTracerFormat ray_tracer_format = 9;
 
-    // Different predefined raytracer formats
+    // Different predefined ray tracer formats
     // 
-    enum RaytracerFormat
+    enum RayTracerFormat
     {
         // Type of channel format is unknown (must not be used).
         //
-        RAYTRACER_FORMAT_UNKNOWN = 0;
+        RAY_TRACER_FORMAT_UNKNOWN = 0;
 
         // Unspecified but known channel format.
         // Consider proposing an additional format if using
-        // \c #RAYTRACER_FORMAT_OTHER.
+        // \c #RAY_TRACER_FORMAT_OTHER.
         //
-        RAYTRACER_FORMAT_OTHER = 1;        
+        RAY_TRACER_FORMAT_OTHER = 1;        
 
-        // Raytracer format for Shoot and Bounce Approach (adapted for
+        // Ray tracer format for Shoot and Bounce Approach (adapted for
         // electromagnetic wave propagation) [1]
         //
         // The 64-byte message consists of the fields in the described order,
@@ -1145,29 +1144,29 @@ message RaytracerViewConfiguration
         //
         // * \c direction_of_arrival_hitpoint - float32[3] (meters):
         //
-        //   Coordinates of the DoA (last hitpoint) in the raytracer's
+        //   Coordinates of the DoA (last hitpoint) in the ray tracer's
         //   coordinate system defined by the mounting position.
         //
         //   Order: x, y, z
         //
-        //   Coordinate system: right-handed ([see OSI coordinate system definition](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html))
+        //   Coordinate system: right-handed (<a href="https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html">see OSI coordinate system definition</a>)
         //
         //   Offset: 40 (12 bytes)
         //
         // * \c direction_of_departure_hitpoint - float32[3] (meters):
         //
-        //   Coordinates of the DoD (first hitpoint) in the raytracer's
+        //   Coordinates of the DoD (first hitpoint) in the ray tracer's
         //   coordinate system defined by the mounting position.
         //
         //   Order: x, y, z
         //
-        //   Coordinate system: right-handed ([see OSI coordinate system definition](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html))
+        //   Coordinate system: right-handed (<a href="https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/usecases/transforming_coordinate_systems.html">see OSI coordinate system definition</a>)
         //
         //   Offset: 52 (12 bytes)
         //
         // /par Reference
         // [1] Brem, R., & Eibert, T. F. (2015, August). A Shooting and Bouncing Ray (SBR) Modeling Framework Involving Dielectrics and Perfect Conductors. IEEE Transactions on Antennas and Propagation, 63(8), 3599-3609. https://doi.org/10.1109/TAP.2015.2438318
         //
-        RAYTRACER_FORMAT_SBR = 2;
-        }
+        RAY_TRACER_FORMAT_SBR = 2;
+    }
 }


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#689 

#### Add a description
PR adds RaytracerViewConfig to SensorView fpr raytracinf interfaces and changes Lidar/RadarSensorView in interfaces without rendering techniques related fields. Changes in Lidar and RadarSensorView are not backward compatible.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
