### PR TITLE
Logical lanes: add street name

### DIFF
--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -582,6 +582,10 @@ message LogicalLane
     //
     repeated LaneConnection successor_lane = 15;
 
+    // Name of the street this lane belongs to.
+    //
+    optional string street_name = 16;
+
     //
     // Definition of available lane types.
     //


### PR DESCRIPTION
The street name is helpful when displaying the map (e.g. for navigation purposes). The street name is added to the logical lanes, since the street name will typically come from the underlying map, and most map formats are more similar to logical lanes than to physical lanes.