### PR TITLE
Remove OSC todo comment from source_reference

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -520,8 +520,6 @@ message MovingObject
     // * identifier[0] = Entity-Type ("Vehicle" or "Pedestrian")
     // * identifier[1] = name of Vehicle/Pedestrian in Entity
     //
-    // \todo OpenSCENARIO currently does not provide an animal type.
-    //
     // \note For non-ASAM Standards, it is implementation-specific how
     //       source_reference is resolved.
     //


### PR DESCRIPTION
We should not include todo notes concerning other standards in OSI's documentation. Apparently, such todo notes are prominentely displayed in the documentation menu tree.

![grafik](https://github.com/OpenSimulationInterface/open-simulation-interface/assets/65231631/243461ca-a6f6-488d-a51e-c0d8159725e8)
