### PR TITLE
Fix sensordata reference frame definitions

### DIFF
--- a/osi_detectedlane.proto
+++ b/osi_detectedlane.proto
@@ -54,6 +54,15 @@ message DetectedLane
 //
 // \image html OSI_DetectedLaneBoundary.svg
 //
+// The parent frame of a detected lane boundary is the virtual sensor coordinate
+// system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensor mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
+//
 message DetectedLaneBoundary
 {
     // Common information of one detected item.

--- a/osi_detectedlane.proto
+++ b/osi_detectedlane.proto
@@ -57,7 +57,7 @@ message DetectedLane
 // The parent frame of a detected lane boundary is the virtual sensor coordinate
 // system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// /note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -93,6 +93,15 @@ message DetectedItemHeader
 //
 // \image html OSI_DetectedStationaryObject.svg
 //
+// The parent frame of a detected stationary object is the virtual sensor
+// coordinate system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensor mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
+//
 message DetectedStationaryObject
 {
     // Common information of one detected item.
@@ -172,8 +181,17 @@ message DetectedStationaryObject
 }
 
 //
-// \brief Moving object in the environment as detected and perceived by
-// the sensor.
+// \brief Moving object in the environment as detected and perceived by the
+// sensor.
+//
+// The parent frame of a detected moving object is the virtual sensor coordinate
+// system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensor mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
 //
 message DetectedMovingObject
 {
@@ -183,8 +201,7 @@ message DetectedMovingObject
 
     // The base parameters of the moving object.
     //
-    // \note The bounding box does NOT includes mirrors for vehicles.
-    // \note The parent frame of \c base is the sensor's vehicle frame.
+    // \note The bounding box does NOT include mirrors for vehicles.
     // \note The height includes the ground_clearance. It always goes from the
     // top to the ground.
     //
@@ -193,8 +210,6 @@ message DetectedMovingObject
     // The root mean squared error of the base parameters of the detected
     // moving object (e.g. car). \c MovingObject::base has to be
     // identical for all \c #candidate moving objects.
-    //
-    // \note The parent frame of \c base is the sensor's vehicle frame.
     //
     optional BaseMoving base_rmse = 3;
 

--- a/osi_detectedobject.proto
+++ b/osi_detectedobject.proto
@@ -96,7 +96,7 @@ message DetectedItemHeader
 // The parent frame of a detected stationary object is the virtual sensor
 // coordinate system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// /note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the
@@ -187,7 +187,7 @@ message DetectedStationaryObject
 // The parent frame of a detected moving object is the virtual sensor coordinate
 // system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// /note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the

--- a/osi_detectedroadmarking.proto
+++ b/osi_detectedroadmarking.proto
@@ -23,7 +23,7 @@ package osi3;
 // The parent frame of a detected road marking is the virtual sensor coordinate
 // system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// /note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the

--- a/osi_detectedroadmarking.proto
+++ b/osi_detectedroadmarking.proto
@@ -20,6 +20,15 @@ package osi3;
 // RoadMarking::Classification::type == \c
 // RoadMarking::Classification::TYPE_SYMBOLIC_TRAFFIC_SIGN is not marked.
 //
+// The parent frame of a detected road marking is the virtual sensor coordinate
+// system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensor mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
+//
 message DetectedRoadMarking
 {
     // Common information of one detected item.

--- a/osi_detectedtrafficlight.proto
+++ b/osi_detectedtrafficlight.proto
@@ -13,18 +13,18 @@ package osi3;
 //
 // \image html OSI_DetectedTrafficLight.svg
 //
+// One detected traffic light message defines a single 'bulb' and not a box of
+// several bulbs, e.g. red, yellow, green are three separate detected traffic
+// lights.
+//
 // The parent frame of a detected traffic light is the virtual sensor coordinate
 // system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// /note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the
 // vehicle coordinate system.
-//
-// One detected traffic light message defines a single 'bulb' and not a box of
-// several bulbs, e.g. red, yellow, green are three separate detected traffic
-// lights.
 //
 message DetectedTrafficLight
 {

--- a/osi_detectedtrafficlight.proto
+++ b/osi_detectedtrafficlight.proto
@@ -13,6 +13,15 @@ package osi3;
 //
 // \image html OSI_DetectedTrafficLight.svg
 //
+// The parent frame of a detected traffic light is the virtual sensor coordinate
+// system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensor mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
+//
 // One detected traffic light message defines a single 'bulb' and not a box of
 // several bulbs, e.g. red, yellow, green are three separate detected traffic
 // lights.

--- a/osi_detectedtrafficsign.proto
+++ b/osi_detectedtrafficsign.proto
@@ -13,6 +13,15 @@ package osi3;
 //
 // \image html OSI_DetectedSign.svg
 //
+// The parent frame of a detected traffic sign is the virtual sensor coordinate
+// system.
+//
+// The virtual sensor coordinate system is relative to the vehicle coordinate
+// system which has its origin in the center of the rear axle of the ego
+// vehicle. This means if virtual sensoqr mounting position and orientation are
+// set to (0,0,0) the virtual sensor coordinate system coincides with the
+// vehicle coordinate system.
+//
 message DetectedTrafficSign
 {
     // Common information of one detected item.
@@ -45,11 +54,14 @@ message DetectedTrafficSign
         //
         // The orientation of the bounding box \c #base
         // ( \c BaseStationary::orientation ) is defined as follows:
+        //
         // The z-axis of the given \c BaseStationary::orientation is the vector
         // from the bottom to the top of the traffic sign's 2D image plate.
         // (Normally it is equal to the ground truth z-axis.)
+        //
         // The x-axis of the given \c BaseStationary::orientation is view
         // normal of the traffic sign's image.
+        //
         // This x-axis points from the traffic sign's image in the direction
         // from where a 'viewer' could see the traffic sign image.
         //

--- a/osi_detectedtrafficsign.proto
+++ b/osi_detectedtrafficsign.proto
@@ -18,7 +18,7 @@ package osi3;
 //
 // The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
-// vehicle. This means if virtual sensoqr mounting position and orientation are
+// vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the
 // vehicle coordinate system.
 //

--- a/osi_detectedtrafficsign.proto
+++ b/osi_detectedtrafficsign.proto
@@ -16,7 +16,7 @@ package osi3;
 // The parent frame of a detected traffic sign is the virtual sensor coordinate
 // system.
 //
-// The virtual sensor coordinate system is relative to the vehicle coordinate
+// \note The virtual sensor coordinate system is relative to the vehicle coordinate
 // system which has its origin in the center of the rear axle of the ego
 // vehicle. This means if virtual sensor mounting position and orientation are
 // set to (0,0,0) the virtual sensor coordinate system coincides with the

--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -70,10 +70,9 @@ message SensorDetectionHeader
     //
     optional uint64 cycle_counter = 2;
 
-    // Mounting position of the sensor (origin and orientation of the sensor
-    // frame). Both origin and orientation are given in and with respect to the
-    // host vehicle coordinate system (see: \c MovingObject::Vehicle vehicle
-    // reference point) [1].
+    // The physical mounting position of the sensor (origin and orientation of
+    // the sensor frame). Both origin and orientation are given in and with
+    // respect to the host vehicle coordinate system [1].
     //
     // The sensor frame's x-axis is pointing in the central viewing direction of
     // the sensor. It is the angle bisector of the sensor's horizontal and

--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -31,7 +31,7 @@ message LogicalDetectionData
     // The parent frame of a logical detection is the virtual sensor coordinate
     // system specified by \c SensorView::mounting_position .
     //
-    // The virtual sensor coordinate system is relative to the vehicle
+    // /note The virtual sensor coordinate system is relative to the vehicle
     // coordinate system which has its origin in the center of the rear axle of
     // the ego vehicle. This means if virtual sensor mounting position and
     // orientation are set to (0,0,0) the virtual sensor coordinate system

--- a/osi_logicaldetectiondata.proto
+++ b/osi_logicaldetectiondata.proto
@@ -25,9 +25,17 @@ message LogicalDetectionData
     //
     optional LogicalDetectionDataHeader header = 2;
 
-    // logical detections consisting of transformed (and potentially fused) detections from one or multiple sensors and sensor types.
-    // Logical detections are given with respect to the reference frame of the logical/virtual sensor
-    // \c SensorView::mounting_position (e.g. center of rear axle of the ego car)
+    // Logical detections consisting of transformed (and potentially fused)
+    // detections from one or multiple sensors and sensor types.
+    //
+    // The parent frame of a logical detection is the virtual sensor coordinate
+    // system specified by \c SensorView::mounting_position .
+    //
+    // The virtual sensor coordinate system is relative to the vehicle
+    // coordinate system which has its origin in the center of the rear axle of
+    // the ego vehicle. This means if virtual sensor mounting position and
+    // orientation are set to (0,0,0) the virtual sensor coordinate system
+    // coincides with the vehicle coordinate system.
     //
     repeated LogicalDetection logical_detection = 3;
 }
@@ -131,8 +139,8 @@ message LogicalDetection
     //
     optional Identifier object_id = 2;
 
-    // Measured position of the logical detection given in cartesian coordinates in the
-    // host vehicle coordinate system.
+    // Measured position of the logical detection given in cartesian coordinates
+    // in the virtual sensor coordinate system.
     //
     // Unit: m
     //
@@ -143,7 +151,7 @@ message LogicalDetection
     optional Vector3d position_rmse = 4;
 
     // Velocity of the logical detection given in cartesian coordinates in the
-    // host vehicle coordinate system.
+    // virtual sensor coordinate system.
     //
     // Unit: m/s
     //

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -62,15 +62,17 @@ message SensorView
     //
     optional Identifier sensor_id = 3;
 
-    // The virtual mounting position of the sensor (origin and orientation
-    // of the sensor coordinate system) given in vehicle coordinates [1].
-    // The virtual position pertains to the sensor as a whole, regardless
-    // of the actual position of individual physical detectors, and governs
-    // the sensor-relative coordinates in detected objects of the sensor
-    // as a whole. Individual features detected by individual physical
-    // detectors are governed by the actual physical mounting positions
-    // of the detectors, as indicated in the technology-specific sub-views
-    // and sub-view configurations.
+    // The virtual mounting position of the sensor (origin and orientation of
+    // the sensor frame). Both origin and orientation are given in and with
+    // respect to the host vehicle coordinate system [1].
+    //
+    // The virtual position pertains to the sensor as a whole, regardless of the
+    // actual position of individual physical detectors, and governs the
+    // sensor-relative coordinates in detected objects of the sensor as a whole.
+    // Individual features detected by individual physical detectors are
+    // governed by the actual physical mounting positions of the detectors, as
+    // indicated in the technology-specific sub-views and sub-view
+    // configurations.
     //
     // \arg \b x-direction of sensor coordinate system: sensor viewing direction
     // \arg \b z-direction of sensor coordinate system: sensor (up)


### PR DESCRIPTION
Resolves #712 

- I removed the incorrect parent frame definition for detected moving object base and base_rmse.
- I added definitions of the respective parent frame for all SensorData objects (moving objects, stationary objects, traffic sign, traffic light, road marking, lane boundary). Some of those SensorData objects have example images where the reference frame of the detected objects is shown to be the vehicle coordinate system (with its origin in the center of the rear axle of the ego vehicle). Though, this only applies if virtual mounting position and orientation are set to (0,0,0) for x, y, z and yaw, pitch, roll. I tried to clarify those images by adding some explanation.