### PR TITLE
Fix multiple rule bugs

### DIFF
--- a/osi_lane.proto
+++ b/osi_lane.proto
@@ -748,13 +748,6 @@ message LaneBoundary
     // \attention For \c BoundaryPoint the same rule for the approximation
     // error applies as for \c Lane::Classification::centerline.
     //
-    // \rules
-    // first_element width is_equal_to 0.13
-    // first_element height is_equal_to 0.14
-    // last_element width is_equal_to 0.13
-    // last_element height is_equal_to 0.13
-    // \endrules
-    //
     repeated BoundaryPoint boundary_line = 2;
 
     // The classification of the lane boundary.

--- a/osi_logicallane.proto
+++ b/osi_logicallane.proto
@@ -407,10 +407,6 @@ message LogicalLane
     // For LogicalLanes without a correspondence to a Lane.Classification.Subtype 
     // (i.e. TYPE_MEDIAN, TYPE_CURB, TYPE_TRAM, TYPE_RAIL) this field has no value.
     //
-    // \rules
-    // refers_to: Lane
-    // \endrules
-    //
     repeated PhysicalLaneReference physical_lane_reference = 4;
 
     // The \link ReferenceLine reference line\endlink for this logical lane

--- a/osi_sensorview.proto
+++ b/osi_sensorview.proto
@@ -138,7 +138,7 @@ message SensorView
     // The ID of the host vehicle in the \c #global_ground_truth data.
     //
     // \rules
-    // refers_to: 'MovingObject'
+    // refers_to: MovingObject
     // is_set
     // \endrules
     //


### PR DESCRIPTION
`LogicalLane::PhysicalLaneReference` has a rule `refer_to: Lane` which can not be checked because there is no specification of which field inside PhysicalLaneReference contains the relevant id to be checked.
The `physical_lane_id` field has this rule as well (see [here](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/V3.5.0/gen/structosi3_1_1LogicalLane_1_1PhysicalLaneReference.html#a3fdd0c1928556254713f31168c76ae1c)). There it can be properly checked.

I removed the rule that is both redundant and incorrectly located. I guess the `refers_to` rule can only be used for Identifiers.

Resolves #848