### PR TITLE
Add new message for sub-bounding boxes

### DIFF
--- a/osi_common.proto
+++ b/osi_common.proto
@@ -431,13 +431,6 @@ message BoundingBox
     //
     optional Type contained_object_type = 4;
 
-    // Another type of object contained in the bounding box
-    // 
-    // This field shall only be used if \c contained_object_type is TYPE_OTHER
-    // and the object type is not defined withing \c contained_object_type.
-    //
-    optional string other_object_type = 5;
-
     // Opaque reference of an associated 3D model of the bounding box.
     //
     // \note It is implementation-specific how model_references are resolved to
@@ -448,9 +441,6 @@ message BoundingBox
 
     // Definition of different types of object contained within the bounding box
     //
-    // \note This enum field is mainly a placeholder to be extended in the future.
-    // feel free to suggest type definitions for future releases.
-    //
     enum Type
     {
         // Object of unknown type (must not be used in ground truth).
@@ -460,6 +450,31 @@ message BoundingBox
         // Any other type of object.
         //
         TYPE_OTHER = 1;
+
+        // The main structure of an object, e.g. a chassis of a vehicle, 
+        // or the central structure of a building, a tree trunk, etc.
+        //
+        TYPE_BASE_STRUCTURE = 2;
+
+        // The door of an object.
+        //
+        TYPE_DOOR = 3;
+
+        // The side mirror of a vehicle.
+        //
+        // \note The side mirror is not included in the overall bounding box
+        // of the parent object.
+        //
+        TYPE_SIDE_MIRROR = 4;
+
+        // Additional, temporarily attached cargo to an object.
+        //
+        TYPE_CARGO = 5;
+
+        // An overhanging, integral part of on object, which is not temporarily attached. 
+        // e.g. a tree crown, or a light pole arm.
+        //
+        TYPE_PROTRUDING = 6;
     }
 }
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -456,25 +456,25 @@ message BoundingBox
         //
         TYPE_BASE_STRUCTURE = 2;
 
+        // An overhanging, integral part of an object, which is not 
+        // temporarily attached, e.g. a tree crown, or a light pole arm.
+        //
+        TYPE_PROTRUDING_STRUCTURE = 3;
+
+        // Additional, temporarily attached cargo to an object.
+        //
+        TYPE_CARGO = 4;
+
         // The door of an object.
         //
-        TYPE_DOOR = 3;
+        TYPE_DOOR = 5;
 
         // The side mirror of a vehicle.
         //
         // \note The side mirror is not included in the overall bounding box
         // of the parent object.
         //
-        TYPE_SIDE_MIRROR = 4;
-
-        // Additional, temporarily attached cargo to an object.
-        //
-        TYPE_CARGO = 5;
-
-        // An overhanging, integral part of an object, which is not 
-        // temporarily attached, e.g. a tree crown, or a light pole arm.
-        //
-        TYPE_PROTRUDING = 6;
+        TYPE_SIDE_MIRROR = 6;
     }
 }
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -471,7 +471,7 @@ message BoundingBox
         //
         TYPE_CARGO = 5;
 
-        // An overhanging, integral part of on object, which is not 
+        // An overhanging, integral part of an object, which is not 
         // temporarily attached, e.g. a tree crown, or a light pole arm.
         //
         TYPE_PROTRUDING = 6;

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -472,7 +472,7 @@ message BoundingBox
         TYPE_CARGO = 5;
 
         // An overhanging, integral part of on object, which is not 
-        // temporarily attached. e.g. a tree crown, or a light pole arm.
+        // temporarily attached, e.g. a tree crown, or a light pole arm.
         //
         TYPE_PROTRUDING = 6;
     }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -387,16 +387,20 @@ message LogicalLaneAssignment
     optional double angle_to_lane = 4;
 }
 
-// \brief A bounding box description. 
+// \brief A bounding box description.
 //
-// A bounding box representing a sub-section of it's parents overall dimension, 
-// either that of a \c BaseMoving or \c BaseStationary .
+// A bounding box representing a sub-section of its parent's overall
+// dimension, either that of a \c BaseMoving or \c BaseStationary .
 //
-// The parent frame of the \c BoundingBox is not relative to the parent object
-// it is associated to, but in the same parent frame as the parent object.
+// The parent frame of the \c BoundingBox is identical to the parent frame
+// of the \c MovingObject or \c StationaryObject it is associated to. For
+// example, if the parent object coordinates are given relative to the
+// global coordinate system, then the \c BoundingBox coordinates are also
+// given relative to the global coordinate system.
 //
-// \note The actual bounding box of the object is defined in dimension, position
-// and orientation of the \c BaseMoving and \c BaseStationary .
+// \note The overall bounding box of the object is still defined using the
+// dimension, position and orientation of the \c BaseMoving or
+// \c BaseStationary .
 //
 message BoundingBox
 {
@@ -406,25 +410,25 @@ message BoundingBox
 
     // The 3D position of the bounding box.
     //
-    // \note The position should be within the same coordinate frame as it's
-    // parent, not relative to coordinate frame of the parent object. The 
-    // position becomes global/absolute if the parent frame is inertial 
+    // \note The position should be within the same coordinate frame as
+    // its parent, not relative to coordinate frame of the parent object.
+    // The position becomes global/absolute if the parent frame is inertial
     // (all parent frames up to ground truth).
     //
     optional Vector3d position = 2;
 
     // The 3D orientation of the bounding box.
     //
-    // \note The orientation should be within the same coordinate frame as it's
-    // parent, not relative to coordinate frame of the parent object. The 
-    // orientation becomes global/absolute if the parent frame is inertial 
+    // \note The orientation should be within the same coordinate frame as
+    // its parent, not relative to the coordinate frame of the parent object.
+    // The orientation becomes global/absolute if the parent frame is inertial
     // (all parent frames up to ground truth).
     //
     optional Orientation3d orientation = 3;
 
     // The type of object contained in the bounding box.
     //
-    optional Type contained_object_type = 4; 
+    optional Type contained_object_type = 4;
 
     // Opaque reference of an associated 3D model of the bounding box.
     //
@@ -449,59 +453,59 @@ message BoundingBox
         // The main chassis of a vehicle.
         //
         TYPE_CHASSIS = 2;
-        
+
         // The door of a vehicle.
-        // 
+        //
         TYPE_DOOR = 3;
-        
+
         // The side mirror of a vehicle.
         //
-        // \note The side mirror is not included in the actual bounding box of 
-        // the parent object.
-        // 
+        // \note The side mirror is not included in the overall bounding box
+        // of the parent object.
+        //
         TYPE_SIDE_MIRROR = 4;
-        
+
         // Additional cargo attached to the a vehicle which is temporarily
         // attached.
-        // 
+        //
         TYPE_CARGO = 5;
-        
+
         // The wheel of a vehicle.
         //
         // \note For more detailed information about the wheels of an object,
         // please refer to \c MovingObject/VehicleAttributes/WheelData.
-        // 
+        //
         TYPE_WHEEL = 6;
-        
+
         // The torso section of a person or animal.
-        // 
+        //
         TYPE_TORSO = 7;
-        
+
         // An external limb of a person or animal.
-        // 
-        // \note Limbs can be sub-divided to increase accuracy, i.e. for upper 
+        //
+        // \note Limbs can be sub-divided to increase accuracy, i.e. for upper
         // and lower arm/leg sections.
         //
         TYPE_LIMB = 8;
-        
+
         // The head of a person or animal.
-        // 
+        //
         TYPE_HEAD = 9;
-        
+
         // The trunk section of a tree.
-        // 
+        //
         TYPE_TREE_TRUNK = 10;
-        
+
         // The crown of a tree, usually encompassing the branches and leaves.
-        // 
+        //
         TYPE_TREE_CROWN = 11;
-        
+
         // The vertical pole of a street light.
-        // 
+        //
         TYPE_STREET_LIGHT_POLE = 12;
-        
+
         // The horizontal arm of a street light.
-        // 
+        //
         TYPE_STREET_LIGHT_ARM = 13;
     }
 }
@@ -524,7 +528,7 @@ message BaseStationary
     // The 3D dimensions of the stationary object (bounding box), e.g. a
     // landmark.
     //
-    // \note The \c #dimension must completely enclose the geometry of the 
+    // \note The \c #dimension must completely enclose the geometry of the
     // \c BaseStationary .
     //
     optional Dimension3d dimension = 1;
@@ -575,11 +579,15 @@ message BaseStationary
     // The bounding box sections can include separate parts on partially-opaque
     // objects such as trees with a distinction between trunk and crown.
     // 
-    // \note It is expected that when using \c #bounding_box_section ,
-    // anyone consuming this data has the guarantee that all others parts of 
-    // the \c BaseStationary are covered by a sub-section, such that the 
-    // guarentee is that the remaining area of the objects dimension is
-    // represented by space where no physical collisions could be detected.
+    // \note The bounding box sub-divisions can extend beyond the overall
+    // bounding box, however no actual geometry must reside outside of the
+    // overall bounding box.
+    //
+    // \note If any sub-divisions are provided, then they must cover all
+    // occupied space of the overall bounding box. In other words, a consumer
+    // of this data is guaranteed that any part of the overall bounding box
+    // that is not covered by any sub-division is free of physical objects,
+    // and thus no collisions can occur there.
     //
     repeated BoundingBox bounding_box_section = 5;
 }
@@ -604,8 +612,8 @@ message BaseMoving
 {
     // The 3D dimension of the moving object (its bounding box).
     //
-    // \note The \c #dimension must completely enclose the geometry of the 
-    // \c BaseMoving .
+    // \note The \c #dimension must completely enclose the geometry of the
+    // \c BaseMoving with the exception of the side mirrors for vehicles.
     //
     // \note The bounding box does NOT include side mirrors for vehicles.
     //
@@ -613,7 +621,6 @@ message BaseMoving
 
     // The reference point for position and orientation: the center (x,y,z) of
     // the bounding box.
-    //
     //
     optional Vector3d position = 2;
 
@@ -711,15 +718,19 @@ message BaseMoving
 
     // Sub-divisions of the overall bounding box of the \c BaseMoving object.
     //
-    // The bounding box sections can include side mirrors, cargo, etc. for 
-    // vehicles, as well as body-part sections for pedestrians.
-    // 
-    // \note It is also expected that when using \c #bounding_box_section ,
-    // anyone consuming this data has the guarantee that all others parts of 
-    // the \c BaseMoving are covered by a sub-section, such that the 
-    // guarentee is that the remaining area of the objects dimension is
-    // represented by space where no physical collisions could be detected.
-    // This does not include the side mirrors.
+    // The bounding box sections can include side mirrors, cargo, etc. for
+    // vehicles, as well as body-part sections for pedestrians. Note that for
+    // more precise pedestrian information \c PedestrianAttributes can be used.
+    //
+    // \note The bounding box sub-divisions can extend beyond the overall
+    // bounding box, however no actual geometry must reside outside of the
+    // overall bounding box, with the specific exception of the side mirrors.
+    //
+    // \note If any sub-divisions are provided, then they must cover all
+    // occupied space of the overall bounding box. In other words, a consumer
+    // of this data is guaranteed that any part of the overall bounding box
+    // that is not covered by any sub-division is free of physical objects,
+    // and thus no collisions can occur there.
     //
     repeated BoundingBox bounding_box_section = 9;
 }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -458,8 +458,8 @@ message BoundingBox
 
         // A protruding, integral part of an object, which is not 
         // temporarily attached, e.g. a tree crown, a light pole arm, or a 
-		// parking house gate. The protruding structure is meant to be an 
-		// additional part to a base structure.
+        // parking house gate. The protruding structure is meant to be an 
+        // additional part to a base structure.
         //
         TYPE_PROTRUDING_STRUCTURE = 3;
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -408,7 +408,8 @@ message BoundingBox
     //
     optional Dimension3d dimension = 1;
 
-    // The 3D position of the bounding box.
+    // The 3D position of the bounding box. The position is the center
+    // of the bounding box and the pivot for the \c dimension and \c orientation.
     //
     // \note The position should be within the same coordinate frame as
     // its parent, not relative to coordinate frame of the parent object.
@@ -430,15 +431,25 @@ message BoundingBox
     //
     optional Type contained_object_type = 4;
 
+    // Another type of object contained in the bounding box
+    // 
+    // This field shall only be used if \c contained_object_type is TYPE_OTHER
+    // and the object type is not defined withing \c contained_object_type.
+    //
+    optional string other_object_type = 5;
+
     // Opaque reference of an associated 3D model of the bounding box.
     //
     // \note It is implementation-specific how model_references are resolved to
     // 3d models. This means the coordinate system, model origin, and model
     // orientation are also implementation-specific.
     //
-    optional string model_reference = 5;
+    optional string model_reference = 6;
 
     // Definition of different types of object contained within the bounding box
+    //
+    // \note This enum field is mainly a placeholder to be extended in the future.
+    // feel free to suggest type definitions for future releases.
     //
     enum Type
     {
@@ -449,64 +460,6 @@ message BoundingBox
         // Any other type of object.
         //
         TYPE_OTHER = 1;
-
-        // The main chassis of a vehicle.
-        //
-        TYPE_CHASSIS = 2;
-
-        // The door of a vehicle.
-        //
-        TYPE_DOOR = 3;
-
-        // The side mirror of a vehicle.
-        //
-        // \note The side mirror is not included in the overall bounding box
-        // of the parent object.
-        //
-        TYPE_SIDE_MIRROR = 4;
-
-        // Additional cargo attached to the a vehicle which is temporarily
-        // attached.
-        //
-        TYPE_CARGO = 5;
-
-        // The wheel of a vehicle.
-        //
-        // \note For more detailed information about the wheels of an object,
-        // please refer to \c MovingObject/VehicleAttributes/WheelData.
-        //
-        TYPE_WHEEL = 6;
-
-        // The torso section of a person or animal.
-        //
-        TYPE_TORSO = 7;
-
-        // An external limb of a person or animal.
-        //
-        // \note Limbs can be sub-divided to increase accuracy, i.e. for upper
-        // and lower arm/leg sections.
-        //
-        TYPE_LIMB = 8;
-
-        // The head of a person or animal.
-        //
-        TYPE_HEAD = 9;
-
-        // The trunk section of a tree.
-        //
-        TYPE_TREE_TRUNK = 10;
-
-        // The crown of a tree, usually encompassing the branches and leaves.
-        //
-        TYPE_TREE_CROWN = 11;
-
-        // The vertical pole of a street light.
-        //
-        TYPE_STREET_LIGHT_POLE = 12;
-
-        // The horizontal arm of a street light.
-        //
-        TYPE_STREET_LIGHT_ARM = 13;
     }
 }
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -387,13 +387,16 @@ message LogicalLaneAssignment
     optional double angle_to_lane = 4;
 }
 
-// \brief A bounding box containing a sub-section of a object. 
+// \brief A bounding box description. 
 //
 // A bounding box representing a sub-section of it's parents overall dimension, 
-// either that of a \c MovingObject or \c StationaryObject .
+// either that of a \c BaseMoving or \c BaseStationary .
 //
 // The parent frame of the \c BoundingBox is not relative to the parent object
 // it is associated to, but in the same parent frame as the parent object.
+//
+// \note The actual bounding box of the object is defined in dimension, position
+// and orientation of the \c BaseMoving and \c BaseStationary .
 //
 message BoundingBox
 {
@@ -448,31 +451,25 @@ message BoundingBox
         TYPE_CHASSIS = 2;
         
         // The door of a vehicle.
-        //
-        // \note A door may extend beyond the dimension of the parent when in
-        // an open state. A closed door must be within the original dimension.
         // 
         TYPE_DOOR = 3;
         
         // The side mirror of a vehicle.
         //
-        // \note A side mirror may extend beyond the dimension of the parent.
+        // \note The side mirror is not included in the actual bounding box of 
+        // the parent object.
         // 
         TYPE_SIDE_MIRROR = 4;
         
         // Additional cargo attached to the a vehicle which is temporarily
         // attached.
-        //
-        // \note Cargo may extend beyond the dimension of the parent.
         // 
         TYPE_CARGO = 5;
         
         // The wheel of a vehicle.
         //
-        // \note A wheel may extend beyond the dimension of the parent.
-        //
         // \note For more detailed information about the wheels of an object,
-        // please refer to \c MovingObject/VehicleAttributes/WheelData .
+        // please refer to \c MovingObject/VehicleAttributes/WheelData.
         // 
         TYPE_WHEEL = 6;
         
@@ -484,6 +481,7 @@ message BoundingBox
         // 
         // \note Limbs can be sub-divided to increase accuracy, i.e. for upper 
         // and lower arm/leg sections.
+        //
         TYPE_LIMB = 8;
         
         // The head of a person or animal.
@@ -525,6 +523,9 @@ message BaseStationary
 {
     // The 3D dimensions of the stationary object (bounding box), e.g. a
     // landmark.
+    //
+    // \note The \c #dimension must completely enclose the geometry of the 
+    // \c BaseStationary .
     //
     optional Dimension3d dimension = 1;
 
@@ -572,13 +573,9 @@ message BaseStationary
     // Sub-divisions of the overall bounding box of the \c BaseStationary object.
     //
     // The bounding box sections can include separate parts on partially-opaque
-    // objects such are trees with a distinction between trunk and crown.
-    //
-    // \note When one or more \c BoundingBox s are associated to a 
-    // \c BaseStationary , the expectation is that all sections are contained
-    // within the bounds of the \c #dimension .
+    // objects such as trees with a distinction between trunk and crown.
     // 
-    // \note It is also expcted that when using \c #bounding_box_section ,
+    // \note It is expected that when using \c #bounding_box_section ,
     // anyone consuming this data has the guarantee that all others parts of 
     // the \c BaseStationary are covered by a sub-section, such that the 
     // guarentee is that the remaining area of the objects dimension is
@@ -607,12 +604,16 @@ message BaseMoving
 {
     // The 3D dimension of the moving object (its bounding box).
     //
+    // \note The \c #dimension must completely enclose the geometry of the 
+    // \c BaseMoving .
+    //
     // \note The bounding box does NOT include side mirrors for vehicles.
     //
     optional Dimension3d dimension = 1;
 
     // The reference point for position and orientation: the center (x,y,z) of
     // the bounding box.
+    //
     //
     optional Vector3d position = 2;
 
@@ -712,16 +713,13 @@ message BaseMoving
     //
     // The bounding box sections can include side mirrors, cargo, etc. for 
     // vehicles, as well as body-part sections for pedestrians.
-    //
-    // \note When one or more \c BoundingBox s are associated to a 
-    // \c BaseMoving , the expectation is that all sections are contained
-    // within the bounds of the \c #dimension .
     // 
-    // \note It is also expcted that when using \c #bounding_box_section ,
+    // \note It is also expected that when using \c #bounding_box_section ,
     // anyone consuming this data has the guarantee that all others parts of 
     // the \c BaseMoving are covered by a sub-section, such that the 
     // guarentee is that the remaining area of the objects dimension is
     // represented by space where no physical collisions could be detected.
+    // This does not include the side mirrors.
     //
     repeated BoundingBox bounding_box_section = 9;
 }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -482,6 +482,8 @@ message BoundingBox
         
         // An external limb of a person or animal.
         // 
+        // \note Limbs can be sub-divided to increase accuracy, i.e. for upper 
+        // and lower arm/leg sections.
         TYPE_LIMB = 8;
         
         // The head of a person or animal.

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -471,8 +471,8 @@ message BoundingBox
         //
         TYPE_CARGO = 5;
 
-        // An overhanging, integral part of on object, which is not temporarily attached. 
-        // e.g. a tree crown, or a light pole arm.
+        // An overhanging, integral part of on object, which is not 
+        // temporarily attached. e.g. a tree crown, or a light pole arm.
         //
         TYPE_PROTRUDING = 6;
     }

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -456,8 +456,10 @@ message BoundingBox
         //
         TYPE_BASE_STRUCTURE = 2;
 
-        // An overhanging, integral part of an object, which is not 
-        // temporarily attached, e.g. a tree crown, or a light pole arm.
+        // A protruding, integral part of an object, which is not 
+        // temporarily attached, e.g. a tree crown, a light pole arm, or a 
+		// parking house gate. The protruding structure is meant to be an 
+		// additional part to a base structure.
         //
         TYPE_PROTRUDING_STRUCTURE = 3;
 

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -387,6 +387,125 @@ message LogicalLaneAssignment
     optional double angle_to_lane = 4;
 }
 
+// \brief A bounding box containing a sub-section of a object. 
+//
+// A bounding box representing a sub-section of it's parents overall dimension, 
+// either that of a \c MovingObject or \c StationaryObject .
+//
+// The parent frame of the \c BoundingBox is not relative to the parent object
+// it is associated to, but in the same parent frame as the parent object.
+//
+message BoundingBox
+{
+    // The 3D dimensions of the bounding box.
+    //
+    optional Dimension3d dimension = 1;
+
+    // The 3D position of the bounding box.
+    //
+    // \note The position should be within the same coordinate frame as it's
+    // parent, not relative to coordinate frame of the parent object. The 
+    // position becomes global/absolute if the parent frame is inertial 
+    // (all parent frames up to ground truth).
+    //
+    optional Vector3d position = 2;
+
+    // The 3D orientation of the bounding box.
+    //
+    // \note The orientation should be within the same coordinate frame as it's
+    // parent, not relative to coordinate frame of the parent object. The 
+    // orientation becomes global/absolute if the parent frame is inertial 
+    // (all parent frames up to ground truth).
+    //
+    optional Orientation3d orientation = 3;
+
+    // The type of object contained in the bounding box.
+    //
+    optional Type contained_object_type = 4; 
+
+    // Opaque reference of an associated 3D model of the bounding box.
+    //
+    // \note It is implementation-specific how model_references are resolved to
+    // 3d models. This means the coordinate system, model origin, and model
+    // orientation are also implementation-specific.
+    //
+    optional string model_reference = 5;
+
+    // Definition of different types of object contained within the bounding box
+    //
+    enum Type
+    {
+        // Object of unknown type (must not be used in ground truth).
+        //
+        TYPE_UNKNOWN = 0;
+
+        // Any other type of object.
+        //
+        TYPE_OTHER = 1;
+
+        // The main chassis of a vehicle.
+        //
+        TYPE_CHASSIS = 2;
+        
+        // The door of a vehicle.
+        //
+        // \note A door may extend beyond the dimension of the parent when in
+        // an open state. A closed door must be within the original dimension.
+        // 
+        TYPE_DOOR = 3;
+        
+        // The side mirror of a vehicle.
+        //
+        // \note A side mirror may extend beyond the dimension of the parent.
+        // 
+        TYPE_SIDE_MIRROR = 4;
+        
+        // Additional cargo attached to the a vehicle which is temporarily
+        // attached.
+        //
+        // \note Cargo may extend beyond the dimension of the parent.
+        // 
+        TYPE_CARGO = 5;
+        
+        // The wheel of a vehicle.
+        //
+        // \note A wheel may extend beyond the dimension of the parent.
+        //
+        // \note For more detailed information about the wheels of an object,
+        // please refer to \c MovingObject/VehicleAttributes/WheelData .
+        // 
+        TYPE_WHEEL = 6;
+        
+        // The torso section of a person or animal.
+        // 
+        TYPE_TORSO = 7;
+        
+        // An external limb of a person or animal.
+        // 
+        TYPE_LIMB = 8;
+        
+        // The head of a person or animal.
+        // 
+        TYPE_HEAD = 9;
+        
+        // The trunk section of a tree.
+        // 
+        TYPE_TREE_TRUNK = 10;
+        
+        // The crown of a tree, usually encompassing the branches and leaves.
+        // 
+        TYPE_TREE_CROWN = 11;
+        
+        // The vertical pole of a street light.
+        // 
+        TYPE_STREET_LIGHT_POLE = 12;
+        
+        // The horizontal arm of a street light.
+        // 
+        TYPE_STREET_LIGHT_ARM = 13;
+    }
+}
+
 //
 // \brief The base attributes of a stationary object or entity.
 //
@@ -447,6 +566,23 @@ message BaseStationary
     // The polygon is defined counter-clockwise.
     //
     repeated Vector2d base_polygon = 4;
+
+    // Sub-divisions of the overall bounding box of the \c BaseStationary object.
+    //
+    // The bounding box sections can include separate parts on partially-opaque
+    // objects such are trees with a distinction between trunk and crown.
+    //
+    // \note When one or more \c BoundingBox s are associated to a 
+    // \c BaseStationary , the expectation is that all sections are contained
+    // within the bounds of the \c #dimension .
+    // 
+    // \note It is also expcted that when using \c #bounding_box_section ,
+    // anyone consuming this data has the guarantee that all others parts of 
+    // the \c BaseStationary are covered by a sub-section, such that the 
+    // guarentee is that the remaining area of the objects dimension is
+    // represented by space where no physical collisions could be detected.
+    //
+    repeated BoundingBox bounding_box_section = 5;
 }
 
 //
@@ -569,6 +705,23 @@ message BaseMoving
     // The polygon is defined counter-clockwise.
     //
     repeated Vector2d base_polygon = 7;
+
+    // Sub-divisions of the overall bounding box of the \c BaseMoving object.
+    //
+    // The bounding box sections can include side mirrors, cargo, etc. for 
+    // vehicles, as well as body-part sections for pedestrians.
+    //
+    // \note When one or more \c BoundingBox s are associated to a 
+    // \c BaseMoving , the expectation is that all sections are contained
+    // within the bounds of the \c #dimension .
+    // 
+    // \note It is also expcted that when using \c #bounding_box_section ,
+    // anyone consuming this data has the guarantee that all others parts of 
+    // the \c BaseMoving are covered by a sub-section, such that the 
+    // guarentee is that the remaining area of the objects dimension is
+    // represented by space where no physical collisions could be detected.
+    //
+    repeated BoundingBox bounding_box_section = 9;
 }
 
 //

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -469,6 +469,9 @@ message BoundingBox
 
         // The door of an object.
         //
+        // For vehicles, this includes driver and passenger doors, trunk
+        // and front hoods, and fuel or charging port covers.
+        //
         TYPE_DOOR = 5;
 
         // The side mirror of a vehicle.

--- a/osi_common.proto
+++ b/osi_common.proto
@@ -437,7 +437,7 @@ message BoundingBox
     // 3d models. This means the coordinate system, model origin, and model
     // orientation are also implementation-specific.
     //
-    optional string model_reference = 6;
+    optional string model_reference = 5;
 
     // Definition of different types of object contained within the bounding box
     //


### PR DESCRIPTION
This PR is a continuation of #695 (and #685) with fixed history. It proposes the addition of bounding box sub-sections to BaseMoving and BaseStationary objects, to help sub-divide and classify different parts of the overall object structure.
