### PR TITLE
Install OSI3 under conventional install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ else()
 endif()
 set(OSI_INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
-set(OSI_INSTALL_LIB_DIR ${OSI_INSTALL_LIB_DIR}/osi${VERSION_MAJOR})
+set(OSI_INSTALL_LIB_DIR ${OSI_INSTALL_LIB_DIR})
 set(OSI_INSTALL_INCLUDE_DIR ${OSI_INSTALL_INCLUDE_DIR}/osi${VERSION_MAJOR})
 
 configure_file(osi_version.proto.in osi_version.proto)


### PR DESCRIPTION
The usual practice is to install libraries directly under `${INSTALL_PREFIX}/lib`.

This PR is a small step toward discussing the adoption of CMake’s [`GNUInstallDirs`](https://cmake.org/cmake/help/v3.25/module/GNUInstallDirs.html) conventions for standardized install locations.

If this approach sounds reasonable, I’d prefer the OSI fully embrace `GNUInstallDirs` conventions instead of using custom install location variables.