### PR TITLE
Move sensor specifics to DetectedItemHeader

### DIFF
--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -67,6 +67,34 @@ message DetectedItemHeader
     //
     repeated Identifier sensor_id = 6;
 
+    // Additional data that is specific to radar sensors.
+    //
+    // \note Field needs not to be set if simulated sensor is not a radar
+    // sensor.
+    //
+    optional RadarSpecificObjectData radar_specifics = 100;
+
+    // Additional data that is specific to lidar sensors.
+    //
+    // \note Field needs not to be set if simulated sensor is not a lidar
+    // sensor.
+    //
+    optional LidarSpecificObjectData lidar_specifics = 101;
+
+    // Additional data that is specific to camera sensors.
+    //
+    // \note Field needs not to be set if simulated sensor is not a camera
+    // sensor.
+    //
+    optional CameraSpecificObjectData camera_specifics = 102;
+
+    // Additional data that is specific to ultrasonic sensors.
+    //
+    // \note Field needs not to be set if simulated sensor is not an ultrasonic
+    // sensor.
+    //
+    optional UltrasonicSpecificObjectData ultrasonic_specifics = 103;
+
     // Definition of measurement states.
     //
     enum MeasurementState
@@ -136,12 +164,16 @@ message DetectedStationaryObject
     // \note Field needs not to be set if simulated sensor is not a radar
     // sensor.
     //
+    // \note DEPRECATED: Use radar_specifics in DetectedItemHeader instead.
+    //
     optional RadarSpecificObjectData radar_specifics = 100;
 
     // Additional data that is specific to lidar sensors.
     //
     // \note Field needs not to be set if simulated sensor is not a lidar
     // sensor.
+    //
+    // \note DEPRECATED: Use lidar_specifics in DetectedItemHeader instead.
     //
     optional LidarSpecificObjectData lidar_specifics = 101;
 
@@ -150,12 +182,16 @@ message DetectedStationaryObject
     // \note Field needs not to be set if simulated sensor is not a camera
     // sensor.
     //
+    // \note DEPRECATED: Use camera_specifics in DetectedItemHeader instead.
+    //
     optional CameraSpecificObjectData camera_specifics = 102;
 
     // Additional data that is specific to ultrasonic sensors.
     //
     // \note Field needs not to be set if simulated sensor is not an ultrasonic
     // sensor.
+    //
+    // \note DEPRECATED: Use ultrasonic_specifics in DetectedItemHeader instead.
     //
     optional UltrasonicSpecificObjectData ultrasonic_specifics = 103;
 
@@ -273,12 +309,16 @@ message DetectedMovingObject
     // \note Field needs not to be set if simulated sensor is not a radar
     // sensor.
     //
+    // \note DEPRECATED: Use radar_specifics in DetectedItemHeader instead.
+    //
     optional RadarSpecificObjectData radar_specifics = 100;
 
     // Additional data that is specific to lidar sensors.
     //
     // \note Field needs not to be set if simulated sensor is not a lidar
     // sensor.
+    //
+    // \note DEPRECATED: Use lidar_specifics in DetectedItemHeader instead.
     //
     optional LidarSpecificObjectData lidar_specifics = 101;
 
@@ -287,12 +327,16 @@ message DetectedMovingObject
     // \note Field needs not to be set if simulated sensor is not a camera
     // sensor.
     //
+    // \note DEPRECATED: Use camera_specifics in DetectedItemHeader instead.
+    //
     optional CameraSpecificObjectData camera_specifics = 102;
 
     // Additional data that is specific to ultrasonic sensors.
     //
     // \note Field needs not to be set if simulated sensor is not an ultrasonic
     // sensor.
+    //
+    // \note DEPRECATED: Use ultrasonic_specifics in DetectedItemHeader instead.
     //
     optional UltrasonicSpecificObjectData ultrasonic_specifics = 103;
 


### PR DESCRIPTION
Signed-off-by: Thomas Sedlmayer <tsedlmayer@pmsfit.de>

This addresses #462. The PR introduces sensor-specifics in DetectedItemHeader and deprecates all sensor-specific fields that are located in DetectedMovingObject and DetectedStationaryObject directly.

This also should be discussed in terms of harmonization with ISO23150.

Resolves #462 