### PR TITLE
Links in README and example moved to docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Open Simulation Interface <sup>[[1]](https://www.hot.ei.tum.de/forschung/aut
 
 As the complexity of automated driving functions rapidly increases, the requirements for test and development methods are growing. Testing in virtual environments offers the advantage of completely controlled and reproducible environment conditions.
 
-For more information on OSI see the [official documentation]https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/index.html) or the [class list](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/annotated.html) for defined protobuf messages.
+For more information on OSI see the [official documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/index.html) or the [class list](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/annotated.html) for defined protobuf messages.
 
 [1] Hanke, T., Hirsenkorn, N., van-Driesten, C., Garcia-Ramos, P., Schiementz, M., Schneider, S. & Biebl, E. (2017, February 03). *A generic interface for the environment perception of automated driving functions in virtual scenarios.* Retrieved January 25, 2020, from https://www.hot.ei.tum.de/forschung/automotive-veroeffentlichungen/
 

--- a/README.md
+++ b/README.md
@@ -7,82 +7,18 @@ The Open Simulation Interface <sup>[[1]](https://www.hot.ei.tum.de/forschung/aut
 
 As the complexity of automated driving functions rapidly increases, the requirements for test and development methods are growing. Testing in virtual environments offers the advantage of completely controlled and reproducible environment conditions.
 
-For more information on OSI see the [official documentation](https://opensimulationinterface.github.io/osi-documentation/) or the [official reference documentation](https://opensimulationinterface.github.io/open-simulation-interface/) for defined protobuf messages.
-
-<!-- TODO: Update with new Antora hosting -->
+For more information on OSI see the [official documentation]https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/index.html) or the [class list](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/annotated.html) for defined protobuf messages.
 
 [1] Hanke, T., Hirsenkorn, N., van-Driesten, C., Garcia-Ramos, P., Schiementz, M., Schneider, S. & Biebl, E. (2017, February 03). *A generic interface for the environment perception of automated driving functions in virtual scenarios.* Retrieved January 25, 2020, from https://www.hot.ei.tum.de/forschung/automotive-veroeffentlichungen/
 
 ## Usage
-##### Example of generating OSI messages in `Python`
-```python
-# generate_osi_messages.py
-from osi3.osi_sensorview_pb2 import SensorView
-import struct
+For usage examples, please refer to the official documentation:
+- [Trace file generation with python](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_example.html)
+- [OSMP examples](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/sensor-model/setup/build_install_example.html), including the code found at [osi-sensor-model-packaging](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging):
+  - [OSMPDummySource](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPDummySource)
+  - [OSMPDummySensor](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPDummySensor)
+  - [OSMPCNetworkProxy](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPCNetworkProxy)
 
-NANO_INCREMENT = 10000000
-MOVING_OBJECT_LENGTH = 5
-MOVING_OBJECT_WIDTH = 2
-MOVING_OBJECT_HEIGHT = 1
-
-def main():
-    """Initialize SensorView"""
-    f = open("sv_330_361_1000_movingobject.osi", "ab")
-    sensorview = SensorView()
-
-    sv_ground_truth = sensorview.global_ground_truth
-    sv_ground_truth.version.version_major = 3
-    sv_ground_truth.version.version_minor = 5
-    sv_ground_truth.version.version_patch = 0
-
-    sv_ground_truth.timestamp.seconds = 0
-    sv_ground_truth.timestamp.nanos = 0
-
-    moving_object = sv_ground_truth.moving_object.add()
-    moving_object.id.value = 42
-
-    # Generate 1000 OSI messages for a duration of 10 seconds
-    for i in range(1000):
-
-        # Increment the time
-        if sv_ground_truth.timestamp.nanos > 1000000000:
-            sv_ground_truth.timestamp.seconds += 1
-            sv_ground_truth.timestamp.nanos = 0
-        sv_ground_truth.timestamp.nanos += NANO_INCREMENT
-
-        moving_object.vehicle_classification.type = 2
-
-        moving_object.base.dimension.length = MOVING_OBJECT_LENGTH
-        moving_object.base.dimension.width = MOVING_OBJECT_WIDTH
-        moving_object.base.dimension.height = MOVING_OBJECT_HEIGHT
-
-        moving_object.base.position.x += 0.5
-        moving_object.base.position.y = 0.0
-        moving_object.base.position.z = 0.0
-
-        moving_object.base.orientation.roll = 0.0
-        moving_object.base.orientation.pitch = 0.0
-        moving_object.base.orientation.yaw = 0.0
-
-        """Serialize"""
-        bytes_buffer = sensorview.SerializeToString()
-        f.write(struct.pack("<L", len(bytes_buffer)))
-        f.write(bytes_buffer)
-
-    f.close()
-
-if __name__ == "__main__":
-    main()
-```
-
-To run the script execute the following command in the terminal:
-```bash
-python3 generate_osi_messages.py
-```
-
-This will output an osi file (`sv_330_361_1000_movingobject.osi`) which can be visualized and played back by the [osi-visualizer](https://github.com/OpenSimulationInterface/osi-visualizer).
-
-See Google's documentation for more tutorials on how to use protocol buffers with [Python](https://developers.google.com/protocol-buffers/docs/pythontutorial) or [C++](https://developers.google.com/protocol-buffers/docs/cpptutorial).
 ## Installation
 ##### Dependencies
 Install `cmake` 3.10.2:

--- a/doc/_config.adoc
+++ b/doc/_config.adoc
@@ -41,6 +41,7 @@ ifndef::include-only-once[]
 // Please note that this variable has to used in all image includes. Includes here have to use "image::./images..."
 // :images_osi_sensor_model_packaging: ./osi-sensor-model-packaging/doc/images  // example
 :imagesoutdir: ./images/generated_images
+
 endif::[]
 ifndef::use-antora-rules[]
 include::{asciidoc-resources}/preamble.adoc[]

--- a/doc/architecture/trace_file_example.adoc
+++ b/doc/architecture/trace_file_example.adoc
@@ -1,0 +1,75 @@
+ifndef::include-only-once[]
+:root-path: ../
+include::{root-path}_config.adoc[]
+endif::[]
+[#top-osi_trace_file_example]
+= OSI trace file example
+[source,ruby]
+----
+# generate_osi_messages.py
+from osi3.osi_sensorview_pb2 import SensorView
+import struct
+
+NANO_INCREMENT = 10000000
+MOVING_OBJECT_LENGTH = 5
+MOVING_OBJECT_WIDTH = 2
+MOVING_OBJECT_HEIGHT = 1
+
+def main():
+    """Initialize SensorView"""
+    f = open("sv_330_361_1000_movingobject.osi", "ab")
+    sensorview = SensorView()
+
+    sv_ground_truth = sensorview.global_ground_truth
+    sv_ground_truth.version.version_major = 3
+    sv_ground_truth.version.version_minor = 5
+    sv_ground_truth.version.version_patch = 0
+
+    sv_ground_truth.timestamp.seconds = 0
+    sv_ground_truth.timestamp.nanos = 0
+
+    moving_object = sv_ground_truth.moving_object.add()
+    moving_object.id.value = 42
+
+    # Generate 1000 OSI messages for a duration of 10 seconds
+    for i in range(1000):
+
+        # Increment the time
+        if sv_ground_truth.timestamp.nanos > 1000000000:
+            sv_ground_truth.timestamp.seconds += 1
+            sv_ground_truth.timestamp.nanos = 0
+        sv_ground_truth.timestamp.nanos += NANO_INCREMENT
+
+        moving_object.vehicle_classification.type = 2
+
+        moving_object.base.dimension.length = MOVING_OBJECT_LENGTH
+        moving_object.base.dimension.width = MOVING_OBJECT_WIDTH
+        moving_object.base.dimension.height = MOVING_OBJECT_HEIGHT
+
+        moving_object.base.position.x += 0.5
+        moving_object.base.position.y = 0.0
+        moving_object.base.position.z = 0.0
+
+        moving_object.base.orientation.roll = 0.0
+        moving_object.base.orientation.pitch = 0.0
+        moving_object.base.orientation.yaw = 0.0
+
+        """Serialize"""
+        bytes_buffer = sensorview.SerializeToString()
+        f.write(struct.pack("<L", len(bytes_buffer)))
+        f.write(bytes_buffer)
+
+    f.close()
+
+if __name__ == "__main__":
+    main()
+----
+
+To run the script execute the following command in the terminal:
+----
+python3 generate_osi_messages.py
+----
+
+This will output an osi file (`sv_330_361_1000_movingobject.osi`) which can be visualized and played back by the [osi-visualizer](https://github.com/OpenSimulationInterface/osi-visualizer).
+
+See Google's documentation for more tutorials on how to use protocol buffers with [Python](https://developers.google.com/protocol-buffers/docs/pythontutorial) or [C++](https://developers.google.com/protocol-buffers/docs/cpptutorial).

--- a/doc/architecture/trace_file_example.adoc
+++ b/doc/architecture/trace_file_example.adoc
@@ -4,7 +4,8 @@ include::{root-path}_config.adoc[]
 endif::[]
 [#top-osi_trace_file_example]
 = OSI trace file example
-[source,ruby]
+
+[source, python]
 ----
 # generate_osi_messages.py
 from osi3.osi_sensorview_pb2 import SensorView
@@ -66,10 +67,12 @@ if __name__ == "__main__":
 ----
 
 To run the script execute the following command in the terminal:
+
+[source, bash]
 ----
 python3 generate_osi_messages.py
 ----
 
-This will output an osi file (`sv_330_361_1000_movingobject.osi`) which can be visualized and played back by the [osi-visualizer](https://github.com/OpenSimulationInterface/osi-visualizer).
+This will output an osi file (`sv_330_361_1000_movingobject.osi`) which can be visualized and played back by the https://github.com/OpenSimulationInterface/osi-visualizer[osi-visualizer^].
 
-See Google's documentation for more tutorials on how to use protocol buffers with [Python](https://developers.google.com/protocol-buffers/docs/pythontutorial) or [C++](https://developers.google.com/protocol-buffers/docs/cpptutorial).
+See Google's documentation for more tutorials on how to use protocol buffers with https://developers.google.com/protocol-buffers/docs/pythontutorial[Python^] or https://developers.google.com/protocol-buffers/docs/cpptutorial[C++^].

--- a/doc/open-simulation-interface_user_guide.adoc
+++ b/doc/open-simulation-interface_user_guide.adoc
@@ -67,6 +67,8 @@ include::./architecture/trace_file_naming.adoc[leveloffset=+3]
 
 // include::./architecture/test_scripts.adoc[leveloffset=+3]
 
+include::./architecture/trace_file_example.adoc[leveloffset=+3]
+
 include::./architecture/formatting_scripts.adoc[leveloffset=+3]
 
 == Setting up OSI


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
This PR should solve #719.

#### Add a description
As discussed in the last CCB meeting, we should change the README to only link to the usage examples in the official documentation.

Required steps:
- Move current example as an example to trace-file section in the docu
- Add links in the README to trace file section and OSMP examples

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
