### PR TITLE
Move missing vcpkg information to prerequisites

### DIFF
--- a/doc/setup/installing_prerequisites.adoc
+++ b/doc/setup/installing_prerequisites.adoc
@@ -31,16 +31,19 @@ Therefore, it could make sense to still dynamically link against the C Runtime w
 
 The easiest way to achieve static linking on Windows without setting all the stuff manually in Cmake and building _protobuf_ is to actually **install static _protobuf_ with dynamic c-runtime with vcpkg**:
 
+Install vcpkg as per the vcpkg documentation.
+Create a new triplet file for the required combination of static library linking with dynamic runtime (usually needed for dynamic linking to still work):
+Create a file named x64-windows-static-md.cmake in the triplets directory with the following content:
+
+----
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+----
+
+Now the protobuf libraries can be built automatically using:
 ----
 vcpkg install --triplet=x64-windows-static-md protobuf
-----
-
-Build::
-
-For the cmake configuration, we can directly specify our vcpkg installation:
-----
-cmake .. -DVCPKG_TARGET_TRIPLET=x64-windows-static-md -DCMAKE_TOOLCHAIN_FILE=C:/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake -A x64
-cmake --build . --config Release
 ----
 
 == Linux

--- a/doc/setup/installing_windows_cpp.adoc
+++ b/doc/setup/installing_windows_cpp.adoc
@@ -43,6 +43,12 @@ cd build
 cmake .. [-G <generator>] [-DCMAKE_INSTALL_PREFIX=<osi-install-directory>]
 ----
 +
+  If you used vcpkg to install protobuf, then provide the target and toolchain file information, as follows
++
+----
+cmake .. -DVCPKG_TARGET_TRIPLET=x64-windows-static-md -DCMAKE_TOOLCHAIN_FILE=C:/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 [-G <generator>] [-DCMAKE_INSTALL_PREFIX=<osi-install-directory>]
+----
+
 . Build and install OSI.
 +
 ----


### PR DESCRIPTION
Adds additional vcpkg build information from OSMP, drops redundant build steps in prerequisites, moving them to the installing documentation.