### PR TITLE
Fix flatbuffer builds for upcoming release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flatbuffers"]
-	path = flatbuffers
-	url = https://github.com/google/flatbuffers.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,10 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES})
 set(FLAT_HEADERS "")
 if(OSI_BUILD_FLATBUFFER)
   set(FLAT_FBS "")
-  add_subdirectory("flatbuffers"
-                   ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-build
-                   EXCLUDE_FROM_ALL)
+  find_package(flatbuffers REQUIRED)
+  if(NOT FLATBUFFERS_FLATC_EXECUTABLE)
+    set(FLATBUFFERS_FLATC_EXECUTABLE ${flatbuffers_DIR}/../../tools/flatbuffers/flatc)
+  endif()
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/descriptor.fbs" "namespace osi3;")
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
   list(APPEND FLAT_FBS "${CMAKE_CURRENT_BINARY_DIR}/descriptor.fbs")
@@ -111,8 +112,8 @@ if(OSI_BUILD_FLATBUFFER)
     set(fbs "${proto_base}.fbs")
     add_custom_command(
       OUTPUT "${fbs}"
-      COMMAND $<TARGET_FILE:flatc> -I "${PROTOBUF_IMPORT_DIRS}" -I "${CMAKE_CURRENT_BINARY_DIR}" -o "${CMAKE_CURRENT_BINARY_DIR}" --proto "${proto}"
-      DEPENDS "${proto}" flatc
+      COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE} -I "${PROTOBUF_IMPORT_DIRS}" -I "${CMAKE_CURRENT_BINARY_DIR}" -o "${CMAKE_CURRENT_BINARY_DIR}" --proto "${proto}"
+      DEPENDS "${proto}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Convert ${proto} to ${fbs} using flatc"
     )
@@ -125,8 +126,8 @@ if(OSI_BUILD_FLATBUFFER)
     set(fbh "${flat_base}_generated.h")
     add_custom_command(
       OUTPUT "include/${fbh}"
-      COMMAND $<TARGET_FILE:flatc> -o "${CMAKE_CURRENT_BINARY_DIR}/include" --cpp --gen-mutable --gen-name-strings --scoped-enums "${fbs}"
-      DEPENDS "${FLAT_FBS}" flatc
+      COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE} -o "${CMAKE_CURRENT_BINARY_DIR}/include" --cpp --gen-mutable --gen-name-strings --scoped-enums "${fbs}"
+      DEPENDS "${FLAT_FBS}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
       COMMENT "Process ${fbs} to ${fbh} using flatc"
     )
@@ -137,7 +138,7 @@ if(OSI_BUILD_FLATBUFFER)
   add_library(${PROJECT_NAME}_fbs INTERFACE)
   target_include_directories(${PROJECT_NAME}_fbs INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>)
   target_include_directories(${PROJECT_NAME}_fbs SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
-  target_link_libraries(${PROJECT_NAME}_fbs INTERFACE flatbuffers)
+  target_link_libraries(${PROJECT_NAME}_fbs INTERFACE flatbuffers::flatbuffers)
 endif()
 
 add_library(${PROJECT_NAME}_static STATIC ${PROTO_SRCS} ${PROTO_HEADERS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,9 @@ if(OSI_BUILD_FLATBUFFER)
     set(fbs "${proto_base}.fbs")
     add_custom_command(
       OUTPUT "${fbs}"
-      COMMAND $<TARGET_FILE:flatc> -I "${PROTOBUF_IMPORT_DIRS}" -o "${CMAKE_CURRENT_BINARY_DIR}" --proto "${CMAKE_CURRENT_SOURCE_DIR}/${proto}"
+      COMMAND $<TARGET_FILE:flatc> -I "${PROTOBUF_IMPORT_DIRS}" -I "${CMAKE_CURRENT_BINARY_DIR}" -o "${CMAKE_CURRENT_BINARY_DIR}" --proto "${proto}"
       DEPENDS "${proto}" flatc
-      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Convert ${proto} to ${fbs} using flatc"
     )
     list(APPEND FLAT_FBS "${CMAKE_CURRENT_BINARY_DIR}/${fbs}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(OSI_BUILD_FLATBUFFER)
 
   add_custom_target(${PROJECT_NAME}_fbs_build ALL DEPENDS "${FLAT_HEADERS}")
   add_library(${PROJECT_NAME}_fbs INTERFACE)
+  add_library(${PROJECT_NAME}::${PROJECT_NAME}_fbs ALIAS ${PROJECT_NAME}_fbs)
   target_include_directories(${PROJECT_NAME}_fbs INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>)
   target_include_directories(${PROJECT_NAME}_fbs SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
   target_link_libraries(${PROJECT_NAME}_fbs INTERFACE flatbuffers::flatbuffers)

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -973,27 +973,6 @@ message LaneBoundary
     //
     message Classification
     {
-        // The type of the lane boundary.
-        //
-        optional Type type = 1;
-
-        // The semantic color of the lane boundary in case of lane markings.
-        //
-        // \note The color types represent the semantic classification of
-        // lane markings only. They do not represent an actual visual appearance.
-        //
-        optional Color color = 2;
-
-        // The ids of \c StationaryObject which limit the corresponding lane.
-        // This field must be set if the \c #type is set to
-        // \c #TYPE_STRUCTURE
-        //
-        // \rules
-        // refers_to: StationaryObject
-        // \endrules
-        //
-        repeated Identifier limiting_structure_id = 3;
-
         // The lane boundary type.
         // There is no special representation for double lines, e.g. solid /
         // solid or dashed / solid. In such cases, each lane will define its own
@@ -1069,6 +1048,28 @@ message LaneBoundary
             //
             TYPE_SOUND_BARRIER = 15;
         }
+
+        // The type of the lane boundary.
+        //
+        optional Type type = 1;
+
+        // The semantic color of the lane boundary in case of lane markings.
+        //
+        // \note The color types represent the semantic classification of
+        // lane markings only. They do not represent an actual visual appearance.
+        //
+        optional Color color = 2;
+
+        // The ids of \c StationaryObject which limit the corresponding lane.
+        // This field must be set if the \c #type is set to
+        // \c #TYPE_STRUCTURE
+        //
+        // \rules
+        // refers_to: StationaryObject
+        // \endrules
+        //
+        repeated Identifier limiting_structure_id = 3;
+
 
         // The semantic color of the lane boundary in case of a lane markings.
         // Lane markings that alternate in color must be represented by

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -400,6 +400,31 @@ message MovingObject
     //
     optional BaseMoving base = 2;
 
+    // Definition of object types.
+    //
+    enum Type
+    {
+        // Type of the object is unknown (must not be used in ground truth).
+        //
+        TYPE_UNKNOWN = 0;
+
+        // Other (unspecified but known) type of moving object.
+        //
+        TYPE_OTHER = 1;
+
+        // Object is a vehicle.
+        //
+        TYPE_VEHICLE = 2;
+
+        // Object is a pedestrian.
+        //
+        TYPE_PEDESTRIAN = 3;
+
+        // Object is an animal.
+        //
+        TYPE_ANIMAL = 4;
+    }
+
     // The type of the object.
     //
     optional Type type = 3;
@@ -487,31 +512,6 @@ message MovingObject
     // The dominating color of the material of the moving object.
     //
     optional ColorDescription color_description = 11;
-
-    // Definition of object types.
-    //
-    enum Type
-    {
-        // Type of the object is unknown (must not be used in ground truth).
-        //
-        TYPE_UNKNOWN = 0;
-
-        // Other (unspecified but known) type of moving object.
-        //
-        TYPE_OTHER = 1;
-
-        // Object is a vehicle.
-        //
-        TYPE_VEHICLE = 2;
-
-        // Object is a pedestrian.
-        //
-        TYPE_PEDESTRIAN = 3;
-
-        // Object is an animal.
-        //
-        TYPE_ANIMAL = 4;
-    }
 
     //
     // \brief The vehicle attributes for \c MovingObject (host or other).
@@ -727,33 +727,6 @@ message MovingObject
     //
     message VehicleClassification
     {
-        // The type of the vehicle.
-        //
-        optional Type type = 1;
-
-        // The light state of the vehicle.
-        //
-        optional LightState light_state = 2;
-
-        // Flag defining whether the vehicle has an attached trailer.
-        //
-        optional bool has_trailer = 3;
-
-        // Id of the attached trailer.
-        //
-        // \note Field need not be set if has_Trailer is set to false or use
-        // value for non valid id.
-        //
-        // \rules
-        // check_if this.has_trailer is_equal_to true else do_check is_set
-        // \endrules
-        //
-        optional Identifier trailer_id = 4;
-
-        // The role of the vehicle.
-        //
-        optional Role role = 5;
-
         // Definition of vehicle types.
         //
         // \note OSI provides a richer set of vehicle types than is supported by some
@@ -872,6 +845,33 @@ message MovingObject
             //
             TYPE_STANDUP_SCOOTER = 17;
         }
+
+        // The type of the vehicle.
+        //
+        optional Type type = 1;
+
+        // The light state of the vehicle.
+        //
+        optional LightState light_state = 2;
+
+        // Flag defining whether the vehicle has an attached trailer.
+        //
+        optional bool has_trailer = 3;
+
+        // Id of the attached trailer.
+        //
+        // \note Field need not be set if has_Trailer is set to false or use
+        // value for non valid id.
+        //
+        // \rules
+        // check_if this.has_trailer is_equal_to true else do_check is_set
+        // \endrules
+        //
+        optional Identifier trailer_id = 4;
+
+        // The role of the vehicle.
+        //
+        optional Role role = 5;
 
         //
         // \brief The state of the lights of a vehicle.

--- a/osi_trafficsign.proto
+++ b/osi_trafficsign.proto
@@ -5630,119 +5630,6 @@ message TrafficSign
             //
             optional Variability variability = 1;
 
-            // Type of the supplementary sign.
-            //
-            // \attention Deprecated: A revision is planned for version 4.0.0 to
-            // replace the type enum with a more semantically defined enumeration,
-            // with the exact sign specification being relegated to the newly
-            // introduced 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            optional Type type = 2;
-
-            // Additional value(s) associated with the traffic sign, e.g.
-            // length, mass or starting time in time range.
-            //
-            // \note Field need not be set if traffic sign type does not require
-            // it.
-            //
-            // \note OSI uses singular instead of plural for repeated field
-            // names.
-            //
-            repeated TrafficSignValue value = 3;
-
-            // The IDs of the lanes that the sign is assigned to.
-            // May be multiple if the sign is valid for multiple lanes.
-            //
-            // \note OSI uses singular instead of plural for repeated field
-            // names.
-            //
-            // \rules
-            // refers_to: Lane
-            // \endrules
-            //
-            repeated Identifier assigned_lane_id = 4;
-
-            // This enumerator indicates a traffic actor (e.g.
-            // bikes, cars, trucks and so on), that the supplementary sign
-            // makes reference to.
-            //
-            // \attention Deprecated: A revision is planned for version 4.0.0 to
-            // replace the type enum with a more semantically defined enumeration,
-            // with the exact sign specification being relegated to the newly
-            // introduced 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            repeated Actor actor = 5;
-
-            // A direction arrow shown on the supplementary sign.
-            //
-            // \attention Deprecated: A revision is planned for version 4.0.0 to
-            // replace the type enum with a more semantically defined enumeration,
-            // with the exact sign specification being relegated to the newly
-            // introduced 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            repeated Arrow arrow = 6;
-
-            // Boolean flag to indicate that the supplementary traffic sign is taken out of service.
-            // This can be achieved by visibly crossing the sign or covering it completely.
-            //
-            optional bool is_out_of_service = 7;
-
-            // Country specification of the traffic sign catalog specification
-            // that identifies the actual traffic sign. This is part of the
-            // 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            // Country is specified using the ISO 3166-1, alpha-2 code
-            // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2, or the
-            // special OpenDRIVE country for generic signs.<br>
-            //
-            optional string country = 8;
-
-            // Revision specification of the traffic sign catalog specification
-            // that identifies the actual traffic sign. This is part of the
-            // 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            // The year the traffic rules came into force. <br>
-            // e.g. "2017"
-            //
-            optional string country_revision = 9;
-
-            // Code specification of the traffic sign catalog specification
-            // that identifies the actual traffic sign. This is part of the
-            // 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            // Code identifier according to country and country revision,
-            // corresponds to the type field of OpenDRIVE. <br>
-            // code is only unique in combination with #country and #country_revision.  <br>
-            // e.g. http://www.vzkat.de/2017/VzKat.htm
-            //
-            optional string code = 10;
-
-            // Sub-code specification of the traffic sign catalog specification
-            // that identifies the actual traffic sign. This is part of the
-            // 4-tupel traffic sign catalog specification as used in
-            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
-            //
-            // Sub-code identifier according to country, country revision and code,
-            // corresponds to the subtype field of OpenDRIVE. <br>
-            // sub_code is only unique in combination with #country, #country_revision,
-            // and #code.  <br>
-            // e.g. http://www.vzkat.de/2017/VzKat.htm
-            //
-            optional string sub_code = 11;
-
-            // Assignment of this object to logical lanes.
-            //
-            // \note OSI uses singular instead of plural for repeated field
-            // names.
-            //
-            repeated LogicalLaneAssignment logical_lane_assignment = 12;
-
             // Definition of supplementary sign types.
             //
             // For general supplementary signs use \c #TYPE_TEXT.
@@ -9174,6 +9061,119 @@ message TrafficSign
                 // Please add next element with counter equal to last_counter+1.
                 // After that, manually increment last_counter
             }
+
+            // Type of the supplementary sign.
+            //
+            // \attention Deprecated: A revision is planned for version 4.0.0 to
+            // replace the type enum with a more semantically defined enumeration,
+            // with the exact sign specification being relegated to the newly
+            // introduced 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            optional Type type = 2;
+
+            // Additional value(s) associated with the traffic sign, e.g.
+            // length, mass or starting time in time range.
+            //
+            // \note Field need not be set if traffic sign type does not require
+            // it.
+            //
+            // \note OSI uses singular instead of plural for repeated field
+            // names.
+            //
+            repeated TrafficSignValue value = 3;
+
+            // The IDs of the lanes that the sign is assigned to.
+            // May be multiple if the sign is valid for multiple lanes.
+            //
+            // \note OSI uses singular instead of plural for repeated field
+            // names.
+            //
+            // \rules
+            // refers_to: Lane
+            // \endrules
+            //
+            repeated Identifier assigned_lane_id = 4;
+
+            // This enumerator indicates a traffic actor (e.g.
+            // bikes, cars, trucks and so on), that the supplementary sign
+            // makes reference to.
+            //
+            // \attention Deprecated: A revision is planned for version 4.0.0 to
+            // replace the type enum with a more semantically defined enumeration,
+            // with the exact sign specification being relegated to the newly
+            // introduced 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            repeated Actor actor = 5;
+
+            // A direction arrow shown on the supplementary sign.
+            //
+            // \attention Deprecated: A revision is planned for version 4.0.0 to
+            // replace the type enum with a more semantically defined enumeration,
+            // with the exact sign specification being relegated to the newly
+            // introduced 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            repeated Arrow arrow = 6;
+
+            // Boolean flag to indicate that the supplementary traffic sign is taken out of service.
+            // This can be achieved by visibly crossing the sign or covering it completely.
+            //
+            optional bool is_out_of_service = 7;
+
+            // Country specification of the traffic sign catalog specification
+            // that identifies the actual traffic sign. This is part of the
+            // 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            // Country is specified using the ISO 3166-1, alpha-2 code
+            // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2, or the
+            // special OpenDRIVE country for generic signs.<br>
+            //
+            optional string country = 8;
+
+            // Revision specification of the traffic sign catalog specification
+            // that identifies the actual traffic sign. This is part of the
+            // 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            // The year the traffic rules came into force. <br>
+            // e.g. "2017"
+            //
+            optional string country_revision = 9;
+
+            // Code specification of the traffic sign catalog specification
+            // that identifies the actual traffic sign. This is part of the
+            // 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            // Code identifier according to country and country revision,
+            // corresponds to the type field of OpenDRIVE. <br>
+            // code is only unique in combination with #country and #country_revision.  <br>
+            // e.g. http://www.vzkat.de/2017/VzKat.htm
+            //
+            optional string code = 10;
+
+            // Sub-code specification of the traffic sign catalog specification
+            // that identifies the actual traffic sign. This is part of the
+            // 4-tupel traffic sign catalog specification as used in
+            // <a href="https://releases.asam.net/OpenDRIVE/1.6.0/ASAM_OpenDRIVE_BS_V1-6-0.html#_signals">OpenDRIVE</a>.
+            //
+            // Sub-code identifier according to country, country revision and code,
+            // corresponds to the subtype field of OpenDRIVE. <br>
+            // sub_code is only unique in combination with #country, #country_revision,
+            // and #code.  <br>
+            // e.g. http://www.vzkat.de/2017/VzKat.htm
+            //
+            optional string sub_code = 11;
+
+            // Assignment of this object to logical lanes.
+            //
+            // \note OSI uses singular instead of plural for repeated field
+            // names.
+            //
+            repeated LogicalLaneAssignment logical_lane_assignment = 12;
 
             // Definition of the traffic actors the supplementary sign makes
             // reference to. E.g. bikes, trucks, cars, etc.


### PR DESCRIPTION
This  pull request collects all fixes to the flatbuffer build to make it fully functional:

- Fix CMake build breakage due to better separation of source and binary directories in #551
- Replace flatbuffers submodule with find_package dependency
- Temporary work-around for flatc bug with same-named nested enum types
- Add project-scoped alias for flatbuffers-based library