### PR TITLE
Add pyspelling html filter

### DIFF
--- a/.github/.pyspelling.yml
+++ b/.github/.pyspelling.yml
@@ -17,3 +17,8 @@ matrix:
       delimiters:
       - open: '(?s)^(?P<open> *\/\/)'
         close: '^(?P=open)$'
+  - pyspelling.filters.html:
+      comments: true
+      attributes:
+      - title
+      - alt

--- a/.github/spelling_custom_words_en_US.txt
+++ b/.github/spelling_custom_words_en_US.txt
@@ -20,6 +20,7 @@ auch
 auf
 auml
 Ausfahrt
+außer
 Baugebiet
 Baustelle
 Baustellen
@@ -89,6 +90,7 @@ dt
 Duesseldorf
 Durchgangsverkehr
 dvr
+dürfen
 easting
 EBIKES
 edn
@@ -127,6 +129,8 @@ Fak
 fcm
 fehlende
 Feiertagen
+Flächen
+flächen
 fmu
 Formelsammlung
 Formelzeichen
@@ -138,6 +142,7 @@ fuer
 fullreports
 ge
 geb
+gebührenpflichtig
 Gedeon
 Gefahrenzeichen
 gekennzeichneten
@@ -145,6 +150,7 @@ gekennzeichneter
 Gelegenheitsverkehr
 Geospatial
 gesetze
+geändert
 github
 glichkeit
 GNSS
@@ -152,6 +158,7 @@ grayscale
 gridded
 Groessen
 GroundTruthInit
+Grüne
 gulleys
 haben
 Hafengebiet
@@ -208,6 +215,7 @@ lte
 luminance
 luv
 lx
+Lärmschutz
 Mainz
 Meteorologische
 metoffice
@@ -239,8 +247,8 @@ oktas
 ONEWAY
 onlinepubs
 ONRAMP
-opengroup
 opendrive
+opengroup
 openscenario
 optischen
 Ordnung
@@ -254,8 +262,10 @@ parametrize
 Parkausweis
 Parken
 Parkfl
+Parkflächen
 Parkschein
 Parkst
+Parkstände
 Paulat
 pdf
 png
@@ -281,6 +291,7 @@ rcs
 rdquo
 README
 Rei
+Reißverschluss
 rfc
 rfen
 rgb
@@ -291,6 +302,7 @@ rmschutz
 rmse
 Rollsplitt
 Rosenberger
+räumen
 Sa
 SAE
 sae
@@ -319,6 +331,7 @@ Strahlungsphysik
 Strassenfahrzeuge
 Strassenverkehrs
 strassenverkehrsordnung
+Straßenschaden
 StVO
 stvo
 StVZO
@@ -357,6 +370,7 @@ vda
 verkehr
 Verkehrseinrichtungen
 Verkehrsf
+Verkehrsführung
 Verkehrstechnik
 verkehrszeichen
 verschluss
@@ -365,12 +379,13 @@ Vorfahrt
 Vorschriftzeichen
 Vorweg
 vz
-vzkat
 VzKat
+vzkat
 wa
 Welle
 Wellenausbreitung
 Wendem
+Wendemöglichkeit
 werden
 werktags
 Wernli
@@ -382,6 +397,7 @@ wp
 wsdot
 www
 www
+während
 xrat
 XXXX
 xy
@@ -391,3 +407,5 @@ Zeitschrift
 Zou
 Zufahrt
 Zuflussregelung
+Ölspur
+überholt

--- a/.github/spelling_custom_words_en_US.txt
+++ b/.github/spelling_custom_words_en_US.txt
@@ -15,7 +15,6 @@ antecessor
 arg
 asam
 atsc
-au
 auch
 auf
 auml
@@ -34,7 +33,6 @@ bei
 beleuchtung
 Benrath
 Bereich
-berholt
 Besondere
 Bewohner
 BGBl
@@ -56,7 +54,6 @@ cd
 cellpadding
 cellspacing
 centerline
-chen
 Cianciaruso
 CIE
 cie
@@ -109,7 +106,6 @@ Endeninch
 endlink
 endrules
 engl
-enschaden
 enum
 enums
 eoas
@@ -152,7 +148,6 @@ Geospatial
 gesetze
 geändert
 github
-glichkeit
 GNSS
 grayscale
 gridded
@@ -167,9 +162,6 @@ halten
 hier
 Hochwasser
 href
-hrend
-hrenpflichtig
-hrung
 hsv
 htm
 html
@@ -210,7 +202,6 @@ lidar
 lidar's
 Linksabbieger
 lm
-lspur
 lte
 luminance
 luv
@@ -225,8 +216,6 @@ Modellierung
 MULTITRACK
 nd
 nde
-ndert
-ne
 NEBEL
 Nebenstrecke
 neuer
@@ -261,10 +250,8 @@ parametrization
 parametrize
 Parkausweis
 Parken
-Parkfl
 Parkflächen
 Parkschein
-Parkst
 Parkstände
 Paulat
 pdf
@@ -290,15 +277,12 @@ rbd
 rcs
 rdquo
 README
-Rei
 Reißverschluss
 rfc
-rfen
 rgb
 rgbir
 rggb
 Richtzeichen
-rmschutz
 rmse
 Rollsplitt
 Rosenberger
@@ -326,7 +310,6 @@ sr
 sslnet
 Steinburg
 steradian
-Stra
 Strahlungsphysik
 Strassenfahrzeuge
 Strassenverkehrs
@@ -356,7 +339,6 @@ ubc
 ubc
 uint
 uk
-umen
 umich
 umtri
 und
@@ -373,7 +355,6 @@ Verkehrsf
 Verkehrsführung
 Verkehrstechnik
 verkehrszeichen
-verschluss
 Verschmutzte
 Vorfahrt
 Vorschriftzeichen
@@ -384,7 +365,6 @@ vzkat
 wa
 Welle
 Wellenausbreitung
-Wendem
 Wendemöglichkeit
 werden
 werktags
@@ -395,7 +375,6 @@ wikipedia
 Wilster
 wp
 wsdot
-www
 www
 während
 xrat


### PR DESCRIPTION
I noticed that adding new hyperlinks to the proto files requires to add any character sequences from the hyperlink as exceptions to the spellchecker (see #790). So I found that it is possible to add a html filter that excludes such character sequences.

[Here](https://github.com/thomassedlmayer/open-simulation-interface/commit/0b376bce907a40fdebc05d480a204625f8db9b61) I added a exemplary `<a>`-tag with a hyperlink that contains strings that should trigger a spellchecker fail. With the new html filter the hyperlink does not trigger the fail anymore but now it fails because it now detects a lot more strings that contain mutated vowels which were not detected before. I guess the html filter converts those special characters so that the spellchecker can also check those words.

@ClemensLinnhoff Could you please check if this type of filter does not screw things up? Was there any reason why this was not added before? If it works, we should probably add the "new" mutated vowel-words as exceptions but remove any exceptions that were previously added because they are contained inside hyperlinks (or also html tags/attribute names like `cellspacing`, `href`, `colspan` etc.). Also, wouldn't it make sense to add German as secondary language so that we don't have to add every German word to the exception list?