### PR TITLE
Remove land vehicle type

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -1051,14 +1051,6 @@ message MovingObject
             // future versions as needed.
             //
             TYPE_AIRCRAFT = 21;
-
-            // A land vehicle is a vehicle designed for travel on land.
-            //
-            // \note This category is deliberately generic to include land
-            // vehicles that do not fall into other categories and may be
-            // refined in future versions as needed.
-            //
-            TYPE_LAND_VEHICLE = 22;
         }
 
         // The type of the vehicle.


### PR DESCRIPTION
Based on the [decision in the traffic participant harmonization project](https://code.asam.net/simulation/harmonization/trafficparticipants/traffic-participants-specification/-/merge_requests/17), OSI adopts the removal of the type `TYPE_LAND_VEHICLE`. Note that the concerned changes were not included in a release yet.

`TYPE_OTHER` already exists in OSI, so it does not need to be added.

@jakobkaths