### PR TITLE
Remove is_globally_unique rule from messages, where it does not make sense

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -41,7 +41,6 @@ message Lane
     // \note Note ID is global unique.
     //
     // \rules
-    // is_globally_unique
     // is_set
     // \endrules
     //
@@ -713,7 +712,6 @@ message LaneBoundary
     // The ID of the lane boundary.
     //
     // \rules
-    // is_globally_unique
     // \endrules
     //
     optional Identifier id = 1;

--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -38,8 +38,6 @@ message Lane
     // The ID of the lane.
     // Example: l4 (see reference picture HighwayExit).
     //
-    // \note Note ID is global unique.
-    //
     // \rules
     // is_set
     // \endrules

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -57,7 +57,6 @@ message LogicalLaneBoundary
     // The ID of the lane boundary.
     //
     // \rules
-    // is_globally_unique
     // is_set
     // \endrules
     //
@@ -329,12 +328,6 @@ message LogicalLaneBoundary
 message LogicalLane
 {
     // The ID of the logical lane.
-    //
-    // \note Note ID is global unique.
-    //
-    // \rules
-    // is_globally_unique
-    // \endrules
     //
     optional Identifier id = 1;
 

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -28,13 +28,6 @@ message ReferenceLine
 {
     // The ID of the reference line.
     //
-    // \note Note ID is global unique.
-    //
-    // \rules
-    // is_globally_unique
-    // is_set
-    // \endrules
-    //
     optional Identifier id = 1;
 
     // The type of the reference line.

--- a/osi_referenceline.proto
+++ b/osi_referenceline.proto
@@ -28,6 +28,10 @@ message ReferenceLine
 {
     // The ID of the reference line.
     //
+    // \rules
+    // is_set
+    // \endrules
+    //
     optional Identifier id = 1;
 
     // The type of the reference line.

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -64,11 +64,6 @@ message SensorView
     // object output; it is distinct from the IDs of its physical detectors,
     // which are used in the detected features.
     //
-    // \rules
-    // is_globally_unique
-    // is_set
-    // \endrules
-    //
     optional Identifier sensor_id = 3;
 
     // The virtual mounting position of the sensor (origin and orientation of

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -64,6 +64,10 @@ message SensorView
     // object output; it is distinct from the IDs of its physical detectors,
     // which are used in the detected features.
     //
+    // \rules
+    // is_set
+    // \endrules
+    //
     optional Identifier sensor_id = 3;
 
     // The virtual mounting position of the sensor (origin and orientation of

--- a/osi_streamingupdate.proto
+++ b/osi_streamingupdate.proto
@@ -82,5 +82,7 @@ message StreamingUpdate
     // Entities that will no longer be updated, because they are considered
     // obsolete by the sender.
     //
+    // \note Referenced IDs are globally unique.
+    //
     repeated Identifier obsolete_id = 9;
 }

--- a/osi_streamingupdate.proto
+++ b/osi_streamingupdate.proto
@@ -82,7 +82,5 @@ message StreamingUpdate
     // Entities that will no longer be updated, because they are considered
     // obsolete by the sender.
     //
-    // \note IDs are globally unique.
-    //
     repeated Identifier obsolete_id = 9;
 }


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#809 

#### Add a description
Removed rule is_globally_unique from messages, where a globally unique ID does not make any sense.

Some IDs depend on the scenario, e.g. object IDs in Ground Truth. Some IDs depend on the map, e.g. lane IDs. And some IDs depend on the sensor setup, e.g. sensor IDs.

I can't think of a reason, why there shouldn't be a moving object with ID 0, a lane with ID 0 and a sensor with ID 0. Therefore, I removed the is_globally_unique rule from every message, that is not a ground truth object.


#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
