### PR TITLE
Added radial_velocity to LidarDetection

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -454,6 +454,12 @@ message LidarDetection
     // [1] Rosenberger, P., Holder, M.F., Cianciaruso, N. et al. (2020). <em>Sequential lidar sensor system simulation: a modular approach for simulation-based safety validation of automated driving</em> Automot. Engine Technol. 5, Fig 7, Fig 8. Retrieved May 10, 2021, from https://doi.org/10.1007/s41104-020-00066-x
     //
     optional double echo_pulse_width = 11;
+
+    // Radial velocity of the detection positive in direction to the sensor.
+    //
+    // Unit: m/s
+    //
+    optional double radial_velocity = 12;
 }
 
 //


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#307

#### Add a description
Added radial_velocity to LidarDetection as FMCW lidars are capable of measuring the relative radial velocity.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
