### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,3 +182,11 @@ jobs:
         with:
           file: ASAM_OSI_${{needs.setup.outputs.output1}}.zip
           tag: ${{ github.ref }}
+      - name: Trigger generator
+        if: ${{ env.MUP_KEY != '' }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.MACHINE_USER_PAT }}
+          event-type: antora-build-trigger
+          repository: OpenSimulationInterface/osi-antora-generator
+          client-payload: '{"src": "${{ github.repository }}", "ref": "master"}'


### PR DESCRIPTION
Added Antora Generator call at the end to trigger the GitHub Pages build.

#### Add a description
When a release is published, the release pipeline generates the new release package.
However, currently the Antora Generator only runs in that pipeline to create the slimmer package output. 
The GitHub pages are, therefore, not updated with the new release automatically.

To solve this, a final call was added to trigger the Generator after the package has been created and uploaded. This will ensure that the new tag is also included in the GitHub pages, but only if the release update was successful.