### PR TITLE
Add osi_trafficcommandupdate.proto to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(OSI_PROTO_FILES
     osi_trafficlight.proto
     osi_trafficupdate.proto
     osi_trafficcommand.proto
+    osi_trafficcommandupdate.proto
     osi_referenceline.proto
     osi_roadmarking.proto
     osi_lane.proto


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#743 

#### Add a description
Add osi_trafficcommandupdate.proto to CMakeLists. Fixing the bug, that no header for osi_trafficcommandupdate is built.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
