### PR TITLE
Add model_reference attribute to RoadMarking (#874)

### DIFF
--- a/osi_roadmarking.proto
+++ b/osi_roadmarking.proto
@@ -101,6 +101,11 @@ message RoadMarking
     // \note It is implementation-specific how model_references are resolved to
     // 3d models.
     //
+    // \note Road markings' base objects are positioned differently from other
+    // OSI objects: their local z-axis corresponds to how the marking is placed
+    // on the xy-plane of the lane, rather than pointing upwards as it does for
+    // other objects.
+    //
     optional string model_reference = 6;
 
     //


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
https://github.com/OpenSimulationInterface/open-simulation-interface/issues/874

#### Add a description
Adding the model_reference attribute to the RoadMarking class. 
This was missing and is now consistent with the other classes TrafficLight, MovingObject...

Backward-compatible, as added as optional and at the end (attribute #6).

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/dco.html).
- [x] My changes generate no errors when passing CI tests.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
