### PR TITLE
Add pyi_out option to protoc command in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,9 @@ class ProtobufGenerator:
         for source in self.osi_files:
             sys.stdout.write("Protobuf-compiling " + source + "\n")
             source_path = os.path.join(package_name, source)
-            subprocess.check_call([self.find_protoc(), "--python_out=.", "--pyi_out=.", source_path])
+            subprocess.check_call(
+                [self.find_protoc(), "--python_out=.", "--pyi_out=.", source_path]
+            )
 
     def maybe_generate(self):
         if os.path.exists("osi_version.proto.in"):

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ class ProtobufGenerator:
         for source in self.osi_files:
             sys.stdout.write("Protobuf-compiling " + source + "\n")
             source_path = os.path.join(package_name, source)
-            subprocess.check_call([self.find_protoc(), "--python_out=.", source_path])
+            subprocess.check_call([self.find_protoc(), "--python_out=.", "--pyi_out=.", source_path])
 
     def maybe_generate(self):
         if os.path.exists("osi_version.proto.in"):


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
#820

#### Add a description
Add pyi_out option to protoc command in the setup.py. This ways, IDEs recognize the modules and classes and autocorrect is supported:
![image](https://github.com/OpenSimulationInterface/open-simulation-interface/assets/27010086/bb2b67eb-9ec2-4ece-9ac5-72947f37fbe5)

![image](https://github.com/OpenSimulationInterface/open-simulation-interface/assets/27010086/92e9b900-b070-47c5-b762-4522cf88b851)

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/howtocontribute.html#developer-certification-of-origin-dco).
- [x] My changes generate no errors when passing CI tests. 
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
