### PR TITLE
Roadtype

### DIFF
--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -889,4 +889,3 @@ message LogicalLane
     }
 }
 
-

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -582,6 +582,10 @@ message LogicalLane
     //
     repeated LaneConnection successor_lane = 15;
 
+    // The road type of the logical lane.
+    //
+    optional RoadType road_type = 16;
+
     //
     // Definition of available lane types.
     //
@@ -690,6 +694,72 @@ message LogicalLane
         // #overlapping_lane then describes where a tram crosses other lanes.
         //
         TYPE_TRAM = 18;
+    }
+
+    //
+    // Definition of available road types.
+    //
+    // The road types are aligned with OpenDRIVE and describe the type of a
+    // higher structure that spans one or multiple logical lanes.
+    //
+    enum RoadType{
+        // Lane of unknown type. Do not use in ground truth.
+        //
+        ROADTYPE_UNKNOWN = 0;
+
+        // Any other type of road.
+        //
+        ROADTYPE_OTHER = 1;
+
+        // A road designated to accomodate multiple road users,
+        // such as pedestrian and cyclist.
+        //
+        ROADTYPE_LOWSPEED = 2;
+
+        // A road specially built for fast travel over long distances.
+        //
+        ROADTYPE_MOTORWAY = 3;
+
+        // A pedestrian exclusive road.
+        //
+        ROADTYPE_PEDESTRIAN = 4;
+
+        // A country road which is often narrow and unpaved.
+        //
+        ROADTYPE_RURAL = 5;
+
+        // A high capacity urban road.
+        //
+        ROADTYPE_TOWNARTERIAL = 6;
+
+        // An auxiliary road to direct traffic from the residential areas
+        // to the arterial roads.
+        //
+        ROADTYPE_TOWNCOLLECTOR = 7;
+
+        // A motor vehicle exclusive road designed to connect highways with urban areas.
+        //
+        ROADTYPE_TOWNEXPRESSWAY = 8;
+
+        // A road intended to serve residential areas.
+        //
+        ROADTYPE_TOWNLOCAL = 9;
+
+        // A street that is closed to through traffic and is designated for children's play activities.
+        //
+        ROADTYPE_TOWNPLAYSTREET = 10;
+
+        // A town road which is part of a private property.
+        //
+        ROADTYPE_TOWNPRIVATE = 11;
+
+        // A regular town road.
+        //
+        ROADTYPE_TOWN = 12;
+
+        // A road that is designated for cyclists.
+        //
+        ROADTYPE_BICYCLE = 13;
     }
 
     //
@@ -818,4 +888,5 @@ message LogicalLane
         optional double end_s_other = 5;
     }
 }
+
 


### PR DESCRIPTION
**Add a description**
LogicalLane message was extended to support road type information from OpenDRIVE.

**Some questions to ask:**
What is this change?
- An additional enum type and the respective message extension.

What does it fix?
-  Missing road type information to determine the speed limit and to easily display a road in a navigation system. 

**Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:**
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.