### PR TITLE
Logical Traffic Rules and Speed Limit

### DIFF
--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 option optimize_for = SPEED;
 
 import "osi_common.proto";
+import "osi_object.proto";
 
 package osi3;
 
@@ -587,6 +588,10 @@ message LogicalLane
     //
     optional string street_name = 16;
 
+    // A list of traffic rules on the lane.
+    //
+    repeated TrafficRule traffic_rule = 17;
+
     //
     // Definition of available lane types.
     //
@@ -822,5 +827,117 @@ message LogicalLane
         //
         optional double end_s_other = 5;
     }
+
+    //
+    // Describes traffic rules on a lane. 
+    // The traffic rule can thereby induced by regulations, traffic signs 
+    // or by other means. If the modeled traffic rule is induced by a traffic sign
+    // the information should be identical with the respective traffic sign.
+    //
+    // Note: Every instance should be corresponding to only one specific rule.
+    // The type of the traffic rule should be set using the respective filed.
+    // Additionally, every message should contain the traffic rule validity information
+    // and the respective field for the respective traffic rule type.
+    //
+    // Note: Each traffic rule corresponds to only one lane. If the traffic rule
+    // is also valid on adjacent/successing/predecessing lanes it needs to be
+    // specified for each lane individually.
+    //
+    // \brief Logical Model of a traffic rule on a lane.
+    //
+    message TrafficRule {
+
+        // The type of the traffic rule.
+        //
+        // This specifies the type of the traffic rule to be modeled.
+        // Based on the type the respective message containing the information
+        // corresponding to the traffic rule should be filled.
+        //
+        optional TrafficRuleType traffic_rule_type = 1;
+
+        // The validity information of the traffic rule.
+        //
+        optional TrafficRuleValidity traffic_rule_validity = 2;
+
+        // Traffic rule information for traffic rule of type speed limit.
+        //
+        optional SpeedLimit speed_limit = 3;
+
+        //
+        // The type of the the traffic rule.
+        //
+        enum TrafficRuleType {
+
+            // Traffic rule is of type speed limit
+            //
+            TRAFFIC_RULE_TYPE_SPEED_LIMIT = 0;
+        }
+
+        // 
+        // \brief Validity information for a traffic rule.
+        //
+        message TrafficRuleValidity {
+            
+            //
+            // The starting point of the traffic rule validity on the lane.
+            // Must be in range [\c sStart,\c sEnd] of the reference line.
+            //
+            optional double start_s = 1;
+
+            //
+            // The ending point of the traffic rule validity on the lane.
+            // Must be in range [\c sStart,\c sEnd] of the reference line.
+            // Note: Should always be greater than the starting point.
+            //
+            optional double end_s = 2;
+
+            //
+            // List of vehicle types for which the speed limit is valid.
+            // If the traffic rule validity is independent of the vehicle type 
+            // the list should be empty.
+            //
+            repeated MovingObject.VehicleClassification.Type valid_for_type = 3;
+        }
+
+        //
+        // \brief Speed limit on a lane.
+        //
+        message SpeedLimit {
+
+            //
+            // The speed limit in the unit specified by the respective files
+            //
+            optional double speed_limit = 1;
+
+            //
+            // The unit in which the speed limit is specified.
+            //
+            optional Unit speed_limit_unit = 2;
+
+            // Unit of the specified speed limit.
+            //
+            enum Unit
+            {
+                // Meters per second.
+                //
+                // Unit: km/h
+                //
+                UNIT_METER_PER_SECOND = 1;
+
+                // Kilometers per hour.
+                //
+                // Unit: km/h
+                //
+                UNIT_KILOMETER_PER_HOUR = 2;
+
+                // Miles per hour.
+                //
+                // Unit: mph
+                //
+                UNIT_MILE_PER_HOUR = 3;
+            }
+        }
+    }
+
 }
 

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -934,7 +934,7 @@ message LogicalLane
 
             //
             // The value of the speed limit.
-            // The unit filed in the TrafficSignValue message may only be set to
+            // The unit field in the TrafficSignValue message may only be set to
             // units associated with velocities and must not be UNKNOWN or OTHER.
             //
             // Note: All speed limits are to be led this way, independent

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -830,12 +830,12 @@ message LogicalLane
 
     //
     // Describes traffic rules on a lane. 
-    // The traffic rule can thereby induced by regulations, traffic signs 
+    // The traffic rule can thereby be induced by regulations, traffic signs 
     // or by other means. If the modeled traffic rule is induced by a traffic sign
     // the information should be identical with the respective traffic sign.
     //
     // Note: Every instance should be corresponding to only one specific rule.
-    // The type of the traffic rule should be set using the respective filed.
+    // The type of the traffic rule should be set using the respective field.
     // Additionally, every message should contain the traffic rule validity information
     // and the respective field for the respective traffic rule type.
     // In case of traffic rule (priority) conflicts for rules of the same type that 

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -4,6 +4,7 @@ option optimize_for = SPEED;
 
 import "osi_common.proto";
 import "osi_object.proto";
+import "osi_trafficsign.proto";
 
 package osi3;
 
@@ -895,11 +896,35 @@ message LogicalLane
             optional double end_s = 2;
 
             //
-            // List of vehicle types for which the speed limit is valid.
+            // List of traffic participan types for which the speed limit is valid.
             // If the traffic rule validity is independent of the vehicle type 
             // the list should be empty.
             //
-            repeated MovingObject.VehicleClassification.Type valid_for_type = 3;
+            repeated TypeValidity valid_for_type = 3;
+
+            //
+            // \brief Type of traffic paricipant for which a rule is valid.
+            //
+            message TypeValidity {
+
+                //
+                // The type of objects for which the traffic rule applys.
+                // Must not be UNKNOWN or OTHER
+                //
+                optional MovingObject.Type type = 1;
+                
+                //
+                // Vehicle classification type for trafic participants 
+                // May only be set if type is TYPE_VEHICLE. Must not be UNKNOWN or OTHER.
+                //
+                optional MovingObject.VehicleClassification.Type vehicle_type = 2;
+
+                //
+                // Role of traffic participant.
+                // May only be set if type is TYPE_VEHICLE. Must not be UNKNOWN or OTHER.
+                //
+                optional MovingObject.VehicleClassification.Role vehicle_role = 3;
+            }
         }
 
         //
@@ -908,37 +933,15 @@ message LogicalLane
         message SpeedLimit {
 
             //
-            // The speed limit in the unit specified by the respective files
+            // The value of the speed limit.
+            // The unit filed in the TrafficSigneValue message may only be set to
+            // units associated with velocities and must not be UNKNOWN or OTHER.
             //
-            optional double speed_limit = 1;
-
+            // Note: All speed limits are to be modelled this way, indpendent
+            // of how they are induced.
             //
-            // The unit in which the speed limit is specified.
-            //
-            optional Unit speed_limit_unit = 2;
+            optional TrafficSignValue speed_limit_value = 1;
 
-            // Unit of the specified speed limit.
-            //
-            enum Unit
-            {
-                // Meters per second.
-                //
-                // Unit: m/s
-                //
-                UNIT_METER_PER_SECOND = 0;
-
-                // Kilometers per hour.
-                //
-                // Unit: km/h
-                //
-                UNIT_KILOMETER_PER_HOUR = 1;
-
-                // Miles per hour.
-                //
-                // Unit: mph
-                //
-                UNIT_MILE_PER_HOUR = 2;
-            }
         }
     }
 

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -870,7 +870,7 @@ message LogicalLane
 
             // Traffic rule is of type speed limit
             //
-            TRAFFIC_RULE_TYPE_SPEED_LIMIT = 0;
+            TRAFFIC_RULE_TYPE_SPEED_LIMIT = 1;
         }
 
         // 
@@ -920,7 +920,7 @@ message LogicalLane
             {
                 // Meters per second.
                 //
-                // Unit: km/h
+                // Unit: m/s
                 //
                 UNIT_METER_PER_SECOND = 1;
 

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -873,7 +873,7 @@ message LogicalLane
 
             // Traffic rule is of type speed limit
             //
-            TRAFFIC_RULE_TYPE_SPEED_LIMIT = 1;
+            TRAFFIC_RULE_TYPE_SPEED_LIMIT = 0;
         }
 
         // 
@@ -925,19 +925,19 @@ message LogicalLane
                 //
                 // Unit: m/s
                 //
-                UNIT_METER_PER_SECOND = 1;
+                UNIT_METER_PER_SECOND = 0;
 
                 // Kilometers per hour.
                 //
                 // Unit: km/h
                 //
-                UNIT_KILOMETER_PER_HOUR = 2;
+                UNIT_KILOMETER_PER_HOUR = 1;
 
                 // Miles per hour.
                 //
                 // Unit: mph
                 //
-                UNIT_MILE_PER_HOUR = 3;
+                UNIT_MILE_PER_HOUR = 2;
             }
         }
     }

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -909,19 +909,20 @@ message LogicalLane
 
                 //
                 // The type of object for which the traffic rule is valid.
-                // Must not be UNKNOWN or OTHER
                 //
                 optional MovingObject.Type type = 1;
                 
                 //
                 // Vehicle classification type for traffic participants 
-                // May only be set if type is TYPE_VEHICLE. Must not be UNKNOWN or OTHER.
+                // Should be set to UNKNOWN if type is not TYPE_VEHICLE or the rule
+                // is valid for all vehicle types.
                 //
                 optional MovingObject.VehicleClassification.Type vehicle_type = 2;
 
                 //
                 // Role of traffic participant.
-                // May only be set if type is TYPE_VEHICLE. Must not be UNKNOWN or OTHER.
+                // Should be set to UNKNOWN if type is not TYPE_VEHICLE or the rule
+                // is valid for all vehicle roles.
                 //
                 optional MovingObject.VehicleClassification.Role vehicle_role = 3;
             }
@@ -935,9 +936,9 @@ message LogicalLane
             //
             // The value of the speed limit.
             // The unit field in the TrafficSignValue message may only be set to
-            // units associated with velocities and must not be UNKNOWN or OTHER.
+            // units associated with velocities and must not be UNKNOWN.
             //
-            // Note: All speed limits are to be led this way, independent
+            // Note: All speed limits are to be modeled this way, independent
             // of how they are induced.
             //
             optional TrafficSignValue speed_limit_value = 1;

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -844,7 +844,7 @@ message LogicalLane
     // valid rule should be provided.
     //
     // Note: Each traffic rule corresponds to only one lane. If the traffic rule
-    // is also valid on adjacent/successing/predecessing lanes it needs to be
+    // is also valid on adjacent/successor/predecessor lanes it needs to be
     // specified for each lane individually.
     //
     // \brief Logical Model of a traffic rule on a lane.
@@ -896,25 +896,25 @@ message LogicalLane
             optional double end_s = 2;
 
             //
-            // List of traffic participan types for which the speed limit is valid.
+            // List of traffic participant types for which the speed limit is valid.
             // If the traffic rule validity is independent of the vehicle type 
             // the list should be empty.
             //
             repeated TypeValidity valid_for_type = 3;
 
             //
-            // \brief Type of traffic paricipant for which a rule is valid.
+            // \brief Type of traffic participant for which a rule is valid.
             //
             message TypeValidity {
 
                 //
-                // The type of objects for which the traffic rule applys.
+                // The type of object for which the traffic rule is valid.
                 // Must not be UNKNOWN or OTHER
                 //
                 optional MovingObject.Type type = 1;
                 
                 //
-                // Vehicle classification type for trafic participants 
+                // Vehicle classification type for traffic participants 
                 // May only be set if type is TYPE_VEHICLE. Must not be UNKNOWN or OTHER.
                 //
                 optional MovingObject.VehicleClassification.Type vehicle_type = 2;
@@ -934,10 +934,10 @@ message LogicalLane
 
             //
             // The value of the speed limit.
-            // The unit filed in the TrafficSigneValue message may only be set to
+            // The unit filed in the TrafficSignValue message may only be set to
             // units associated with velocities and must not be UNKNOWN or OTHER.
             //
-            // Note: All speed limits are to be modelled this way, indpendent
+            // Note: All speed limits are to be led this way, independent
             // of how they are induced.
             //
             optional TrafficSignValue speed_limit_value = 1;

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -838,6 +838,9 @@ message LogicalLane
     // The type of the traffic rule should be set using the respective filed.
     // Additionally, every message should contain the traffic rule validity information
     // and the respective field for the respective traffic rule type.
+    // In case of traffic rule (priority) conflicts for rules of the same type that 
+    // can not be depicted using the traffic rule validity only the currently 
+    // valid rule should be provided.
     //
     // Note: Each traffic rule corresponds to only one lane. If the traffic rule
     // is also valid on adjacent/successing/predecessing lanes it needs to be

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -886,12 +886,19 @@ message LogicalLane
             // The starting point of the traffic rule validity on the lane.
             // Must be in range [\c sStart,\c sEnd] of the reference line.
             //
+            // Note: The traffic rule applies only to traffic with notional
+            // direction of travel from the start_s coordinate towards
+            // the end_s coordinate. For unidirectional lanes this must
+            // match the direction of travel as specified by the
+            // move_direction field of the logical lane. For bidirectional
+            // lanes this allows the specification of separate rules for
+            // each direction of travel.
+            //
             optional double start_s = 1;
 
             //
             // The ending point of the traffic rule validity on the lane.
             // Must be in range [\c sStart,\c sEnd] of the reference line.
-            // Note: Should always be greater than the starting point.
             //
             optional double end_s = 2;
 
@@ -913,16 +920,18 @@ message LogicalLane
                 optional MovingObject.Type type = 1;
                 
                 //
-                // Vehicle classification type for traffic participants 
-                // Should be set to UNKNOWN if type is not TYPE_VEHICLE or the rule
-                // is valid for all vehicle types.
+                // Vehicle classification type for traffic participants.
+                //
+                // Should be set to TYPE_UNKNOWN if type is not TYPE_VEHICLE
+                // or the rule is valid for all vehicle types.
                 //
                 optional MovingObject.VehicleClassification.Type vehicle_type = 2;
 
                 //
                 // Role of traffic participant.
-                // Should be set to UNKNOWN if type is not TYPE_VEHICLE or the rule
-                // is valid for all vehicle roles.
+                //
+                // Should be set to ROLE_UNKNOWN if type is not TYPE_VEHICLE
+                // or the rule is valid for all vehicle roles.
                 //
                 optional MovingObject.VehicleClassification.Role vehicle_role = 3;
             }


### PR DESCRIPTION
Introduce a message for traffic rule information for logical lanes. The message is intended to be used by traffic participants to easily get information in traffic rules without having to process traffic signs or other additional information.

While this contains an implementation for a speed limit traffic rule the message is designes so that it can be extended with additional traffic rule types in the future.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.