### PR TITLE
Add orientation rate to PedestrianAttributes::Bone

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -1181,6 +1181,9 @@ message MovingObject
 
             // The orientation rate of the bone.
             //
+            // Reference System is the root, defined by bbcenter_to_root
+            // (\c PedestrianAttributes::bbcenter_to_root).
+            //
             optional Orientation3d orientation_rate = 7;
 
             // The type of the bone.

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -1172,9 +1172,16 @@ message MovingObject
             //
             optional bool missing = 5;
 
+            // The velocity of the bone.
+            //
+            // Reference System is the root, defined by bbcenter_to_root
+            // (\c PedestrianAttributes::bbcenter_to_root).
+            //
+            optional Vector3d velocity = 6;
+
             // The orientation rate of the bone.
             //
-            optional Orientation3d orientation_rate = 6;
+            optional Orientation3d orientation_rate = 7;
 
             // The type of the bone.
             //

--- a/osi_object.proto
+++ b/osi_object.proto
@@ -1172,6 +1172,10 @@ message MovingObject
             //
             optional bool missing = 5;
 
+            // The orientation rate of the bone.
+            //
+            optional Orientation3d orientation_rate = 6;
+
             // The type of the bone.
             //
             // \image html OSI_PedestrianModelHierarchy.jpg


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#747 

#### Add a description
Add orientation rate to the bone class. The translatory velocity of the bones can be calculated with the orientation rate of the parent bones.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

