### PR TITLE
Added hvd as a trace file type for HostVehicleData

### DIFF
--- a/doc/architecture/trace_file_naming.adoc
+++ b/doc/architecture/trace_file_naming.adoc
@@ -29,6 +29,8 @@ Trace file contains `TrafficUpdate` messages.
 `tc`::
 Trace file contains `TrafficCommand` messages.
 
+`hvd`::
+Trace file contains `HostVehicleData` messages.
 
 **Example**
 


### PR DESCRIPTION
Added hvd as a supported trace file type for HostVehicleData

#### Add a description
We are using OSI to send data within our test vehicle. Within the vehicle, we are just sending HostVehicleData information, because other data is not required. To have data for testing and evaluation, tracing that HostVehicleData should be available in a general fashion.

This change is just an extension in the naming conventions, which will allow saving HostVehicleData as hvd files.

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
