### PR TITLE
docs: deprecate SensorDataSeries and SensorDataSeriesList for removal in v4.0.0

### DIFF
--- a/osi_datarecording.proto
+++ b/osi_datarecording.proto
@@ -7,8 +7,14 @@ import "osi_sensordata.proto";
 package osi3;
 
 //
-// \brief (Time) Series of \c SensorData messages that may be used for data
-// recording or internal buffering by some sensor models.
+// \brief (Time) Series of \c SensorData messages.
+//
+// \attention DEPRECATED: This message will be removed in OSI 4.0.0.
+// Use the OSI trace file formats instead, which generalize
+// the concept to any top-level message type and support streaming
+// without requiring all time steps to be held in memory at once.
+// Internal buffering by sensor models should be handled within the
+// sensor model implementation.
 //
 message SensorDataSeries
 {
@@ -20,6 +26,11 @@ message SensorDataSeries
 //
 // \brief List of sensors where each element contains a time series of
 // \c SensorData messages.
+//
+// \attention DEPRECATED: This message will be removed in OSI 4.0.0.
+// Use the OSI trace file formats instead, which generalize
+// the concept to any combination of top-level message types and
+// provide metadata, schema records, compression, and random access.
 //
 message SensorDataSeriesList
 {


### PR DESCRIPTION
## Summary

Deprecates `SensorDataSeries` and `SensorDataSeriesList` in `osi_datarecording.proto` with `\attention` notes indicating removal in OSI 4.0.0.

## Motivation

As discussed in #900, these messages predate the OSI trace file formats and have been fully superseded:

| Deprecated message | Superseded by | Why |
|---|---|---|
| `SensorDataSeries` | Single-channel `.osi` trace format | Generalizes to any top-level message type; supports streaming without loading all timesteps into memory |
| `SensorDataSeriesList` | Multi-channel `.mcap` trace format | Generalizes to any combination of top-level message types; adds metadata, schema records, compression, and random access |

The original `\brief` also mentioned *internal buffering by sensor models* as a use case. This is an implementation concern of individual sensor models and does not belong in the interface specification.

## Changes

- Updated `\brief` for `SensorDataSeries` (removed the internal buffering language)
- Added `\attention` deprecation notes to both `SensorDataSeries` and `SensorDataSeriesList` explaining the rationale and the superseding formats

## Recommendation from maintainers

Per @jdsika, @pmai, and @thomassedlmayer in #900: deprecate now, remove entirely in v4.0.0.

Resolves #900
