### PR TITLE
Fix osi trace robustness

### DIFF
--- a/osi3trace/osi_trace.py
+++ b/osi3trace/osi_trace.py
@@ -55,8 +55,8 @@ class OSITrace:
         if not self.read_complete:
             self.current_index = len(self.message_offsets) - 1
             self.file.seek(self.message_offsets[-1], 0)
-        while (
-            not self.read_complete and not limit or len(self.message_offsets) <= limit
+        while not self.read_complete and (
+            not limit or len(self.message_offsets) <= limit
         ):
             self.retrieve_message(skip=True)
         return self.message_offsets

--- a/tests/test_osi_trace.py
+++ b/tests/test_osi_trace.py
@@ -22,6 +22,20 @@ class TestOSITrace(unittest.TestCase):
 
             self.assertTrue(os.path.exists(path_output))
 
+    def test_osi_trace_offsets_robustness(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path_input = os.path.join(tmpdirname, "input.osi")
+            create_sample(path_input)
+
+            trace = OSITrace(path_input)
+            # Test whether the function can handle be run multiple times safely
+            offsets = trace.retrieve_offsets(None)
+            offsets2 = trace.retrieve_offsets(None)
+            trace.close()
+
+            self.assertEqual(len(offsets), 10)
+            self.assertEqual(offsets, offsets2)
+
 
 def create_sample(path):
     f = open(path, "ab")


### PR DESCRIPTION
﻿As identified by @ClemensLinnhoff there is a precedence error in retrieve_offsets which can lead to errors if the function is called again after a completed read.

This PR fixes this bug and adds a test case to detect such errors.