### PR TITLE
Add beam ID to LidarDetection

### DIFF
--- a/osi_featuredata.proto
+++ b/osi_featuredata.proto
@@ -460,6 +460,10 @@ message LidarDetection
     // Unit: m/s
     //
     optional double radial_velocity = 12;
+    
+    // ID of the corresponding lidar beam.
+    //
+    optional Identifier beam_id = 13;
 }
 
 //


### PR DESCRIPTION
#### Add a description
Added beam_id as an identifier to LidarDetection.
Now, individual detection points can be assigned to a lidar beam. This enables the identification of multiple returns in one beam and also aligns with the output of some real lidar sensors, e.g. Velodynes.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

