### PR TITLE
Fix documentation on FeatureData messages

### DIFF
--- a/doc/architecture/architecture_overview.adoc
+++ b/doc/architecture/architecture_overview.adoc
@@ -7,7 +7,7 @@ endif::[]
 OSI contains an object-based environment description that uses the message format of the https://github.com/protocolbuffers/protobuf/wiki[Protocol Buffer] library.
 Google developed and maintains the Protocol Buffer library.
 OSI defines top-level messages that are used to exchange data between separate models.
-Top-level messages define the `GroundTruth` interface, the `SensorData` interface, and – since OSI version 3.0.0 – the interfaces `SensorView`, `SensorViewConfiguration`, and `FeatureData`.
+Top-level messages define the `GroundTruth` interface, the `SensorData` interface, and – since OSI version 3.0.0 – the interfaces `SensorView` and `SensorViewConfiguration`. Further top-level messages that were added in later versions of OSI are `TrafficCommand`, `TrafficUpdate`, `MotionRequest`, and `StreamingUpdate`.
 
 The following figure shows the interfaces and models involved in modeling a sensor.
 

--- a/doc/architecture/architecture_overview.adoc
+++ b/doc/architecture/architecture_overview.adoc
@@ -7,7 +7,8 @@ endif::[]
 OSI contains an object-based environment description that uses the message format of the https://github.com/protocolbuffers/protobuf/wiki[Protocol Buffer] library.
 Google developed and maintains the Protocol Buffer library.
 OSI defines top-level messages that are used to exchange data between separate models.
-Top-level messages define the `GroundTruth` interface, the `SensorData` interface, and – since OSI version 3.0.0 – the interfaces `SensorView` and `SensorViewConfiguration`. Further top-level messages that were added in later versions of OSI are `TrafficCommand`, `TrafficUpdate`, `MotionRequest`, and `StreamingUpdate`.
+Top-level messages define the `GroundTruth` interface, the `SensorData` interface, and – since OSI version 3.0.0 – the interfaces `SensorView` and `SensorViewConfiguration`.
+Further top-level messages that were added in later versions of OSI are `TrafficCommand`, `TrafficUpdate`, `MotionRequest`, and `StreamingUpdate`.
 
 The following figure shows the interfaces and models involved in modeling a sensor.
 

--- a/doc/architecture/feature_data.adoc
+++ b/doc/architecture/feature_data.adoc
@@ -1,9 +1,0 @@
-ifndef::include-only-once[]
-:root-path: ../
-include::{root-path}_config.adoc[]
-endif::[]
-= Feature data
-
-`FeatureData` messages contain detected features in the reference frame of a sensor.
-`FeatureData` messages are generated from `GroundTruth` messages.
-They serve, for example, as an input to sensor models simulating object detection or feature fusion models.

--- a/doc/architecture/sensor_data.adoc
+++ b/doc/architecture/sensor_data.adoc
@@ -9,3 +9,7 @@ They can be generated from `GroundTruth` messages, `SensorView` messages, `Featu
 With the exception of feature data, all information regarding the environment is given with respect to the virtual sensor coordinate system.
 Feature data is given with respect to the physical sensor coordinate system.
 Sensor data can be used as input for an automated driving function, a sensor model simulating limited perception, or a sensor fusion model.
+
+`SensorData` messages include `FeatureData` messages which contain detected features in the reference frame of a sensor.
+`FeatureData` messages are generated from `GroundTruth` messages.
+They serve, for example, as an input to sensor models simulating object detection or feature fusion models.

--- a/doc/open-simulation-interface_user_guide.adoc
+++ b/doc/open-simulation-interface_user_guide.adoc
@@ -15,8 +15,6 @@ include::./architecture/architecture_overview.adoc[leveloffset=+2]
 
 include::./architecture/ground_truth.adoc[leveloffset=+3]
 
-include::./architecture/feature_data.adoc[leveloffset=+3]
-
 include::./architecture/sensor_view.adoc[leveloffset=+3]
 
 include::./architecture/sensor_view_configuration.adoc[leveloffset=+3]


### PR DESCRIPTION
As discussed in the last Performance/Packaging WG meeting, I created this pull request to remove any comments from the documentation that suggest that FeatureData could be a top-level message. Since FeatureData does not even contain the simulation timestamp, it can not be used as a top-level message at present anyway. This probably was an oversight from earlier documentation activities.

Resolves #771