### PR TITLE
feat: Grouping the traffic lights

### DIFF
--- a/osi_trafficlight.proto
+++ b/osi_trafficlight.proto
@@ -140,6 +140,13 @@ message TrafficLight
         //
         repeated LogicalLaneAssignment logical_lane_assignment = 7;
 
+        // Shared group identifier for related bulbs.
+        //
+        // \note All bulbs belonging to the same signal unit share the identical \c #group_id .
+        // \note The id must be globally unique within a single ground_truth message.
+        // All traffic lights with identical \c #group_id form one logical traffic signal unit.
+        optional Identifier group_id = 8;
+
         // Definition of semantic colors for traffic lights.
         //
         // \note The color types represent the semantic classification of a traffic light


### PR DESCRIPTION
﻿#### Reference to a related issue in the repository
[TrafficLight rework proposal. #754](https://github.com/OpenSimulationInterface/open-simulation-interface/issues/754)

#### Add a description

The individual bulbs of a traffic light rarely function as standalone signals. Rather, they form a unit consisting of two or three bulbs that convey a specific instruction to the driver.

The introduction of the group_id defines a unique assignment of the lights. It replaces heuristics—such as those based on position and orientation—that were previously necessary in the user software.

**Some questions to ask**:

- It's a new feature.
- Backward compatibility:
   ```
   IF group_id IS PRESENT:
       → Group bulbs by group_id
   ELSE:
       → Fall back to position-based / heuristic grouping (legacy)
   ```

#### Take this checklist as orientation for yourself, if this PR is ready for the Change Control Board:
- [x] My suggestion follows the [style and contributors guidelines](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/start_contributing.html).
- [x] I have taken care about the [message documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_messages.html) and the [fields and enums documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/commenting_fields_enums.html).
- [x] I have done the [DCO signoff](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/contributing/dco.html).
- [x] My changes generate no errors when passing CI tests.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

If you can’t check all of them, please explain why.
If all boxes are checked or commented and you have achieved at least one positive review, you can assign the label ReadyForCCBReview!
