### PR TITLE
Fix outdated documentation on formatting scripts

### DIFF
--- a/doc/architecture/formatting_script.adoc
+++ b/doc/architecture/formatting_script.adoc
@@ -2,10 +2,10 @@ ifndef::include-only-once[]
 :root-path: ../
 include::{root-path}_config.adoc[]
 endif::[]
-= Trace-file formatting scripts
+= Trace-file formatting script
 
-The OSI repository contains Python scripts for converting trace files from one format to another.
-The formatting scripts are stored in `open-simulation-interface/format/`
+The OSI repository contains a Python script for converting trace files from one format to another.
+The formatting script is stored in `open-simulation-interface/osi3trace/`.
 
 **osi2read.py**
 
@@ -22,12 +22,7 @@ The default value is `'SensorView'`.
 
 `--output`, `-o`::
 Optional string containing the name of the output file.
-The default value is `'converted.txth'`.
-
-`--format`, `-f`::
-Optional string containing the format type of the trace file.
-`'separated'`, or `None` are permitted values.
-The default value is `None`.
+The default value is `None`, in which case the output file name is set to the name of the input file, with the file extension being replaced by `.txth`.
 
 **Related topics**
 

--- a/doc/open-simulation-interface_user_guide.adoc
+++ b/doc/open-simulation-interface_user_guide.adoc
@@ -69,7 +69,7 @@ include::./architecture/trace_file_naming.adoc[leveloffset=+3]
 
 include::./architecture/trace_file_example.adoc[leveloffset=+3]
 
-include::./architecture/formatting_scripts.adoc[leveloffset=+3]
+include::./architecture/formatting_script.adoc[leveloffset=+3]
 
 
 // Setting up OSI


### PR DESCRIPTION
Fixes outdated documentation on osi3trace formatting scripts:

- Fixed folder specification.
- Fixed default value info for `output` arg.
- Removed `format` arg info.
- Changed documentation file name and header from plural to singular because there is only one formatting script left.