### PR TITLE
Add check that all proto files are included in build

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         submodules: true
 
+    - name: Check Build Setup
+      run: |
+        ( result=0 ; for f in *.proto ; do grep -wq "$f" CMakeLists.txt || { echo "Missing $f in CMakeLists.txt" && let "result++"; } ; done ; exit $result )
+        ( result=0 ; for f in *.proto ; do grep -q '"'$f'"' setup.py || { echo "Missing $f in setup.py" && let "result++"; } ; done ; exit $result )
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
As decided in the CCB 2023-12-04 based on the issue fixed in #744, this adds checks to the build infrastructure to check that all proto files are actually referenced in CMakeLists.txt and setup.py.